### PR TITLE
Add separate address fields with CEP autofill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+zxtec-intranet.zip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Chat-Pro
 
 Este é o repositório inicial para o Codex do ChatGPT.
+
+## Plugins
+
+ - **ZX Tec**: plugin WordPress localizado em `zxtec-intranet/` com gerenciamento de clientes, servicos, ordens e contratos. Inclui painel do colaborador com confirmacao e finalizacao de ordens, mapa de geolocalizacao, exportacao financeira em CSV, PDF e Excel, notificacoes por e-mail, historico de servicos com filtros e exportacao em CSV, contratos ativos, agenda de ordens confirmadas e mapa de tecnicos com atribuicao automatica pelo GPS. A versao 0.9 considerava tambem o custo por Km do colaborador e definia o agendamento automaticamente. A versao 1.0 adicionou relatorio financeiro individual e justificativa obrigatoria ao recusar servicos. A versao 1.1 ampliou o historico com filtros por data e tecnico. A versao 1.2 traz controle de despesas com relatorio e saldo liquido. A versao 1.3 inclui o framework Bootstrap para deixar o painel responsivo. A versao 1.4 permite exportar o financeiro individual em PDF. A versao 1.5 adiciona notificacoes internas sobre ordens e atualizacoes de status. A versao 1.6 inclui uma pagina de Notificacoes para administradores gerenciarem alertas dos colaboradores.
+ A versao 1.7 adiciona limpeza completa de dados ao desinstalar o plugin.
+ A versao 1.8 permite configurar o percentual de comissao na pagina de configuracoes do plugin.
+ A versao 1.9 traz um widget de resumo no painel inicial do WordPress exibindo quantas ordens estao pendentes, confirmadas e concluidas.
+ A versao 2.0 permite filtrar o Relatorio Financeiro por datas antes de exportar os arquivos.
+ A versao 2.1 permite definir comissao individual para cada colaborador.
+ A versao 2.2 apresenta um painel analitico com graficos interativos.
+A versao 2.3 aplica o tema Flatly do Bootswatch e adiciona endereco e CEP nas ordens de servico.
+A versao 2.4 traz folhas de estilo proprias para uma interface mais moderna em todas as paginas do plugin.
+A versao 2.4.1 garante que esses estilos tenham prioridade sobre o CSS padrao do WordPress.
+A versao 2.4.2 aumenta ainda mais a prioridade para assegurar que o visual do plugin se sobreponha ao tema do WordPress.
+A versao 2.5 aplica automaticamente o endereco a partir do CEP e garante o estilo moderno tambem nas telas de edicao dos tipos de post.
+A versao 2.6 separa os campos de endereco e preenche rua, bairro, cidade e estado automaticamente apos digitar o CEP. A versao 2.6.1 corrigiu o carregamento automatico do endereco e suavizou o visual. A versao 2.6.2 acrescenta um estilo inspirado em templates SaaS com cor #ff7700.
+
+## Development
+Run `scripts/test.sh` to lint all PHP files.
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+find zxtec-intranet -name '*.php' -print0 | xargs -0 -n1 php -l

--- a/zxtec-intranet/README.md
+++ b/zxtec-intranet/README.md
@@ -1,0 +1,42 @@
+# ZX Tec
+
+Versao 2.6.2
+
+Este plugin oferece um sistema de gerenciamento interno com dois paineis: administrativo e dashboard do colaborador.
+
+Sao registrados os tipos de post **Clientes**, **Servicos**, **Ordens** e **Contratos** com campos personalizados.
+O dashboard de colaboradores lista as ordens designadas ao usuario logado, permitindo confirmar, recusar ou finalizar cada servico e abrindo a rota no Google Maps.
+O sistema possui notificacoes internas para informar tecnicos e administradores sobre novas ordens e mudancas de status.
+
+Ha tambem o tipo de post **Despesas** para registrar gastos de cada colaborador.
+
+Ative o plugin no WordPress e acesse as paginas em **ZX Tec** dentro do menu administrativo.
+
+O cadastro de ordens possui campos de geolocalizacao e um mapa interativo com Leaflet para selecionar a coordenada. A pagina **Relatorio Financeiro** exibe o total de servicos concluidos por colaborador e calcula a comissao configurada pelo administrador. Ha tambem uma pagina de **Historico de Servicos** mostrando todas as ordens finalizadas. O dashboard de colaboradores pode ser exibido em qualquer pagina usando o shortcode `[zxtec_colaborador_dashboard]`.
+O relatorio financeiro agora permite **exportar os dados em CSV**. Sempre que uma ordem for atribuida ou tiver o status modificado, o tecnico recebe uma notificacao por e-mail.
+Ha tambem um botao para **exportar o relatorio em PDF**, uma pagina de **Contratos Ativos** listando contratos em andamento e uma pagina de **Agenda** exibindo ordens confirmadas pelo tecnico.
+A versao 0.7 inclui campos de localizacao nos perfis dos colaboradores, um **Mapa de Tecnicos** para visualizar todos no painel administrativo e atribuicao automatica de ordens ao tecnico mais proximo.
+Na versao 0.8 adicionamos campos de **especialidade** para servicos e colaboradores, permitindo que a atribuicao automatica considere a area de atuacao alem da proximidade geográfica.
+Agora na versao 0.9 adicionamos um campo de **custo por Km** para cada colaborador, melhorando a escolha automatica do tecnico de acordo com o menor custo estimado. O agendamento tambem pode ser definido automaticamente para o proximo dia livre do tecnico e o relatorio financeiro oferece opcao de **exportacao em Excel**.
+
+Na versao 1.0 incluimos um **relatorio financeiro individual** no dashboard do colaborador, permitindo exportar seus ganhos em CSV. A recusa de ordens agora exige uma justificativa que fica registrada na ordem.
+Na versao 1.1 adicionamos filtros de data e tecnico ao **Historico de Servicos**, alem de um botao para **exportar o historico em CSV**.
+Na versao 1.2 foi implementado um controle de **despesas** por colaborador com relatorio e exportacao em CSV. O saldo liquido agora desconta as despesas registradas.
+Na versao 1.3 o plugin passou a carregar o framework **Bootstrap** para deixar o painel administrativo e o dashboard responsivos.
+Na versao 1.4 foi adicionada opcao de **exportar o financeiro individual em PDF**, acessivel no dashboard do colaborador.
+Na versao 1.5 criamos um sistema de **notificacoes internas** para avisar tecnicos e administradores sobre novas ordens e mudancas de status.
+Na versao 1.6 adicionamos uma pagina de **Notificacoes** no painel administrativo para visualizar e limpar alertas de todos os colaboradores. Na versao 1.7 passa a existir um script de desinstalacao que remove todos os dados.
+Na versao 1.8 e possivel definir o percentual de comissao na pagina de configuracoes do plugin.
+Na versao 1.9 adicionamos um widget no painel inicial do WordPress exibindo o total de ordens pendentes, confirmadas e concluidas.
+Na versao 2.0 o Relatorio Financeiro passou a aceitar filtros de data e manteve as opcoes de exportacao.
+Na versao 2.1 e possivel definir um percentual de comissao individual para cada colaborador.
+Na versao 2.2 incluimos um **painel analitico** com graficos interativos de receita e despesas.
+Na versao 2.3 aplicamos o tema Flatly do Bootswatch para modernizar a interface e adicionamos campos de endereco e CEP nas ordens de servico.
+Na versao 2.4 incorporamos estilos proprios para todas as paginas do plugin, oferecendo um visual mais robusto e organizado.
+Na versao 2.4.1 priorizamos o carregamento desses estilos para que se sobreponham ao visual padrao do WordPress.
+Na versao 2.4.2 aumentamos a prioridade desse carregamento garantindo que o visual do plugin prevaleça sobre o CSS do WordPress.
+Na versao 2.5 adicionamos preenchimento automatico de endereco via CEP e aplicamos o estilo moderno em todas as telas dos tipos de post personalizados.
+Na versao 2.6 os campos de endereco foram separados (rua, numero, bairro, complemento, cidade, estado e pais) e sao preenchidos automaticamente ao digitar o CEP. A versao 2.6.1 corrigiu o carregamento automatico do endereco e suavizou o visual com cantos arredondados. A versao 2.6.2 inclui uma folha de estilo adicional baseada em templates SaaS, com barra lateral moderna e cor principal #ff7700.
+
+Ao desinstalar o plugin, todos os registros e metas personalizados sao removidos automaticamente.
+

--- a/zxtec-intranet/css/zxtec-admin.css
+++ b/zxtec-intranet/css/zxtec-admin.css
@@ -1,0 +1,33 @@
+/* Custom ZX Tec admin styles for robust design */
+.zxtec-container {
+    padding: 20px;
+}
+.zxtec-card {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 0.75rem;
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+.zxtec-card h2 {
+    margin-top: 0;
+}
+.zxtec-table {
+    width: 100%;
+}
+
+.zxtec-container input[type="text"],
+.zxtec-container input[type="email"],
+.zxtec-container input[type="number"],
+.zxtec-container input[type="date"],
+.zxtec-container select,
+.zxtec-container textarea,
+.zxtec-container .widefat {
+    border-radius: 0.375rem;
+    padding: 8px 10px;
+}
+
+button.button-primary {
+    border-radius: 0.375rem;
+}

--- a/zxtec-intranet/css/zxtec-dashboard.css
+++ b/zxtec-intranet/css/zxtec-dashboard.css
@@ -1,0 +1,13 @@
+/* Custom ZX Tec dashboard styles */
+.zxtec-container { padding: 20px; }
+.zxtec-card { background:#fff; border:1px solid #dee2e6; border-radius:0.75rem; padding:20px; margin-bottom:20px; box-shadow:0 2px 6px rgba(0,0,0,0.05); }
+.zxtec-card h2 { margin-top:0; }
+.zxtec-table { width:100%; }
+.zxtec-container input[type="text"],
+.zxtec-container input[type="email"],
+.zxtec-container input[type="number"],
+.zxtec-container input[type="date"],
+.zxtec-container select,
+.zxtec-container textarea,
+.zxtec-container .widefat { border-radius:0.375rem; padding:8px 10px; }
+button.button-primary { border-radius:0.375rem; }

--- a/zxtec-intranet/css/zxtec-toolbar.css
+++ b/zxtec-intranet/css/zxtec-toolbar.css
@@ -1,0 +1,8 @@
+/* Modern toolbar styles inspired by SaaS templates */
+#wgl-envato-toolbar{position:absolute;z-index:4000}
+.wgl-toolbar__container{background:#fff;bottom:0;position:fixed;right:0;top:0;transform:translateX(100%);transition:transform .45s ease-in-out;width:360px;z-index:100000}
+.wgl-toolbar__container .wgl-env-theme__title{color:#232323;font-family:'Nunito Sans',sans-serif;font-size:28px;font-weight:700;margin:0 0 14px}
+.wgl-toolbar__container .wgl-env-theme__desc{font-family:'Nunito Sans',sans-serif;font-size:16px;font-weight:400;margin:0 0 30px}
+.wgl-toolbar__container .wgl-env-theme__btn .wgl-toolbar_link{background:#f3f3f3;border-radius:5px;color:#232323;display:inline-block;font-family:'Nunito Sans',sans-serif;font-size:15px;font-weight:700;line-height:24px;margin:0 0 10px;padding:11px 0;transition:all .45s;width:100%}
+.wgl-toolbar__container .wgl-env-theme__btn .wgl-toolbar_link:hover{background:#ff7700;color:#fff}
+#wgl-envato-toolbar.opened .wgl-toolbar__container{transform:translateX(0)}

--- a/zxtec-intranet/includes/class-zxtec-analytics.php
+++ b/zxtec-intranet/includes/class-zxtec-analytics.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ZXTEC_Analytics {
+    public static function page_html() {
+        $data = \ZXTEC_Financial::get_monthly_summary( 12 );
+        $labels = array();
+        $rev = array();
+        $exp = array();
+        $net = array();
+        foreach ( $data as $row ) {
+            $labels[] = $row['label'];
+            $rev[]    = round( $row['revenue'], 2 );
+            $exp[]    = round( $row['expenses'], 2 );
+            $net[]    = round( $row['revenue'] - $row['expenses'], 2 );
+        }
+        ob_start();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Relatorio Grafico', 'zxtec' ); ?></h1>
+            <canvas id="zxtec_chart" height="200"></canvas>
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <script>
+        (function(){
+            const ctx = document.getElementById('zxtec_chart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: <?php echo wp_json_encode( $labels ); ?>,
+                    datasets: [
+                        {label:'Receita',data:<?php echo wp_json_encode( $rev ); ?>,borderColor:'#007bff',fill:false},
+                        {label:'Despesas',data:<?php echo wp_json_encode( $exp ); ?>,borderColor:'#dc3545',fill:false},
+                        {label:'Lucro',data:<?php echo wp_json_encode( $net ); ?>,borderColor:'#28a745',fill:false}
+                    ]
+                }
+            });
+        })();
+        </script>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/zxtec-intranet/includes/class-zxtec-expense.php
+++ b/zxtec-intranet/includes/class-zxtec-expense.php
@@ -1,0 +1,59 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ZXTEC_Expense {
+    /**
+     * Generate expenses report HTML
+     */
+    public static function get_report_html() {
+        $expenses = get_posts( array(
+            'post_type'   => 'zxtec_expense',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+        ) );
+
+        if ( empty( $expenses ) ) {
+            return '<p>' . esc_html__( 'Nenhuma despesa registrada.', 'zxtec' ) . '</p>';
+        }
+
+        ob_start();
+        echo '<p><a class="button" href="?page=zxtec_expense_report&download=csv">' . esc_html__( 'Exportar CSV', 'zxtec' ) . '</a></p>';
+        echo '<table class="widefat">';
+        echo '<thead><tr><th>' . esc_html__( 'Data', 'zxtec' ) . '</th><th>' . esc_html__( 'Tecnico', 'zxtec' ) . '</th><th>' . esc_html__( 'Descricao', 'zxtec' ) . '</th><th>' . esc_html__( 'Valor (R$)', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $expenses as $e ) {
+            $tech_id = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $user = $tech_id ? get_userdata( $tech_id ) : null;
+            $date = get_post_meta( $e->ID, '_zxtec_date', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            echo '<tr><td>' . esc_html( $date ) . '</td><td>' . esc_html( $user ? $user->display_name : '' ) . '</td><td>' . esc_html( $e->post_title ) . '</td><td>' . number_format_i18n( $amount, 2 ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Output CSV with expenses
+     */
+    public static function download_csv() {
+        $expenses = get_posts( array(
+            'post_type'   => 'zxtec_expense',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+        ) );
+
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=despesas.csv' );
+        $out = fopen( 'php://output', 'w' );
+        fputcsv( $out, array( 'Data', 'Tecnico', 'Descricao', 'Valor' ) );
+        foreach ( $expenses as $e ) {
+            $tech_id = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $user = $tech_id ? get_userdata( $tech_id ) : null;
+            $date = get_post_meta( $e->ID, '_zxtec_date', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            fputcsv( $out, array( $date, $user ? $user->display_name : '', $e->post_title, number_format( $amount, 2, ',', '' ) ) );
+        }
+        fclose( $out );
+    }
+}

--- a/zxtec-intranet/includes/class-zxtec-financial.php
+++ b/zxtec-intranet/includes/class-zxtec-financial.php
@@ -1,0 +1,282 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ZXTEC_Financial {
+    /**
+     * Commission rate as decimal for a user
+     */
+    public static function get_rate_for( $user_id = 0 ) {
+        $rate = floatval( get_option( 'zxtec_commission', 10 ) );
+        if ( $user_id ) {
+            $user_rate = get_user_meta( $user_id, 'zxtec_commission', true );
+            if ( $user_rate !== '' && $user_rate !== false ) {
+                $rate = floatval( $user_rate );
+            }
+        }
+        return $rate / 100;
+    }
+
+    /**
+     * Retrieve concluded orders filtered by date range
+     */
+    private static function get_orders( $start = '', $end = '' ) {
+        $meta = array(
+            array(
+                'key'   => '_zxtec_status',
+                'value' => 'concluido',
+            ),
+        );
+        if ( $start ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $start, 'compare' => '>=' );
+        }
+        if ( $end ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $end, 'compare' => '<=' );
+        }
+
+        return get_posts( array(
+            'post_type'   => 'zxtec_order',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+            'meta_query'  => $meta,
+        ) );
+    }
+
+    /**
+     * Retrieve expenses optionally filtered by date range
+     */
+    private static function get_expenses( $start = '', $end = '' ) {
+        $args = array(
+            'post_type'   => 'zxtec_expense',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+        );
+        $meta = array();
+        if ( $start ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $start, 'compare' => '>=' );
+        }
+        if ( $end ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $end, 'compare' => '<=' );
+        }
+        if ( ! empty( $meta ) ) {
+            $args['meta_query'] = $meta;
+        }
+        return get_posts( $args );
+    }
+    /**
+     * Generate financial report table
+     */
+    public static function get_report_html( $start = '', $end = '' ) {
+        $orders = self::get_orders( $start, $end );
+
+        $totals = array();
+        $expenses_total = array();
+        foreach ( $orders as $order ) {
+            $tech = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            if ( ! isset( $totals[ $tech ] ) ) {
+                $totals[ $tech ] = 0;
+            }
+            $totals[ $tech ] += $price;
+        }
+
+        $expenses = self::get_expenses( $start, $end );
+        foreach ( $expenses as $e ) {
+            $tech = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            if ( ! isset( $expenses_total[ $tech ] ) ) {
+                $expenses_total[ $tech ] = 0;
+            }
+            $expenses_total[ $tech ] += $amount;
+        }
+
+        ob_start();
+        $rate_percent = floatval( get_option( 'zxtec_commission', 10 ) );
+        $qs = '';
+        if ( $start ) { $qs .= '&start=' . urlencode( $start ); }
+        if ( $end ) { $qs .= '&end=' . urlencode( $end ); }
+        echo '<p><a class="button" href="?page=zxtec_financial_report&download=csv' . $qs . '">' . esc_html__( 'Exportar CSV', 'zxtec' ) . '</a> ';
+        echo '<a class="button" href="?page=zxtec_financial_report&download=pdf' . $qs . '">' . esc_html__( 'Exportar PDF', 'zxtec' ) . '</a> ';
+        echo '<a class="button" href="?page=zxtec_financial_report&download=xls' . $qs . '">' . esc_html__( 'Exportar Excel', 'zxtec' ) . '</a></p>';
+        echo '<table class="table table-striped zxtec-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Tecnico', 'zxtec' ) . '</th><th>' . esc_html__( 'Total (R$)', 'zxtec' ) . '</th><th>' . esc_html__( 'Despesas', 'zxtec' ) . '</th><th>' . sprintf( esc_html__( 'Comissao (%s%%)', 'zxtec' ), number_format_i18n( $rate_percent, 2 ) ) . '</th><th>' . esc_html__( 'Saldo', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $totals as $tech => $total ) {
+            $user_info = get_userdata( $tech );
+            $commission = $total * self::get_rate_for( $tech );
+            $exp = $expenses_total[ $tech ] ?? 0;
+            $net = $commission - $exp;
+            echo '<tr><td>' . esc_html( $user_info ? $user_info->display_name : '#' . $tech ) . '</td><td>' . number_format_i18n( $total, 2 ) . '</td><td>' . number_format_i18n( $exp, 2 ) . '</td><td>' . number_format_i18n( $commission, 2 ) . '</td><td>' . number_format_i18n( $net, 2 ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Output CSV with financial totals
+     */
+    public static function download_csv( $start = '', $end = '' ) {
+        $orders = self::get_orders( $start, $end );
+
+        $totals = array();
+        $expenses_total = array();
+        foreach ( $orders as $order ) {
+            $tech = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            if ( ! isset( $totals[ $tech ] ) ) {
+                $totals[ $tech ] = 0;
+            }
+            $totals[ $tech ] += $price;
+        }
+
+        $expenses = self::get_expenses( $start, $end );
+        foreach ( $expenses as $e ) {
+            $tech = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            if ( ! isset( $expenses_total[ $tech ] ) ) {
+                $expenses_total[ $tech ] = 0;
+            }
+            $expenses_total[ $tech ] += $amount;
+        }
+
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=relatorio_financeiro.csv' );
+        $output = fopen( 'php://output', 'w' );
+        $rate = floatval( get_option( 'zxtec_commission', 10 ) );
+        fputcsv( $output, array( 'Tecnico', 'Total (R$)', 'Despesas', 'Comissao (' . $rate . '%)', 'Saldo' ) );
+        foreach ( $totals as $tech => $total ) {
+            $user_info = get_userdata( $tech );
+            $commission = $total * self::get_rate_for( $tech );
+            $exp = $expenses_total[ $tech ] ?? 0;
+            $net = $commission - $exp;
+            fputcsv( $output, array( $user_info ? $user_info->display_name : '#' . $tech, number_format( $total, 2, ',', '' ), number_format( $exp, 2, ',', '' ), number_format( $commission, 2, ',', '' ), number_format( $net, 2, ',', '' ) ) );
+        }
+        fclose( $output );
+    }
+
+    /**
+     * Output PDF with financial totals
+     */
+    public static function download_pdf( $start = '', $end = '' ) {
+        $orders = self::get_orders( $start, $end );
+
+        $totals = array();
+        $expenses_total = array();
+        foreach ( $orders as $order ) {
+            $tech = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            if ( ! isset( $totals[ $tech ] ) ) {
+                $totals[ $tech ] = 0;
+            }
+            $totals[ $tech ] += $price;
+        }
+
+        $expenses = self::get_expenses( $start, $end );
+        foreach ( $expenses as $e ) {
+            $tech = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            if ( ! isset( $expenses_total[ $tech ] ) ) {
+                $expenses_total[ $tech ] = 0;
+            }
+            $expenses_total[ $tech ] += $amount;
+        }
+
+        require_once dirname( dirname( __FILE__ ) ) . '/lib/fpdf.php';
+        $pdf = new \FPDF();
+        $pdf->AddPage();
+        $pdf->SetFont( 'Arial', '', 12 );
+        $pdf->Cell( 0, 10, __( 'Relatorio Financeiro', 'zxtec' ), 0, 1 );
+        foreach ( $totals as $tech => $total ) {
+            $user_info = get_userdata( $tech );
+            $rate = self::get_rate_for( $tech );
+            $commission = $total * $rate;
+            $exp = $expenses_total[ $tech ] ?? 0;
+            $net = $commission - $exp;
+            $line = sprintf( '%s - %s (despesas: %s, %s%%: %s, saldo: %s)',
+                $user_info ? $user_info->display_name : '#' . $tech,
+                number_format_i18n( $total, 2 ),
+                number_format_i18n( $exp, 2 ),
+                number_format_i18n( $rate * 100, 2 ),
+                number_format_i18n( $commission, 2 ),
+                number_format_i18n( $net, 2 )
+            );
+            $pdf->Cell( 0, 8, $line, 0, 1 );
+        }
+        $pdf->Output( 'D', 'relatorio_financeiro.pdf' );
+    }
+
+    /**
+     * Output Excel (XLS) with financial totals
+     */
+    public static function download_xls( $start = '', $end = '' ) {
+        $orders = self::get_orders( $start, $end );
+
+        $totals = array();
+        $expenses_total = array();
+        foreach ( $orders as $order ) {
+            $tech = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            if ( ! isset( $totals[ $tech ] ) ) {
+                $totals[ $tech ] = 0;
+            }
+            $totals[ $tech ] += $price;
+        }
+
+        $expenses = self::get_expenses( $start, $end );
+        foreach ( $expenses as $e ) {
+            $tech = get_post_meta( $e->ID, '_zxtec_technician', true );
+            $amount = floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            if ( ! isset( $expenses_total[ $tech ] ) ) {
+                $expenses_total[ $tech ] = 0;
+            }
+            $expenses_total[ $tech ] += $amount;
+        }
+
+        header( 'Content-Type: application/vnd.ms-excel; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=relatorio_financeiro.xls' );
+        $rate = floatval( get_option( "zxtec_commission", 10 ) );
+        echo "Tecnico\tTotal (R$)\tDespesas\tComissao ($rate%)\tSaldo\n";
+        foreach ( $totals as $tech => $total ) {
+            $user_info = get_userdata( $tech );
+            $commission = $total * self::get_rate_for( $tech );
+            $exp = $expenses_total[ $tech ] ?? 0;
+            $net = $commission - $exp;
+        echo ( $user_info ? $user_info->display_name : '#' . $tech ) . "\t" . number_format( $total, 2, ',', '' ) . "\t" . number_format( $exp, 2, ',', '' ) . "\t" . number_format( $commission, 2, ',', '' ) . "\t" . number_format( $net, 2, ',', '' ) . "\n";
+        }
+    }
+
+    /**
+     * Monthly revenue and expense summary for analytics
+     */
+    public static function get_monthly_summary( $months = 12 ) {
+        $data = array();
+        for ( $i = $months - 1; $i >= 0; $i-- ) {
+            $start = date( 'Y-m-01', strtotime( '-' . $i . ' months' ) );
+            $end   = date( 'Y-m-t', strtotime( $start ) );
+            $orders   = self::get_orders( $start, $end );
+            $expenses = self::get_expenses( $start, $end );
+
+            $rev  = 0;
+            foreach ( $orders as $o ) {
+                $service_id = get_post_meta( $o->ID, '_zxtec_service', true );
+                $rev += floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            }
+
+            $exp_total = 0;
+            foreach ( $expenses as $e ) {
+                $exp_total += floatval( get_post_meta( $e->ID, '_zxtec_amount', true ) );
+            }
+
+            $data[] = array(
+                'label'    => date_i18n( 'M/Y', strtotime( $start ) ),
+                'revenue'  => $rev,
+                'expenses' => $exp_total,
+            );
+        }
+        return $data;
+    }
+}

--- a/zxtec-intranet/includes/class-zxtec-intranet.php
+++ b/zxtec-intranet/includes/class-zxtec-intranet.php
@@ -1,0 +1,1497 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ZXTEC_Intranet {
+
+    /**
+     * Singleton instance
+     */
+    private static $instance = null;
+
+    /**
+     * Plugin URL for enqueuing assets
+     * @var string
+     */
+    private $url;
+
+    /**
+     * Get singleton instance
+     */
+    public static function instance() {
+        if ( is_null( self::$instance ) ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor
+     */
+    private function __construct() {
+        $this->url = plugin_dir_url( dirname( __FILE__ ) );
+        $this->includes();
+        $this->hooks();
+    }
+
+    /**
+     * Include required files
+     */
+    private function includes() {
+        require_once plugin_dir_path( __FILE__ ) . 'class-zxtec-financial.php';
+        require_once plugin_dir_path( __FILE__ ) . 'class-zxtec-expense.php';
+        require_once plugin_dir_path( __FILE__ ) . 'class-zxtec-analytics.php';
+    }
+
+    /**
+     * Hooks
+     */
+    private function hooks() {
+        register_activation_hook( __FILE__, array( $this, 'activate_plugin' ) );
+        register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate_plugin' ) );
+        add_action( 'init', array( $this, 'register_post_types' ) );
+        add_action( 'admin_menu', array( $this, 'register_admin_pages' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'add_meta_boxes', array( $this, 'register_meta_boxes' ) );
+        add_action( 'save_post', array( $this, 'save_post_meta' ) );
+        // Load styles with very high priority so ours override the WordPress defaults
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ), 999 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_public_scripts' ) );
+        add_shortcode( 'zxtec_colaborador_dashboard', array( $this, 'dashboard_shortcode' ) );
+        add_action( 'admin_post_zxtec_confirm_order', array( $this, 'handle_confirm_order' ) );
+        add_action( 'admin_post_zxtec_decline_order', array( $this, 'handle_decline_order' ) );
+        add_action( 'admin_post_zxtec_finalize_order', array( $this, 'handle_finalize_order' ) );
+        add_action( 'admin_post_zxtec_user_financial_csv', array( $this, 'download_user_financial_csv' ) );
+        add_action( 'admin_post_zxtec_user_financial_pdf', array( $this, 'download_user_financial_pdf' ) );
+        add_action( 'admin_post_zxtec_history_csv', array( $this, 'download_history_csv' ) );
+        add_action( 'admin_post_zxtec_expense_csv', array( $this, 'download_expense_csv' ) );
+        add_action( 'admin_post_zxtec_clear_notification', array( $this, 'handle_clear_notification' ) );
+        add_action( 'show_user_profile', array( $this, 'user_location_fields' ) );
+        add_action( 'edit_user_profile', array( $this, 'user_location_fields' ) );
+        add_action( 'personal_options_update', array( $this, 'save_user_location_fields' ) );
+        add_action( 'edit_user_profile_update', array( $this, 'save_user_location_fields' ) );
+        add_action( 'show_user_profile', array( $this, 'user_commission_field' ) );
+        add_action( 'edit_user_profile', array( $this, 'user_commission_field' ) );
+        add_action( 'personal_options_update', array( $this, 'save_user_commission_field' ) );
+        add_action( 'edit_user_profile_update', array( $this, 'save_user_commission_field' ) );
+        add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widget' ) );
+    }
+
+    /**
+     * Plugin activation
+     */
+    public function activate_plugin() {
+        $this->register_post_types();
+        add_role( 'zxtec_colaborador', 'Colaborador ZX Tec', array( 'read' => true ) );
+        if ( get_option( 'zxtec_commission', null ) === null ) {
+            add_option( 'zxtec_commission', 10 );
+        }
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Plugin deactivation
+     */
+    public static function deactivate_plugin() {
+        remove_role( 'zxtec_colaborador' );
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Register custom post types
+     */
+    public function register_post_types() {
+        register_post_type( 'zxtec_client', array(
+            'labels' => array(
+                'name' => __( 'Clientes', 'zxtec' ),
+                'singular_name' => __( 'Cliente', 'zxtec' ),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array( 'title', 'editor', 'custom-fields' ),
+        ) );
+
+        register_post_type( 'zxtec_service', array(
+            'labels' => array(
+                'name' => __( 'Servicos', 'zxtec' ),
+                'singular_name' => __( 'Servico', 'zxtec' ),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array( 'title', 'editor', 'custom-fields' ),
+        ) );
+
+        register_post_type( 'zxtec_order', array(
+            'labels' => array(
+                'name' => __( 'Ordens de Servico', 'zxtec' ),
+                'singular_name' => __( 'Ordem de Servico', 'zxtec' ),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array( 'title', 'editor', 'custom-fields' ),
+        ) );
+
+        register_post_type( 'zxtec_contract', array(
+            'labels' => array(
+                'name' => __( 'Contratos', 'zxtec' ),
+                'singular_name' => __( 'Contrato', 'zxtec' ),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array( 'title', 'editor', 'custom-fields' ),
+        ) );
+
+        register_post_type( 'zxtec_expense', array(
+            'labels' => array(
+                'name' => __( 'Despesas', 'zxtec' ),
+                'singular_name' => __( 'Despesa', 'zxtec' ),
+            ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => array( 'title', 'editor', 'custom-fields' ),
+        ) );
+    }
+
+    /**
+     * Register meta boxes for custom fields
+     */
+    public function register_meta_boxes() {
+        add_meta_box( 'zxtec_client_meta', __( 'Dados do Cliente', 'zxtec' ), array( $this, 'client_meta_box' ), 'zxtec_client', 'normal', 'default' );
+        add_meta_box( 'zxtec_service_meta', __( 'Detalhes do Servico', 'zxtec' ), array( $this, 'service_meta_box' ), 'zxtec_service', 'normal', 'default' );
+        add_meta_box( 'zxtec_order_meta', __( 'Detalhes da Ordem', 'zxtec' ), array( $this, 'order_meta_box' ), 'zxtec_order', 'normal', 'default' );
+        add_meta_box( 'zxtec_contract_meta', __( 'Detalhes do Contrato', 'zxtec' ), array( $this, 'contract_meta_box' ), 'zxtec_contract', 'normal', 'default' );
+        add_meta_box( 'zxtec_expense_meta', __( 'Detalhes da Despesa', 'zxtec' ), array( $this, 'expense_meta_box' ), 'zxtec_expense', 'normal', 'default' );
+    }
+
+    /**
+     * Render client meta box
+     */
+    public function client_meta_box( $post ) {
+        $cpf   = get_post_meta( $post->ID, '_zxtec_cpf', true );
+        $phone = get_post_meta( $post->ID, '_zxtec_phone', true );
+        $email = get_post_meta( $post->ID, '_zxtec_email', true );
+        $zip   = get_post_meta( $post->ID, '_zxtec_zip', true );
+        $street = get_post_meta( $post->ID, '_zxtec_street', true );
+        $number = get_post_meta( $post->ID, '_zxtec_number', true );
+        $neigh  = get_post_meta( $post->ID, '_zxtec_neighborhood', true );
+        $compl  = get_post_meta( $post->ID, '_zxtec_complement', true );
+        $city   = get_post_meta( $post->ID, '_zxtec_city', true );
+        $state  = get_post_meta( $post->ID, '_zxtec_state', true );
+        $country = get_post_meta( $post->ID, '_zxtec_country', true );
+        wp_nonce_field( 'zxtec_save_meta', 'zxtec_nonce' );
+        ?>
+        <p><label><?php _e( 'CPF/CNPJ', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_cpf" value="<?php echo esc_attr( $cpf ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Telefone', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_phone" value="<?php echo esc_attr( $phone ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Email', 'zxtec' ); ?><br/>
+        <input type="email" name="zxtec_email" value="<?php echo esc_attr( $email ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'CEP', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_zip" value="<?php echo esc_attr( $zip ); ?>" class="widefat zxtec-cep" data-street="zxtec_street" data-number="zxtec_number" data-neighborhood="zxtec_neighborhood" data-complement="zxtec_complement" data-city="zxtec_city" data-state="zxtec_state" data-country="zxtec_country" /></label></p>
+        <p><label><?php _e( 'Rua', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_street" value="<?php echo esc_attr( $street ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Numero', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_number" value="<?php echo esc_attr( $number ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Bairro', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_neighborhood" value="<?php echo esc_attr( $neigh ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Complemento', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_complement" value="<?php echo esc_attr( $compl ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Cidade', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_city" value="<?php echo esc_attr( $city ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Estado', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_state" value="<?php echo esc_attr( $state ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Pais', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_country" value="<?php echo esc_attr( $country ); ?>" class="widefat" /></label></p>
+        <?php
+    }
+
+    /**
+     * Render service meta box
+     */
+    public function service_meta_box( $post ) {
+        $price = get_post_meta( $post->ID, '_zxtec_price', true );
+        $specialty = get_post_meta( $post->ID, '_zxtec_specialty', true );
+        wp_nonce_field( 'zxtec_save_meta', 'zxtec_nonce' );
+        ?>
+        <p><label><?php _e( 'Preco (R$)', 'zxtec' ); ?><br/>
+        <input type="number" step="0.01" name="zxtec_price" value="<?php echo esc_attr( $price ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Especialidade', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_specialty" value="<?php echo esc_attr( $specialty ); ?>" class="widefat" /></label></p>
+        <?php
+    }
+
+    /**
+     * Render order meta box
+     */
+    public function order_meta_box( $post ) {
+        $client = get_post_meta( $post->ID, '_zxtec_client', true );
+        $service = get_post_meta( $post->ID, '_zxtec_service', true );
+        $technician = get_post_meta( $post->ID, '_zxtec_technician', true );
+        $date = get_post_meta( $post->ID, '_zxtec_date', true );
+        $status  = get_post_meta( $post->ID, '_zxtec_status', true );
+        $lat     = get_post_meta( $post->ID, '_zxtec_lat', true );
+        $lng     = get_post_meta( $post->ID, '_zxtec_lng', true );
+        $addr    = get_post_meta( $post->ID, '_zxtec_order_address', true );
+        $zip     = get_post_meta( $post->ID, '_zxtec_order_zip', true );
+        $street  = get_post_meta( $post->ID, '_zxtec_order_street', true );
+        $number  = get_post_meta( $post->ID, '_zxtec_order_number', true );
+        $neigh   = get_post_meta( $post->ID, '_zxtec_order_neighborhood', true );
+        $compl   = get_post_meta( $post->ID, '_zxtec_order_complement', true );
+        $city    = get_post_meta( $post->ID, '_zxtec_order_city', true );
+        $state   = get_post_meta( $post->ID, '_zxtec_order_state', true );
+        $country = get_post_meta( $post->ID, '_zxtec_order_country', true );
+
+        $clients = get_posts( array( 'post_type' => 'zxtec_client', 'numberposts' => -1 ) );
+        $services = get_posts( array( 'post_type' => 'zxtec_service', 'numberposts' => -1 ) );
+
+        wp_nonce_field( 'zxtec_save_meta', 'zxtec_nonce' );
+        ?>
+        <p><label><?php _e( 'Cliente', 'zxtec' ); ?><br/>
+        <select name="zxtec_client" class="widefat">
+            <option value="">--</option>
+            <?php foreach ( $clients as $c ) : ?>
+                <option value="<?php echo $c->ID; ?>" <?php selected( $client, $c->ID ); ?>><?php echo esc_html( $c->post_title ); ?></option>
+            <?php endforeach; ?>
+        </select></label></p>
+        <p><label><?php _e( 'Servico', 'zxtec' ); ?><br/>
+        <select name="zxtec_service" class="widefat">
+            <option value="">--</option>
+            <?php foreach ( $services as $s ) : ?>
+                <option value="<?php echo $s->ID; ?>" <?php selected( $service, $s->ID ); ?>><?php echo esc_html( $s->post_title ); ?></option>
+            <?php endforeach; ?>
+        </select></label></p>
+        <p><label><?php _e( 'Tecnico (user ID)', 'zxtec' ); ?><br/>
+        <input type="number" name="zxtec_technician" value="<?php echo esc_attr( $technician ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Data', 'zxtec' ); ?><br/>
+        <input type="date" name="zxtec_date" value="<?php echo esc_attr( $date ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Status', 'zxtec' ); ?><br/>
+        <select name="zxtec_status" class="widefat">
+            <option value="pendente" <?php selected( $status, 'pendente' ); ?>><?php _e( 'A Iniciar', 'zxtec' ); ?></option>
+            <option value="confirmado" <?php selected( $status, 'confirmado' ); ?>><?php _e( 'Em execucao', 'zxtec' ); ?></option>
+            <option value="recusado" <?php selected( $status, 'recusado' ); ?>><?php _e( 'Pausado', 'zxtec' ); ?></option>
+            <option value="concluido" <?php selected( $status, 'concluido' ); ?>><?php _e( 'Finalizado', 'zxtec' ); ?></option>
+        </select></label></p>
+        <p><label><?php _e( 'CEP', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_zip" value="<?php echo esc_attr( $zip ); ?>" class="widefat zxtec-cep" data-street="zxtec_order_street" data-number="zxtec_order_number" data-neighborhood="zxtec_order_neighborhood" data-complement="zxtec_order_complement" data-city="zxtec_order_city" data-state="zxtec_order_state" data-country="zxtec_order_country" /></label></p>
+        <p><label><?php _e( 'Rua', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_street" value="<?php echo esc_attr( $street ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Numero', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_number" value="<?php echo esc_attr( $number ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Bairro', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_neighborhood" value="<?php echo esc_attr( $neigh ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Complemento', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_complement" value="<?php echo esc_attr( $compl ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Cidade', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_city" value="<?php echo esc_attr( $city ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Estado', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_state" value="<?php echo esc_attr( $state ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Pais', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_order_country" value="<?php echo esc_attr( $country ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Latitude', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_lat" value="<?php echo esc_attr( $lat ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Longitude', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_lng" value="<?php echo esc_attr( $lng ); ?>" class="widefat" /></label></p>
+        <div id="zxtec_map" style="height:300px;"></div>
+        <?php
+    }
+
+    /**
+     * Render contract meta box
+     */
+    public function contract_meta_box( $post ) {
+        $client = get_post_meta( $post->ID, '_zxtec_client', true );
+        $plan   = get_post_meta( $post->ID, '_zxtec_plan', true );
+        $start  = get_post_meta( $post->ID, '_zxtec_start', true );
+        $end    = get_post_meta( $post->ID, '_zxtec_end', true );
+        $status = get_post_meta( $post->ID, '_zxtec_status', true );
+
+        $clients = get_posts( array( 'post_type' => 'zxtec_client', 'numberposts' => -1 ) );
+
+        wp_nonce_field( 'zxtec_save_meta', 'zxtec_nonce' );
+        ?>
+        <p><label><?php _e( 'Cliente', 'zxtec' ); ?><br/>
+        <select name="zxtec_client" class="widefat">
+            <option value="">--</option>
+            <?php foreach ( $clients as $c ) : ?>
+                <option value="<?php echo $c->ID; ?>" <?php selected( $client, $c->ID ); ?>><?php echo esc_html( $c->post_title ); ?></option>
+            <?php endforeach; ?>
+        </select></label></p>
+        <p><label><?php _e( 'Plano', 'zxtec' ); ?><br/>
+        <input type="text" name="zxtec_plan" value="<?php echo esc_attr( $plan ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Inicio', 'zxtec' ); ?><br/>
+        <input type="date" name="zxtec_start" value="<?php echo esc_attr( $start ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Fim', 'zxtec' ); ?><br/>
+        <input type="date" name="zxtec_end" value="<?php echo esc_attr( $end ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Status', 'zxtec' ); ?><br/>
+        <select name="zxtec_status" class="widefat">
+            <option value="ativo" <?php selected( $status, 'ativo' ); ?>><?php _e( 'Ativo', 'zxtec' ); ?></option>
+            <option value="encerrado" <?php selected( $status, 'encerrado' ); ?>><?php _e( 'Encerrado', 'zxtec' ); ?></option>
+        </select></label></p>
+        <?php
+    }
+
+    /**
+     * Render expense meta box
+     */
+    public function expense_meta_box( $post ) {
+        $tech  = get_post_meta( $post->ID, '_zxtec_technician', true );
+        $amount = get_post_meta( $post->ID, '_zxtec_amount', true );
+        $date   = get_post_meta( $post->ID, '_zxtec_date', true );
+        $users = get_users( array( 'role' => 'zxtec_colaborador' ) );
+        wp_nonce_field( 'zxtec_save_meta', 'zxtec_nonce' );
+        ?>
+        <p><label><?php _e( 'Tecnico', 'zxtec' ); ?><br/>
+        <select name="zxtec_technician" class="widefat">
+            <option value="">--</option>
+            <?php foreach ( $users as $u ) : ?>
+                <option value="<?php echo esc_attr( $u->ID ); ?>" <?php selected( $tech, $u->ID ); ?>><?php echo esc_html( $u->display_name ); ?></option>
+            <?php endforeach; ?>
+        </select></label></p>
+        <p><label><?php _e( 'Valor', 'zxtec' ); ?><br/>
+        <input type="number" step="0.01" name="zxtec_amount" value="<?php echo esc_attr( $amount ); ?>" class="widefat" /></label></p>
+        <p><label><?php _e( 'Data', 'zxtec' ); ?><br/>
+        <input type="date" name="zxtec_date" value="<?php echo esc_attr( $date ); ?>" class="widefat" /></label></p>
+        <?php
+    }
+
+    /**
+     * Save post meta
+     */
+    public function save_post_meta( $post_id ) {
+        if ( ! isset( $_POST['zxtec_nonce'] ) || ! wp_verify_nonce( $_POST['zxtec_nonce'], 'zxtec_save_meta' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        $post_type = get_post_type( $post_id );
+
+        switch ( $post_type ) {
+            case 'zxtec_client':
+                update_post_meta( $post_id, '_zxtec_cpf', sanitize_text_field( $_POST['zxtec_cpf'] ?? '' ) );
+                update_post_meta( $post_id, '_zxtec_phone', sanitize_text_field( $_POST['zxtec_phone'] ?? '' ) );
+                update_post_meta( $post_id, '_zxtec_email', sanitize_email( $_POST['zxtec_email'] ?? '' ) );
+                $street  = sanitize_text_field( $_POST['zxtec_street'] ?? '' );
+                $number  = sanitize_text_field( $_POST['zxtec_number'] ?? '' );
+                $neigh   = sanitize_text_field( $_POST['zxtec_neighborhood'] ?? '' );
+                $compl   = sanitize_text_field( $_POST['zxtec_complement'] ?? '' );
+                $city    = sanitize_text_field( $_POST['zxtec_city'] ?? '' );
+                $state   = sanitize_text_field( $_POST['zxtec_state'] ?? '' );
+                $country = sanitize_text_field( $_POST['zxtec_country'] ?? '' );
+                $zip     = sanitize_text_field( $_POST['zxtec_zip'] ?? '' );
+                $full    = trim( $street . ' ' . $number . ' ' . $compl . ', ' . $neigh . ', ' . $city . ' - ' . $state . ', ' . $country );
+                update_post_meta( $post_id, '_zxtec_street', $street );
+                update_post_meta( $post_id, '_zxtec_number', $number );
+                update_post_meta( $post_id, '_zxtec_neighborhood', $neigh );
+                update_post_meta( $post_id, '_zxtec_complement', $compl );
+                update_post_meta( $post_id, '_zxtec_city', $city );
+                update_post_meta( $post_id, '_zxtec_state', $state );
+                update_post_meta( $post_id, '_zxtec_country', $country );
+                update_post_meta( $post_id, '_zxtec_zip', $zip );
+                update_post_meta( $post_id, '_zxtec_address', $full );
+                break;
+            case 'zxtec_service':
+                update_post_meta( $post_id, '_zxtec_price', floatval( $_POST['zxtec_price'] ?? 0 ) );
+                update_post_meta( $post_id, '_zxtec_specialty', sanitize_text_field( $_POST['zxtec_specialty'] ?? '' ) );
+                break;
+           case 'zxtec_order':
+                $old_tech   = get_post_meta( $post_id, '_zxtec_technician', true );
+                $old_status = get_post_meta( $post_id, '_zxtec_status', true );
+
+                $new_client     = absint( $_POST['zxtec_client'] ?? 0 );
+                $new_service    = absint( $_POST['zxtec_service'] ?? 0 );
+                $new_technician = absint( $_POST['zxtec_technician'] ?? 0 );
+                $new_date       = sanitize_text_field( $_POST['zxtec_date'] ?? '' );
+                $new_status     = sanitize_text_field( $_POST['zxtec_status'] ?? '' );
+                $new_lat        = sanitize_text_field( $_POST['zxtec_lat'] ?? '' );
+                $new_lng        = sanitize_text_field( $_POST['zxtec_lng'] ?? '' );
+                $new_street     = sanitize_text_field( $_POST['zxtec_order_street'] ?? '' );
+                $new_number     = sanitize_text_field( $_POST['zxtec_order_number'] ?? '' );
+                $new_neigh      = sanitize_text_field( $_POST['zxtec_order_neighborhood'] ?? '' );
+                $new_compl      = sanitize_text_field( $_POST['zxtec_order_complement'] ?? '' );
+                $new_city       = sanitize_text_field( $_POST['zxtec_order_city'] ?? '' );
+                $new_state      = sanitize_text_field( $_POST['zxtec_order_state'] ?? '' );
+                $new_country    = sanitize_text_field( $_POST['zxtec_order_country'] ?? '' );
+                $new_zip        = sanitize_text_field( $_POST['zxtec_order_zip'] ?? '' );
+                $new_addr       = trim( $new_street . ' ' . $new_number . ' ' . $new_compl . ', ' . $new_neigh . ', ' . $new_city . ' - ' . $new_state . ', ' . $new_country );
+
+                update_post_meta( $post_id, '_zxtec_client', $new_client );
+                update_post_meta( $post_id, '_zxtec_service', $new_service );
+                update_post_meta( $post_id, '_zxtec_technician', $new_technician );
+                update_post_meta( $post_id, '_zxtec_date', $new_date );
+                update_post_meta( $post_id, '_zxtec_status', $new_status );
+                update_post_meta( $post_id, '_zxtec_lat', $new_lat );
+                update_post_meta( $post_id, '_zxtec_lng', $new_lng );
+                update_post_meta( $post_id, '_zxtec_order_street', $new_street );
+                update_post_meta( $post_id, '_zxtec_order_number', $new_number );
+                update_post_meta( $post_id, '_zxtec_order_neighborhood', $new_neigh );
+                update_post_meta( $post_id, '_zxtec_order_complement', $new_compl );
+                update_post_meta( $post_id, '_zxtec_order_city', $new_city );
+                update_post_meta( $post_id, '_zxtec_order_state', $new_state );
+                update_post_meta( $post_id, '_zxtec_order_country', $new_country );
+                update_post_meta( $post_id, '_zxtec_order_address', $new_addr );
+                update_post_meta( $post_id, '_zxtec_order_zip', $new_zip );
+
+                if ( ! $new_technician ) {
+                    $this->assign_nearest_technician( $post_id );
+                    $new_technician = get_post_meta( $post_id, '_zxtec_technician', true );
+                }
+
+                if ( $new_technician && $new_technician !== (int) $old_tech ) {
+                    $user = get_userdata( $new_technician );
+                    if ( $user ) {
+                        wp_mail( $user->user_email, __( 'Nova ordem atribuida', 'zxtec' ), sprintf( __( 'Voce recebeu a ordem "%s".', 'zxtec' ), get_the_title( $post_id ) ) );
+                        $this->add_notification( $new_technician, sprintf( __( 'Nova ordem: %s', 'zxtec' ), get_the_title( $post_id ) ) );
+                    }
+                }
+
+                if ( $new_status !== $old_status ) {
+                    $tech = $new_technician ? get_userdata( $new_technician ) : null;
+                    if ( $tech ) {
+                        wp_mail( $tech->user_email, __( 'Status atualizado', 'zxtec' ), sprintf( __( 'A ordem "%s" agora esta "%s".', 'zxtec' ), get_the_title( $post_id ), $new_status ) );
+                        $this->add_notification( $tech->ID, sprintf( __( 'Status da ordem "%s": %s', 'zxtec' ), get_the_title( $post_id ), $new_status ) );
+                    }
+                }
+                break;
+            case 'zxtec_contract':
+                update_post_meta( $post_id, '_zxtec_client', absint( $_POST['zxtec_client'] ?? 0 ) );
+                update_post_meta( $post_id, '_zxtec_plan', sanitize_text_field( $_POST['zxtec_plan'] ?? '' ) );
+                update_post_meta( $post_id, '_zxtec_start', sanitize_text_field( $_POST['zxtec_start'] ?? '' ) );
+                update_post_meta( $post_id, '_zxtec_end', sanitize_text_field( $_POST['zxtec_end'] ?? '' ) );
+                update_post_meta( $post_id, '_zxtec_status', sanitize_text_field( $_POST['zxtec_status'] ?? '' ) );
+                break;
+            case 'zxtec_expense':
+                update_post_meta( $post_id, '_zxtec_technician', absint( $_POST['zxtec_technician'] ?? 0 ) );
+                update_post_meta( $post_id, '_zxtec_amount', floatval( $_POST['zxtec_amount'] ?? 0 ) );
+                update_post_meta( $post_id, '_zxtec_date', sanitize_text_field( $_POST['zxtec_date'] ?? '' ) );
+                break;
+        }
+    }
+
+    /**
+     * Enqueue scripts for admin
+     */
+    public function enqueue_admin_scripts( $hook ) {
+        if ( 'post.php' === $hook || 'post-new.php' === $hook ) {
+            $screen = get_current_screen();
+            if ( 'zxtec_order' === $screen->post_type ) {
+                wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css' );
+                wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), null, true );
+                wp_add_inline_script( 'leaflet', $this->order_map_script() );
+            }
+        }
+        if ( 'zxtec_admin_panel_page_zxtec_tech_map' === $hook ) {
+            wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css' );
+            wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), null, true );
+        }
+        if ( 'zxtec_admin_panel_page_zxtec_analytics' === $hook ) {
+            wp_enqueue_script( 'chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', array(), null, true );
+        }
+        $screen = get_current_screen();
+        $post_types = array( 'zxtec_client', 'zxtec_service', 'zxtec_order', 'zxtec_contract', 'zxtec_expense' );
+        if ( strpos( $hook, 'zxtec_admin_panel' ) !== false || ( isset( $screen->post_type ) && in_array( $screen->post_type, $post_types, true ) ) ) {
+            wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css' );
+            wp_enqueue_style( 'zxtec-admin', $this->url . 'css/zxtec-admin.css' );
+            wp_enqueue_style( 'zxtec-toolbar', $this->url . 'css/zxtec-toolbar.css' );
+            wp_enqueue_script( 'zxtec-admin', $this->url . 'js/zxtec-admin.js', array(), null, true );
+        }
+    }
+
+    /**
+     * Enqueue styles for frontend dashboard
+     */
+    public function enqueue_public_scripts() {
+        if ( is_singular() ) {
+            global $post;
+            if ( has_shortcode( $post->post_content, 'zxtec_colaborador_dashboard' ) ) {
+                wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/flatly/bootstrap.min.css' );
+                wp_enqueue_style( 'zxtec-dashboard', $this->url . 'css/zxtec-dashboard.css' );
+                wp_enqueue_style( 'zxtec-toolbar', $this->url . 'css/zxtec-toolbar.css' );
+            }
+        }
+    }
+
+    /**
+     * JS used in order meta box
+     */
+    private function order_map_script() {
+        return <<<JS
+document.addEventListener('DOMContentLoaded',function(){
+    var latInput=document.querySelector('input[name="zxtec_lat"]');
+    var lngInput=document.querySelector('input[name="zxtec_lng"]');
+    if(!latInput||!lngInput) return;
+    var lat=parseFloat(latInput.value)||-15;
+    var lng=parseFloat(lngInput.value)||-55;
+    var map=L.map('zxtec_map').setView([lat,lng],5);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19}).addTo(map);
+    var marker=L.marker([lat,lng],{draggable:true}).addTo(map);
+    marker.on('dragend',function(e){
+        var c=e.target.getLatLng();
+        latInput.value=c.lat.toFixed(6);
+        lngInput.value=c.lng.toFixed(6);
+    });
+});
+JS;
+    }
+
+    /**
+     * Register admin pages
+     */
+    public function register_admin_pages() {
+        add_menu_page( __( 'ZX Tec', 'zxtec' ), __( 'ZX Tec', 'zxtec' ), 'manage_options', 'zxtec_admin_panel', array( $this, 'admin_page' ), 'dashicons-admin-generic', 26 );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Colaboradores', 'zxtec' ), __( 'Painel do Colaborador', 'zxtec' ), 'read', 'zxtec_colaborador_dashboard', array( $this, 'dashboard_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Financeiro', 'zxtec' ), __( 'Relatorio Financeiro', 'zxtec' ), 'manage_options', 'zxtec_financial_report', array( $this, 'financial_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Historico', 'zxtec' ), __( 'Historico de Servicos', 'zxtec' ), 'manage_options', 'zxtec_order_history', array( $this, 'history_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Contratos Ativos', 'zxtec' ), __( 'Contratos Ativos', 'zxtec' ), 'manage_options', 'zxtec_active_contracts', array( $this, 'contracts_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Agenda', 'zxtec' ), __( 'Agenda', 'zxtec' ), 'read', 'zxtec_schedule', array( $this, 'schedule_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Mapa de Tecnicos', 'zxtec' ), __( 'Mapa de Tecnicos', 'zxtec' ), 'manage_options', 'zxtec_tech_map', array( $this, 'technician_map_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Despesas', 'zxtec' ), __( 'Relatorio de Despesas', 'zxtec' ), 'manage_options', 'zxtec_expense_report', array( $this, 'expense_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Notificacoes', 'zxtec' ), __( 'Notificacoes', 'zxtec' ), 'manage_options', 'zxtec_notifications', array( $this, 'notifications_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Analiticos', 'zxtec' ), __( 'Relatorio Grafico', 'zxtec' ), 'manage_options', 'zxtec_analytics', array( $this, 'analytics_page' ) );
+        add_submenu_page( 'zxtec_admin_panel', __( 'Configuracoes', 'zxtec' ), __( 'Configuracoes', 'zxtec' ), 'manage_options', 'zxtec_settings', array( $this, 'settings_page' ) );
+    }
+
+    /**
+     * Render admin page
+     */
+    public function admin_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card"><h1 class="mb-4">ZX Tec</h1><p>Bem-vindo ao painel administrativo.</p></div></div>';
+    }
+
+    /**
+     * Financial report page
+     */
+    public function financial_page() {
+        $start = isset( $_GET['start'] ) ? sanitize_text_field( $_GET['start'] ) : '';
+        $end   = isset( $_GET['end'] ) ? sanitize_text_field( $_GET['end'] ) : '';
+        if ( isset( $_GET['download'] ) ) {
+            if ( 'csv' === $_GET['download'] ) {
+                ZXTEC_Financial::download_csv( $start, $end );
+            } elseif ( 'pdf' === $_GET['download'] ) {
+                ZXTEC_Financial::download_pdf( $start, $end );
+            } elseif ( 'xls' === $_GET['download'] ) {
+                ZXTEC_Financial::download_xls( $start, $end );
+            }
+            exit;
+        }
+
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Relatorio Financeiro', 'zxtec' ) . '</h1>';
+        echo '<form method="get" class="mb-3">';
+        echo '<input type="hidden" name="page" value="zxtec_financial_report" />';
+        echo '<label>' . esc_html__( 'De', 'zxtec' ) . ' <input type="date" name="start" value="' . esc_attr( $start ) . '" /></label> ';
+        echo '<label>' . esc_html__( 'Ate', 'zxtec' ) . ' <input type="date" name="end" value="' . esc_attr( $end ) . '" /></label> ';
+        submit_button( __( 'Filtrar', 'zxtec' ), 'secondary', '', false );
+        echo '</form>';
+        echo ZXTEC_Financial::get_report_html( $start, $end );
+        echo '</div></div>';
+    }
+
+    /**
+     * Expense report page
+     */
+    public function expense_page() {
+        if ( isset( $_GET['download'] ) && 'csv' === $_GET['download'] ) {
+            ZXTEC_Expense::download_csv();
+            exit;
+        }
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Relatorio de Despesas', 'zxtec' ) . '</h1>';
+        echo ZXTEC_Expense::get_report_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Orders history page
+     */
+    public function history_page() {
+        if ( isset( $_GET['download'] ) && 'csv' === $_GET['download'] ) {
+            $this->download_history_csv();
+            exit;
+        }
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Historico de Servicos', 'zxtec' ) . '</h1>';
+        echo $this->get_history_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Active contracts page
+     */
+    public function contracts_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Contratos Ativos', 'zxtec' ) . '</h1>';
+        echo $this->get_contracts_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Schedule page for technicians
+     */
+    public function schedule_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Agenda', 'zxtec' ) . '</h1>';
+        echo $this->get_schedule_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Notifications list for administrators
+     */
+    public function notifications_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Notificacoes', 'zxtec' ) . '</h1>';
+        $selected = absint( $_GET['user'] ?? 0 );
+        echo '<form method="get"><input type="hidden" name="page" value="zxtec_notifications" />';
+        echo '<p><label>' . esc_html__( 'Colaborador:', 'zxtec' ) . ' <select name="user"><option value="">--</option>';
+        foreach ( get_users( array( 'role' => 'zxtec_colaborador' ) ) as $u ) {
+            echo '<option value="' . esc_attr( $u->ID ) . '" ' . selected( $selected, $u->ID, false ) . '>' . esc_html( $u->display_name ) . '</option>';
+        }
+        echo '</select></label> <input type="submit" class="button" value="' . esc_attr__( 'Filtrar', 'zxtec' ) . '" /></p></form>';
+
+        $users = $selected ? array( get_userdata( $selected ) ) : get_users( array( 'role' => 'zxtec_colaborador' ) );
+        echo '<table class="table table-striped zxtec-table"><thead><tr><th>' . esc_html__( 'Colaborador', 'zxtec' ) . '</th><th>' . esc_html__( 'Mensagem', 'zxtec' ) . '</th><th>' . esc_html__( 'Data', 'zxtec' ) . '</th><th></th></tr></thead><tbody>';
+        foreach ( $users as $user ) {
+            if ( ! $user ) {
+                continue;
+            }
+            $notes = $this->get_notifications( $user->ID );
+            foreach ( $notes as $i => $n ) {
+                $url = wp_nonce_url( admin_url( 'admin-post.php?action=zxtec_clear_notification&n=' . $i ), 'zxtec_clear_note_' . $user->ID );
+                echo '<tr><td>' . esc_html( $user->display_name ) . '</td><td>' . esc_html( $n['message'] ) . '</td><td>' . esc_html( $n['time'] ) . '</td><td><a href="' . esc_url( $url ) . '">x</a></td></tr>';
+            }
+        }
+        echo '</tbody></table>';
+        echo '</div></div>';
+    }
+
+    /**
+     * Analytics charts page
+     */
+    public function analytics_page() {
+        echo ZXTEC_Analytics::page_html();
+    }
+
+    /**
+     * Render collaborator dashboard page
+     */
+    public function dashboard_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo $this->get_dashboard_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Shortcode handler
+     */
+    public function dashboard_shortcode() {
+        return $this->get_dashboard_html();
+    }
+
+    /**
+     * Dashboard HTML
+     */
+    private function get_dashboard_html() {
+        if ( ! is_user_logged_in() ) {
+            return __( 'Necessario fazer login.', 'zxtec' );
+        }
+
+        $user_id = get_current_user_id();
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_key'   => '_zxtec_technician',
+            'meta_value' => $user_id,
+            'numberposts' => -1,
+        ) );
+        $tech_lat = get_user_meta( $user_id, 'zxtec_lat', true );
+        $tech_lng = get_user_meta( $user_id, 'zxtec_lng', true );
+
+        ob_start();
+        ?>
+        <h1><?php _e( 'Dashboard do Colaborador', 'zxtec' ); ?></h1>
+        <?php
+        $notes = $this->get_notifications( $user_id );
+        if ( ! empty( $notes ) ) : ?>
+            <h2><?php _e( 'Notificacoes', 'zxtec' ); ?></h2>
+            <ul>
+                <?php foreach ( $notes as $i => $n ) : ?>
+                    <li><?php echo esc_html( $n['message'] ); ?>
+                    <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=zxtec_clear_notification&n=' . $i ), 'zxtec_clear_note_' . $user_id ) ); ?>">x</a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+        <?php if ( ! empty( $orders ) ) : ?>
+            <table class="table table-striped zxtec-table">
+                <thead><tr><th><?php _e( 'Ordem', 'zxtec' ); ?></th><th><?php _e( 'Data', 'zxtec' ); ?></th><th><?php _e( 'Status', 'zxtec' ); ?></th><th><?php _e( 'Acao', 'zxtec' ); ?></th></tr></thead>
+                <tbody>
+                <?php foreach ( $orders as $order ) : ?>
+                    <?php
+                        $status = get_post_meta( $order->ID, '_zxtec_status', true );
+                        $lat = get_post_meta( $order->ID, '_zxtec_lat', true );
+                        $lng = get_post_meta( $order->ID, '_zxtec_lng', true );
+                        if ( $tech_lat && $tech_lng && $lat && $lng ) {
+                            $map_url = sprintf( 'https://www.google.com/maps/dir/?api=1&origin=%s,%s&destination=%s,%s', $tech_lat, $tech_lng, $lat, $lng );
+                        } elseif ( $lat && $lng ) {
+                            $map_url = 'https://www.google.com/maps/?q=' . $lat . ',' . $lng;
+                        } else {
+                            $map_url = '';
+                        }
+                        $nonce = wp_create_nonce( 'zxtec_order_action_' . $order->ID );
+                    ?>
+                    <tr>
+                        <td><?php echo esc_html( $order->post_title ); ?></td>
+                        <td><?php echo esc_html( get_post_meta( $order->ID, '_zxtec_date', true ) ); ?></td>
+                        <td><?php echo esc_html( $this->human_status( $status ) ); ?></td>
+                        <td>
+                            <?php if ( $map_url ) : ?>
+                                <a href="<?php echo esc_url( $map_url ); ?>" target="_blank">GPS</a>
+                                |
+                            <?php endif; ?>
+                            <?php if ( 'confirmado' !== $status && 'concluido' !== $status ) : ?>
+                                <a href="<?php echo admin_url( 'admin-post.php?action=zxtec_confirm_order&order=' . $order->ID . '&_wpnonce=' . $nonce ); ?>">Confirmar</a>
+                                |
+                                <a href="#" onclick="var r=prompt('Justificativa:');if(r===null){return false;}window.location.href='<?php echo admin_url( 'admin-post.php?action=zxtec_decline_order&order=' . $order->ID . '&_wpnonce=' . $nonce . '&reason=' ); ?>'+encodeURIComponent(r);return false;">Recusar</a>
+                            <?php elseif ( 'confirmado' === $status ) : ?>
+                                <a href="<?php echo admin_url( 'admin-post.php?action=zxtec_finalize_order&order=' . $order->ID . '&_wpnonce=' . $nonce ); ?>">Finalizar</a>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else : ?>
+            <p><?php _e( 'Nenhuma ordem designada.', 'zxtec' ); ?></p>
+        <?php endif; ?>
+        <?php echo $this->get_user_financial_html(); ?>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * History HTML
+     */
+    private function get_history_html() {
+        $tech  = absint( $_GET['tech'] ?? 0 );
+        $start = isset( $_GET['start'] ) ? sanitize_text_field( $_GET['start'] ) : '';
+        $end   = isset( $_GET['end'] ) ? sanitize_text_field( $_GET['end'] ) : '';
+
+        $meta = array( array( 'key' => '_zxtec_status', 'value' => 'concluido' ) );
+        if ( $tech ) {
+            $meta[] = array( 'key' => '_zxtec_technician', 'value' => $tech );
+        }
+        if ( $start ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $start, 'compare' => '>=' );
+        }
+        if ( $end ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $end, 'compare' => '<=' );
+        }
+
+        $orders = get_posts( array(
+            'post_type'   => 'zxtec_order',
+            'numberposts' => -1,
+            'meta_key'    => '_zxtec_date',
+            'orderby'     => 'meta_value',
+            'order'       => 'ASC',
+            'meta_query'  => $meta,
+        ) );
+
+        ob_start();
+        echo '<form method="get"><input type="hidden" name="page" value="zxtec_order_history" />';
+        echo '<p>';
+        echo '<label>' . esc_html__( 'Tecnico:', 'zxtec' ) . ' <select name="tech"><option value="">--</option>';
+        foreach ( get_users( array( 'role' => 'zxtec_colaborador' ) ) as $u ) {
+            echo '<option value="' . esc_attr( $u->ID ) . '" ' . selected( $tech, $u->ID, false ) . '>' . esc_html( $u->display_name ) . '</option>';
+        }
+        echo '</select></label> ';
+        echo '<label>' . esc_html__( 'Inicio:', 'zxtec' ) . ' <input type="date" name="start" value="' . esc_attr( $start ) . '" /></label> ';
+        echo '<label>' . esc_html__( 'Fim:', 'zxtec' ) . ' <input type="date" name="end" value="' . esc_attr( $end ) . '" /></label> ';
+        echo '<input type="submit" class="button" value="' . esc_attr__( 'Filtrar', 'zxtec' ) . '" /> ';
+        $export_url = add_query_arg( array( 'page' => 'zxtec_order_history', 'download' => 'csv', 'tech' => $tech, 'start' => $start, 'end' => $end ) );
+        echo '<a class="button" href="' . esc_url( $export_url ) . '">' . esc_html__( 'Exportar CSV', 'zxtec' ) . '</a>';
+        echo '</p></form>';
+
+        if ( empty( $orders ) ) {
+            echo '<p>' . esc_html__( 'Nenhum servico concluido.', 'zxtec' ) . '</p>';
+            return ob_get_clean();
+        }
+
+        echo '<table class="table table-striped zxtec-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Ordem', 'zxtec' ) . '</th><th>' . esc_html__( 'Tecnico', 'zxtec' ) . '</th><th>' . esc_html__( 'Data', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $orders as $order ) {
+            $tech_id = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $user    = $tech_id ? get_userdata( $tech_id ) : null;
+            echo '<tr><td>' . esc_html( $order->post_title ) . '</td><td>' . esc_html( $user ? $user->display_name : '' ) . '</td><td>' . esc_html( get_post_meta( $order->ID, '_zxtec_date', true ) ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Active contracts table HTML
+     */
+    private function get_contracts_html() {
+        $contracts = get_posts( array(
+            'post_type'   => 'zxtec_contract',
+            'meta_key'    => '_zxtec_status',
+            'meta_value'  => 'ativo',
+            'numberposts' => -1,
+        ) );
+
+        if ( empty( $contracts ) ) {
+            return '<p>' . esc_html__( 'Nenhum contrato ativo.', 'zxtec' ) . '</p>';
+        }
+
+        ob_start();
+        echo '<table class="table table-striped zxtec-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Cliente', 'zxtec' ) . '</th><th>' . esc_html__( 'Plano', 'zxtec' ) . '</th><th>' . esc_html__( 'Inicio', 'zxtec' ) . '</th><th>' . esc_html__( 'Fim', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $contracts as $contract ) {
+            $client_id = get_post_meta( $contract->ID, '_zxtec_client', true );
+            $client = $client_id ? get_post( $client_id ) : null;
+            echo '<tr><td>' . esc_html( $client ? $client->post_title : '' ) . '</td><td>' . esc_html( get_post_meta( $contract->ID, '_zxtec_plan', true ) ) . '</td><td>' . esc_html( get_post_meta( $contract->ID, '_zxtec_start', true ) ) . '</td><td>' . esc_html( get_post_meta( $contract->ID, '_zxtec_end', true ) ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Technician schedule table HTML
+     */
+    private function get_schedule_html() {
+        if ( ! is_user_logged_in() ) {
+            return '<p>' . esc_html__( 'Necessario fazer login.', 'zxtec' ) . '</p>';
+        }
+
+        $user_id = get_current_user_id();
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_query' => array(
+                array(
+                    'key'   => '_zxtec_technician',
+                    'value' => $user_id,
+                ),
+                array(
+                    'key'   => '_zxtec_status',
+                    'value' => 'confirmado',
+                ),
+            ),
+            'meta_key'   => '_zxtec_date',
+            'orderby'    => 'meta_value',
+            'order'      => 'ASC',
+            'numberposts' => -1,
+        ) );
+
+        if ( empty( $orders ) ) {
+            return '<p>' . esc_html__( 'Nenhum agendamento.', 'zxtec' ) . '</p>';
+        }
+
+        ob_start();
+        echo '<table class="table table-striped zxtec-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Ordem', 'zxtec' ) . '</th><th>' . esc_html__( 'Data', 'zxtec' ) . '</th><th>' . esc_html__( 'Cliente', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $orders as $order ) {
+            $client_id = get_post_meta( $order->ID, '_zxtec_client', true );
+            $client = $client_id ? get_post( $client_id ) : null;
+            echo '<tr><td>' . esc_html( $order->post_title ) . '</td><td>' . esc_html( get_post_meta( $order->ID, '_zxtec_date', true ) ) . '</td><td>' . esc_html( $client ? $client->post_title : '' ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Financial summary for logged in user
+     */
+    private function get_user_financial_html() {
+        if ( ! is_user_logged_in() ) {
+            return '';
+        }
+
+        $user_id = get_current_user_id();
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_query' => array(
+                array( 'key' => '_zxtec_technician', 'value' => $user_id ),
+                array( 'key' => '_zxtec_status', 'value' => 'concluido' ),
+            ),
+            'numberposts' => -1,
+        ) );
+
+        if ( empty( $orders ) ) {
+            return '';
+        }
+
+        $total = 0;
+        $expense_total = 0;
+        ob_start();
+        echo '<h2>' . esc_html__( 'Financeiro', 'zxtec' ) . '</h2>';
+        $url  = wp_nonce_url( admin_url( 'admin-post.php?action=zxtec_user_financial_csv' ), 'zxtec_user_financial_' . $user_id );
+        $urlp = wp_nonce_url( admin_url( 'admin-post.php?action=zxtec_user_financial_pdf' ), 'zxtec_user_financial_' . $user_id );
+        echo '<p><a class="button" href="' . esc_url( $url ) . '">' . esc_html__( 'Exportar CSV', 'zxtec' ) . '</a> ';
+        echo '<a class="button" href="' . esc_url( $urlp ) . '">' . esc_html__( 'Exportar PDF', 'zxtec' ) . '</a></p>';
+        echo '<table class="table table-striped zxtec-table">';
+        echo '<thead><tr><th>' . esc_html__( 'Servico', 'zxtec' ) . '</th><th>' . esc_html__( 'Preco', 'zxtec' ) . '</th><th>' . esc_html__( 'Comissao', 'zxtec' ) . '</th></tr></thead><tbody>';
+        foreach ( $orders as $order ) {
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            $commission = $price * $this->get_commission_rate( $user_id );
+            $total += $commission;
+            echo '<tr><td>' . esc_html( $order->post_title ) . '</td><td>' . number_format_i18n( $price, 2 ) . '</td><td>' . number_format_i18n( $commission, 2 ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+        echo '<p><strong>' . sprintf( esc_html__( 'Total de comissoes: %s', 'zxtec' ), number_format_i18n( $total, 2 ) ) . '</strong></p>';
+
+        $expenses = get_posts( array(
+            'post_type'  => 'zxtec_expense',
+            'meta_key'   => '_zxtec_technician',
+            'meta_value' => $user_id,
+            'numberposts' => -1,
+        ) );
+        foreach ( $expenses as $exp ) {
+            $expense_total += floatval( get_post_meta( $exp->ID, '_zxtec_amount', true ) );
+        }
+        if ( $expense_total > 0 ) {
+            echo '<p>' . sprintf( esc_html__( 'Total de despesas: %s', 'zxtec' ), number_format_i18n( $expense_total, 2 ) ) . '</p>';
+        }
+        $net = $total - $expense_total;
+        echo '<p><strong>' . sprintf( esc_html__( 'Saldo liquido: %s', 'zxtec' ), number_format_i18n( $net, 2 ) ) . '</strong></p>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Handle order confirmation
+     */
+    public function handle_confirm_order() {
+        $order_id = absint( $_GET['order'] ?? 0 );
+        if ( ! $order_id || ! wp_verify_nonce( $_GET['_wpnonce'] ?? '', 'zxtec_order_action_' . $order_id ) ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        update_post_meta( $order_id, '_zxtec_status', 'confirmado' );
+        $this->notify_admins( sprintf( __( 'Ordem %s confirmada', 'zxtec' ), get_the_title( $order_id ) ) );
+        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=zxtec_colaborador_dashboard' ) );
+        exit;
+    }
+
+    /**
+     * Handle order decline
+     */
+    public function handle_decline_order() {
+        $order_id = absint( $_GET['order'] ?? 0 );
+        if ( ! $order_id || ! wp_verify_nonce( $_GET['_wpnonce'] ?? '', 'zxtec_order_action_' . $order_id ) ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        $reason = isset( $_GET['reason'] ) ? sanitize_text_field( wp_unslash( $_GET['reason'] ) ) : '';
+        update_post_meta( $order_id, '_zxtec_status', 'recusado' );
+        if ( $reason ) {
+            update_post_meta( $order_id, '_zxtec_decline_reason', $reason );
+        }
+        $this->notify_admins( sprintf( __( 'Ordem %s recusada', 'zxtec' ), get_the_title( $order_id ) ) );
+        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=zxtec_colaborador_dashboard' ) );
+        exit;
+    }
+
+    /**
+     * Handle order finalize
+     */
+    public function handle_finalize_order() {
+        $order_id = absint( $_GET['order'] ?? 0 );
+        if ( ! $order_id || ! wp_verify_nonce( $_GET['_wpnonce'] ?? '', 'zxtec_order_action_' . $order_id ) ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        update_post_meta( $order_id, '_zxtec_status', 'concluido' );
+        $this->notify_admins( sprintf( __( 'Ordem %s finalizada', 'zxtec' ), get_the_title( $order_id ) ) );
+        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=zxtec_colaborador_dashboard' ) );
+        exit;
+    }
+
+    /**
+     * Technician map admin page
+     */
+    public function technician_map_page() {
+        echo '<div class="zxtec-container"><div class="zxtec-card">';
+        echo '<h1 class="mb-4">' . esc_html__( 'Mapa de Tecnicos', 'zxtec' ) . '</h1>';
+        echo $this->get_technician_map_html();
+        echo '</div></div>';
+    }
+
+    /**
+     * Render technicians map HTML
+     */
+    private function get_technician_map_html() {
+        $users = get_users( array( 'role' => 'zxtec_colaborador' ) );
+        $markers = array();
+        foreach ( $users as $user ) {
+            $lat = get_user_meta( $user->ID, 'zxtec_lat', true );
+            $lng = get_user_meta( $user->ID, 'zxtec_lng', true );
+            if ( $lat && $lng ) {
+                $markers[] = array( 'name' => $user->display_name, 'lat' => $lat, 'lng' => $lng );
+            }
+        }
+        ob_start();
+        ?>
+        <div id="zxtec_tech_map" style="height:400px;"></div>
+        <script>
+        document.addEventListener('DOMContentLoaded',function(){
+            var map=L.map('zxtec_tech_map').setView([0,0],2);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{maxZoom:19}).addTo(map);
+            var data=<?php echo json_encode( $markers ); ?>;
+            data.forEach(function(m){L.marker([m.lat,m.lng]).addTo(map).bindPopup(m.name);});
+        });
+        </script>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Output user location fields
+     */
+    public function user_location_fields( $user ) {
+        $lat = get_user_meta( $user->ID, 'zxtec_lat', true );
+        $lng = get_user_meta( $user->ID, 'zxtec_lng', true );
+        $specialty = get_user_meta( $user->ID, 'zxtec_specialty', true );
+        $cost_km  = get_user_meta( $user->ID, 'zxtec_cost_km', true );
+        ?>
+        <h2><?php esc_html_e( 'Localizacao ZX Tec', 'zxtec' ); ?></h2>
+        <table class="form-table">
+            <tr>
+                <th><label for="zxtec_lat"><?php esc_html_e( 'Latitude', 'zxtec' ); ?></label></th>
+                <td><input type="text" name="zxtec_lat" id="zxtec_lat" value="<?php echo esc_attr( $lat ); ?>" class="regular-text" /></td>
+            </tr>
+            <tr>
+                <th><label for="zxtec_lng"><?php esc_html_e( 'Longitude', 'zxtec' ); ?></label></th>
+                <td><input type="text" name="zxtec_lng" id="zxtec_lng" value="<?php echo esc_attr( $lng ); ?>" class="regular-text" /></td>
+            </tr>
+            <tr>
+                <th><label for="zxtec_specialty"><?php esc_html_e( 'Especialidade', 'zxtec' ); ?></label></th>
+                <td><input type="text" name="zxtec_specialty" id="zxtec_specialty" value="<?php echo esc_attr( $specialty ); ?>" class="regular-text" /></td>
+            </tr>
+            <tr>
+                <th><label for="zxtec_cost_km"><?php esc_html_e( 'Custo por Km (R$)', 'zxtec' ); ?></label></th>
+                <td><input type="number" step="0.01" name="zxtec_cost_km" id="zxtec_cost_km" value="<?php echo esc_attr( $cost_km ); ?>" class="regular-text" /></td>
+            </tr>
+        </table>
+        <?php
+    }
+
+    /**
+     * Save user location
+     */
+    public function save_user_location_fields( $user_id ) {
+        if ( ! current_user_can( 'edit_user', $user_id ) ) {
+            return false;
+        }
+        update_user_meta( $user_id, 'zxtec_lat', sanitize_text_field( $_POST['zxtec_lat'] ?? '' ) );
+        update_user_meta( $user_id, 'zxtec_lng', sanitize_text_field( $_POST['zxtec_lng'] ?? '' ) );
+        update_user_meta( $user_id, 'zxtec_specialty', sanitize_text_field( $_POST['zxtec_specialty'] ?? '' ) );
+        update_user_meta( $user_id, 'zxtec_cost_km', floatval( $_POST['zxtec_cost_km'] ?? 0 ) );
+    }
+
+    /**
+     * Output commission field for user
+     */
+    public function user_commission_field( $user ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $comm = get_user_meta( $user->ID, 'zxtec_commission', true );
+        ?>
+        <h2><?php esc_html_e( 'Comissao ZX Tec', 'zxtec' ); ?></h2>
+        <table class="form-table">
+            <tr>
+                <th><label for="zxtec_commission_user"><?php esc_html_e( 'Percentual de Comissao', 'zxtec' ); ?></label></th>
+                <td><input type="number" step="0.01" name="zxtec_commission_user" id="zxtec_commission_user" value="<?php echo esc_attr( $comm ); ?>" class="regular-text" /> %<p class="description"><?php esc_html_e( 'Deixe em branco para usar o valor padrao.', 'zxtec' ); ?></p></td>
+            </tr>
+        </table>
+        <?php
+    }
+
+    /**
+     * Save user commission field
+     */
+    public function save_user_commission_field( $user_id ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( isset( $_POST['zxtec_commission_user'] ) ) {
+            $val = sanitize_text_field( $_POST['zxtec_commission_user'] );
+            if ( $val === '' ) {
+                delete_user_meta( $user_id, 'zxtec_commission' );
+            } else {
+                update_user_meta( $user_id, 'zxtec_commission', floatval( $val ) );
+            }
+        }
+    }
+
+    /**
+     * Assign the nearest technician to an order
+     */
+    private function assign_nearest_technician( $order_id ) {
+        $lat = get_post_meta( $order_id, '_zxtec_lat', true );
+        $lng = get_post_meta( $order_id, '_zxtec_lng', true );
+        if ( ! $lat || ! $lng ) {
+            return;
+        }
+
+        $service_id = get_post_meta( $order_id, '_zxtec_service', true );
+        $specialty  = $service_id ? get_post_meta( $service_id, '_zxtec_specialty', true ) : '';
+
+        $args = array( 'role' => 'zxtec_colaborador' );
+        if ( $specialty ) {
+            $args['meta_query'] = array(
+                array(
+                    'key'   => 'zxtec_specialty',
+                    'value' => $specialty,
+                ),
+            );
+        }
+
+        $users = get_users( $args );
+        $closest = 0;
+        $best_cost = PHP_FLOAT_MAX;
+        $best_distance = PHP_FLOAT_MAX;
+        foreach ( $users as $user ) {
+            $t_lat = get_user_meta( $user->ID, 'zxtec_lat', true );
+            $t_lng = get_user_meta( $user->ID, 'zxtec_lng', true );
+            if ( $t_lat && $t_lng ) {
+                $d = $this->haversine_distance( $lat, $lng, $t_lat, $t_lng );
+                $cost_km = floatval( get_user_meta( $user->ID, 'zxtec_cost_km', true ) );
+                $est_cost = $d * ( $cost_km ?: 1 );
+                if ( $est_cost < $best_cost || ( $est_cost === $best_cost && $d < $best_distance ) ) {
+                    $best_cost = $est_cost;
+                    $best_distance = $d;
+                    $closest = $user->ID;
+                }
+            }
+        }
+        if ( $closest ) {
+            update_post_meta( $order_id, '_zxtec_technician', $closest );
+            $this->auto_schedule_order( $order_id, $closest );
+        }
+    }
+
+    /**
+     * Schedule order if empty date
+     */
+    private function auto_schedule_order( $order_id, $tech_id ) {
+        $current = get_post_meta( $order_id, '_zxtec_date', true );
+        if ( $current ) {
+            return;
+        }
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_key'   => '_zxtec_technician',
+            'meta_value' => $tech_id,
+            'numberposts' => -1,
+            'post_status' => 'publish',
+        ) );
+        $taken = array();
+        foreach ( $orders as $o ) {
+            $d = get_post_meta( $o->ID, '_zxtec_date', true );
+            if ( $d ) {
+                $taken[ $d ] = true;
+            }
+        }
+        $date = strtotime( 'tomorrow' );
+        for ( $i = 0; $i < 30; $i++ ) {
+            $check = date( 'Y-m-d', $date + DAY_IN_SECONDS * $i );
+            if ( empty( $taken[ $check ] ) ) {
+                update_post_meta( $order_id, '_zxtec_date', $check );
+                break;
+            }
+        }
+    }
+
+    /**
+     * Calculate distance between two points using Haversine formula
+     */
+    private function haversine_distance( $lat1, $lon1, $lat2, $lon2 ) {
+        $earth = 6371; // km
+        $dLat = deg2rad( $lat2 - $lat1 );
+        $dLon = deg2rad( $lon2 - $lon1 );
+        $a = sin( $dLat / 2 ) * sin( $dLat / 2 ) + cos( deg2rad( $lat1 ) ) * cos( deg2rad( $lat2 ) ) * sin( $dLon / 2 ) * sin( $dLon / 2 );
+        $c = 2 * atan2( sqrt( $a ), sqrt( 1 - $a ) );
+        return $earth * $c;
+    }
+
+    /**
+     * Download financial CSV for current user
+     */
+    public function download_user_financial_csv() {
+        if ( ! is_user_logged_in() ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        $user_id = get_current_user_id();
+        check_admin_referer( 'zxtec_user_financial_' . $user_id );
+
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_query' => array(
+                array( 'key' => '_zxtec_technician', 'value' => $user_id ),
+                array( 'key' => '_zxtec_status', 'value' => 'concluido' ),
+            ),
+            'numberposts' => -1,
+        ) );
+
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=financeiro_usuario.csv' );
+        $output = fopen( 'php://output', 'w' );
+        fputcsv( $output, array( 'Servico', 'Preco', 'Comissao' ) );
+        foreach ( $orders as $order ) {
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            $commission = $price * $this->get_commission_rate( $user_id );
+            fputcsv( $output, array( $order->post_title, number_format( $price, 2, ',', '' ), number_format( $commission, 2, ',', '' ) ) );
+        }
+        fclose( $output );
+        exit;
+    }
+
+    /**
+     * Download financial PDF for current user
+     */
+    public function download_user_financial_pdf() {
+        if ( ! is_user_logged_in() ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        $user_id = get_current_user_id();
+        check_admin_referer( 'zxtec_user_financial_' . $user_id );
+
+        $orders = get_posts( array(
+            'post_type'  => 'zxtec_order',
+            'meta_query' => array(
+                array( 'key' => '_zxtec_technician', 'value' => $user_id ),
+                array( 'key' => '_zxtec_status', 'value' => 'concluido' ),
+            ),
+            'numberposts' => -1,
+        ) );
+
+        require_once dirname( dirname( __FILE__ ) ) . '/lib/fpdf.php';
+        $pdf = new \FPDF();
+        $pdf->AddPage();
+        $pdf->SetFont( 'Arial', '', 12 );
+        $pdf->Cell( 0, 10, __( 'Relatorio Financeiro', 'zxtec' ), 0, 1 );
+        $total = 0;
+        foreach ( $orders as $order ) {
+            $service_id = get_post_meta( $order->ID, '_zxtec_service', true );
+            $price = floatval( get_post_meta( $service_id, '_zxtec_price', true ) );
+            $commission = $price * $this->get_commission_rate( $user_id );
+            $total += $commission;
+            $line = sprintf( '%s - %s', $order->post_title, number_format_i18n( $commission, 2 ) );
+            $pdf->Cell( 0, 8, $line, 0, 1 );
+        }
+        $pdf->Cell( 0, 10, sprintf( __( 'Total de comissoes: %s', 'zxtec' ), number_format_i18n( $total, 2 ) ), 0, 1 );
+        $expenses = get_posts( array(
+            'post_type'  => 'zxtec_expense',
+            'meta_key'   => '_zxtec_technician',
+            'meta_value' => $user_id,
+            'numberposts' => -1,
+        ) );
+        $expense_total = 0;
+        foreach ( $expenses as $exp ) {
+            $expense_total += floatval( get_post_meta( $exp->ID, '_zxtec_amount', true ) );
+        }
+        if ( $expense_total > 0 ) {
+            $pdf->Cell( 0, 8, sprintf( __( 'Total de despesas: %s', 'zxtec' ), number_format_i18n( $expense_total, 2 ) ), 0, 1 );
+        }
+        $net = $total - $expense_total;
+        $pdf->Cell( 0, 8, sprintf( __( 'Saldo liquido: %s', 'zxtec' ), number_format_i18n( $net, 2 ) ), 0, 1 );
+        $pdf->Output( 'D', 'financeiro_usuario.pdf' );
+        exit;
+    }
+
+    /**
+     * Download filtered history as CSV
+     */
+    public function download_history_csv() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+
+        $tech  = absint( $_GET['tech'] ?? 0 );
+        $start = isset( $_GET['start'] ) ? sanitize_text_field( $_GET['start'] ) : '';
+        $end   = isset( $_GET['end'] ) ? sanitize_text_field( $_GET['end'] ) : '';
+
+        $meta = array( array( 'key' => '_zxtec_status', 'value' => 'concluido' ) );
+        if ( $tech ) {
+            $meta[] = array( 'key' => '_zxtec_technician', 'value' => $tech );
+        }
+        if ( $start ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $start, 'compare' => '>=' );
+        }
+        if ( $end ) {
+            $meta[] = array( 'key' => '_zxtec_date', 'value' => $end, 'compare' => '<=' );
+        }
+
+        $orders = get_posts( array(
+            'post_type'   => 'zxtec_order',
+            'numberposts' => -1,
+            'meta_query'  => $meta,
+        ) );
+
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=historico.csv' );
+        $out = fopen( 'php://output', 'w' );
+        fputcsv( $out, array( 'Ordem', 'Tecnico', 'Data' ) );
+        foreach ( $orders as $order ) {
+            $tech_id = get_post_meta( $order->ID, '_zxtec_technician', true );
+            $user    = $tech_id ? get_userdata( $tech_id ) : null;
+            fputcsv( $out, array( $order->post_title, $user ? $user->display_name : '', get_post_meta( $order->ID, '_zxtec_date', true ) ) );
+        }
+        fclose( $out );
+        exit;
+    }
+
+    /**
+     * Download expenses CSV
+     */
+    public function download_expense_csv() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        ZXTEC_Expense::download_csv();
+        exit;
+    }
+
+    /**
+     * Register plugin settings
+     */
+    public function register_settings() {
+        register_setting( 'zxtec_settings', 'zxtec_commission', array(
+            'type' => 'number',
+            'sanitize_callback' => 'floatval',
+            'default' => 10,
+        ) );
+    }
+
+    /**
+     * Settings page
+     */
+    public function settings_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Configuracoes', 'zxtec' ) . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields( 'zxtec_settings' );
+        echo '<table class="form-table">';
+        echo '<tr><th scope="row">' . esc_html__( 'Percentual de Comissao', 'zxtec' ) . '</th>';
+        echo '<td><input name="zxtec_commission" type="number" step="0.01" value="' . esc_attr( get_option( 'zxtec_commission', 10 ) ) . '" /> %</td></tr>';
+        echo '</table>';
+        submit_button();
+        echo '</form></div>';
+    }
+
+    /**
+     * Get commission rate as decimal
+     */
+    private function get_commission_rate( $user_id = 0 ) {
+        $rate = floatval( get_option( 'zxtec_commission', 10 ) );
+        if ( $user_id ) {
+            $user_rate = get_user_meta( $user_id, 'zxtec_commission', true );
+            if ( $user_rate !== '' && $user_rate !== false ) {
+                $rate = floatval( $user_rate );
+            }
+        }
+        return $rate / 100;
+    }
+
+    /**
+     * Register dashboard widget
+     */
+    public function add_dashboard_widget() {
+        if ( current_user_can( 'manage_options' ) ) {
+            wp_add_dashboard_widget( 'zxtec_overview', __( 'ZX Tec - Visao Geral', 'zxtec' ), array( $this, 'render_dashboard_widget' ) );
+        }
+    }
+
+    /**
+     * Render dashboard widget content
+     */
+    public function render_dashboard_widget() {
+        $pending    = $this->count_orders_by_status( 'pendente' );
+        $confirmed  = $this->count_orders_by_status( 'confirmado' );
+        $completed  = $this->count_orders_by_status( 'concluido' );
+        echo '<ul>';
+        echo '<li>' . esc_html__( 'Pendentes:', 'zxtec' ) . ' ' . intval( $pending ) . '</li>';
+        echo '<li>' . esc_html__( 'Confirmadas:', 'zxtec' ) . ' ' . intval( $confirmed ) . '</li>';
+        echo '<li>' . esc_html__( 'Concluidas:', 'zxtec' ) . ' ' . intval( $completed ) . '</li>';
+        echo '</ul>';
+    }
+
+    /**
+     * Count orders by custom status
+     */
+    private function count_orders_by_status( $status ) {
+        return count( get_posts( array(
+            'post_type'   => 'zxtec_order',
+            'numberposts' => -1,
+            'meta_key'    => '_zxtec_status',
+            'meta_value'  => $status,
+            'post_status' => 'publish',
+        ) ) );
+    }
+
+    /**
+     * Translate internal status codes to human labels
+     */
+    private function human_status( $status ) {
+        switch ( $status ) {
+            case 'pendente':
+                return __( 'A Iniciar', 'zxtec' );
+            case 'confirmado':
+                return __( 'Em execucao', 'zxtec' );
+            case 'recusado':
+                return __( 'Pausado', 'zxtec' );
+            case 'concluido':
+                return __( 'Finalizado', 'zxtec' );
+            default:
+                return $status;
+        }
+    }
+
+    /**
+     * Store a notification for a user
+     */
+    private function add_notification( $user_id, $message ) {
+        $notes   = (array) get_user_meta( $user_id, 'zxtec_notifications', true );
+        $notes[] = array(
+            'message' => sanitize_text_field( $message ),
+            'time'    => current_time( 'mysql' ),
+        );
+        update_user_meta( $user_id, 'zxtec_notifications', $notes );
+    }
+
+    /**
+     * Retrieve notifications for a user
+     */
+    private function get_notifications( $user_id ) {
+        return (array) get_user_meta( $user_id, 'zxtec_notifications', true );
+    }
+
+    /**
+     * Notify all administrators
+     */
+    private function notify_admins( $message ) {
+        $admins = get_users( array( 'role' => 'administrator' ) );
+        foreach ( $admins as $admin ) {
+            $this->add_notification( $admin->ID, $message );
+        }
+    }
+
+    /**
+     * Clear a single notification
+     */
+    public function handle_clear_notification() {
+        if ( ! is_user_logged_in() ) {
+            wp_die( __( 'Acesso negado', 'zxtec' ) );
+        }
+        $user_id = get_current_user_id();
+        check_admin_referer( 'zxtec_clear_note_' . $user_id );
+        $index   = absint( $_GET['n'] ?? -1 );
+        $notes   = (array) get_user_meta( $user_id, 'zxtec_notifications', true );
+        if ( $index >= 0 && isset( $notes[ $index ] ) ) {
+            unset( $notes[ $index ] );
+            update_user_meta( $user_id, 'zxtec_notifications', array_values( $notes ) );
+        }
+        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=zxtec_colaborador_dashboard' ) );
+        exit;
+    }
+}
+

--- a/zxtec-intranet/js/zxtec-admin.js
+++ b/zxtec-intranet/js/zxtec-admin.js
@@ -1,0 +1,43 @@
+(function(){
+    function fetchAddress(cep, fields){
+        cep = cep.replace(/\D/g,'');
+        if(cep.length !== 8) return;
+        fetch('https://viacep.com.br/ws/'+cep+'/json/')
+            .then(function(r){return r.ok?r.json():null;})
+            .then(function(data){
+                if(!data || data.erro) return;
+                if(fields.street) fields.street.value = data.logradouro || '';
+                if(fields.neighborhood) fields.neighborhood.value = data.bairro || '';
+                if(fields.city) fields.city.value = data.localidade || '';
+                if(fields.state) fields.state.value = data.uf || '';
+                if(fields.country && !fields.country.value) fields.country.value = 'Brasil';
+            });
+    }
+
+    function init(){
+        document.querySelectorAll('.zxtec-cep').forEach(function(input){
+            var fields = {};
+            ['street','number','neighborhood','complement','city','state','country'].forEach(function(k){
+                var sel = input.dataset[k];
+                if(sel){
+                    fields[k] = document.querySelector('[name="'+sel+'"]');
+                }
+            });
+            input.addEventListener('blur', function(){
+                fetchAddress(input.value, fields);
+                setTimeout(function(){
+                    var missing = [];
+                    if(fields.number && !fields.number.value) missing.push('n\u00famero');
+                    if(fields.complement && !fields.complement.value) missing.push('complemento');
+                    if(missing.length) alert('Preencha ' + missing.join(' e '));
+                }, 800);
+            });
+        });
+    }
+
+    if(document.readyState !== 'loading'){
+        init();
+    } else {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+})();

--- a/zxtec-intranet/lib/fpdf.php
+++ b/zxtec-intranet/lib/fpdf.php
@@ -1,0 +1,1934 @@
+<?php
+/*******************************************************************************
+* FPDF                                                                         *
+*                                                                              *
+* Version: 1.86                                                                *
+* Date:    2023-06-25                                                          *
+* Author:  Olivier PLATHEY                                                     *
+*******************************************************************************/
+
+class FPDF
+{
+const VERSION = '1.86';
+protected $page;               // current page number
+protected $n;                  // current object number
+protected $offsets;            // array of object offsets
+protected $buffer;             // buffer holding in-memory PDF
+protected $pages;              // array containing pages
+protected $state;              // current document state
+protected $compress;           // compression flag
+protected $iconv;              // whether iconv is available
+protected $k;                  // scale factor (number of points in user unit)
+protected $DefOrientation;     // default orientation
+protected $CurOrientation;     // current orientation
+protected $StdPageSizes;       // standard page sizes
+protected $DefPageSize;        // default page size
+protected $CurPageSize;        // current page size
+protected $CurRotation;        // current page rotation
+protected $PageInfo;           // page-related data
+protected $wPt, $hPt;          // dimensions of current page in points
+protected $w, $h;              // dimensions of current page in user unit
+protected $lMargin;            // left margin
+protected $tMargin;            // top margin
+protected $rMargin;            // right margin
+protected $bMargin;            // page break margin
+protected $cMargin;            // cell margin
+protected $x, $y;              // current position in user unit
+protected $lasth;              // height of last printed cell
+protected $LineWidth;          // line width in user unit
+protected $fontpath;           // directory containing fonts
+protected $CoreFonts;          // array of core font names
+protected $fonts;              // array of used fonts
+protected $FontFiles;          // array of font files
+protected $encodings;          // array of encodings
+protected $cmaps;              // array of ToUnicode CMaps
+protected $FontFamily;         // current font family
+protected $FontStyle;          // current font style
+protected $underline;          // underlining flag
+protected $CurrentFont;        // current font info
+protected $FontSizePt;         // current font size in points
+protected $FontSize;           // current font size in user unit
+protected $DrawColor;          // commands for drawing color
+protected $FillColor;          // commands for filling color
+protected $TextColor;          // commands for text color
+protected $ColorFlag;          // indicates whether fill and text colors are different
+protected $WithAlpha;          // indicates whether alpha channel is used
+protected $ws;                 // word spacing
+protected $images;             // array of used images
+protected $PageLinks;          // array of links in pages
+protected $links;              // array of internal links
+protected $AutoPageBreak;      // automatic page breaking
+protected $PageBreakTrigger;   // threshold used to trigger page breaks
+protected $InHeader;           // flag set when processing header
+protected $InFooter;           // flag set when processing footer
+protected $AliasNbPages;       // alias for total number of pages
+protected $ZoomMode;           // zoom display mode
+protected $LayoutMode;         // layout display mode
+protected $metadata;           // document properties
+protected $CreationDate;       // document creation date
+protected $PDFVersion;         // PDF version number
+
+/*******************************************************************************
+*                               Public methods                                 *
+*******************************************************************************/
+
+function __construct($orientation='P', $unit='mm', $size='A4')
+{
+	// Initialization of properties
+	$this->state = 0;
+	$this->page = 0;
+	$this->n = 2;
+	$this->buffer = '';
+	$this->pages = array();
+	$this->PageInfo = array();
+	$this->fonts = array();
+	$this->FontFiles = array();
+	$this->encodings = array();
+	$this->cmaps = array();
+	$this->images = array();
+	$this->links = array();
+	$this->InHeader = false;
+	$this->InFooter = false;
+	$this->lasth = 0;
+	$this->FontFamily = '';
+	$this->FontStyle = '';
+	$this->FontSizePt = 12;
+	$this->underline = false;
+	$this->DrawColor = '0 G';
+	$this->FillColor = '0 g';
+	$this->TextColor = '0 g';
+	$this->ColorFlag = false;
+	$this->WithAlpha = false;
+	$this->ws = 0;
+	$this->iconv = function_exists('iconv');
+	// Font path
+	if(defined('FPDF_FONTPATH'))
+		$this->fontpath = FPDF_FONTPATH;
+	else
+		$this->fontpath = dirname(__FILE__).'/font/';
+	// Core fonts
+	$this->CoreFonts = array('courier', 'helvetica', 'times', 'symbol', 'zapfdingbats');
+	// Scale factor
+	if($unit=='pt')
+		$this->k = 1;
+	elseif($unit=='mm')
+		$this->k = 72/25.4;
+	elseif($unit=='cm')
+		$this->k = 72/2.54;
+	elseif($unit=='in')
+		$this->k = 72;
+	else
+		$this->Error('Incorrect unit: '.$unit);
+	// Page sizes
+	$this->StdPageSizes = array('a3'=>array(841.89,1190.55), 'a4'=>array(595.28,841.89), 'a5'=>array(420.94,595.28),
+		'letter'=>array(612,792), 'legal'=>array(612,1008));
+	$size = $this->_getpagesize($size);
+	$this->DefPageSize = $size;
+	$this->CurPageSize = $size;
+	// Page orientation
+	$orientation = strtolower($orientation);
+	if($orientation=='p' || $orientation=='portrait')
+	{
+		$this->DefOrientation = 'P';
+		$this->w = $size[0];
+		$this->h = $size[1];
+	}
+	elseif($orientation=='l' || $orientation=='landscape')
+	{
+		$this->DefOrientation = 'L';
+		$this->w = $size[1];
+		$this->h = $size[0];
+	}
+	else
+		$this->Error('Incorrect orientation: '.$orientation);
+	$this->CurOrientation = $this->DefOrientation;
+	$this->wPt = $this->w*$this->k;
+	$this->hPt = $this->h*$this->k;
+	// Page rotation
+	$this->CurRotation = 0;
+	// Page margins (1 cm)
+	$margin = 28.35/$this->k;
+	$this->SetMargins($margin,$margin);
+	// Interior cell margin (1 mm)
+	$this->cMargin = $margin/10;
+	// Line width (0.2 mm)
+	$this->LineWidth = .567/$this->k;
+	// Automatic page break
+	$this->SetAutoPageBreak(true,2*$margin);
+	// Default display mode
+	$this->SetDisplayMode('default');
+	// Enable compression
+	$this->SetCompression(true);
+	// Metadata
+	$this->metadata = array('Producer'=>'FPDF '.self::VERSION);
+	// Set default PDF version number
+	$this->PDFVersion = '1.3';
+}
+
+function SetMargins($left, $top, $right=null)
+{
+	// Set left, top and right margins
+	$this->lMargin = $left;
+	$this->tMargin = $top;
+	if($right===null)
+		$right = $left;
+	$this->rMargin = $right;
+}
+
+function SetLeftMargin($margin)
+{
+	// Set left margin
+	$this->lMargin = $margin;
+	if($this->page>0 && $this->x<$margin)
+		$this->x = $margin;
+}
+
+function SetTopMargin($margin)
+{
+	// Set top margin
+	$this->tMargin = $margin;
+}
+
+function SetRightMargin($margin)
+{
+	// Set right margin
+	$this->rMargin = $margin;
+}
+
+function SetAutoPageBreak($auto, $margin=0)
+{
+	// Set auto page break mode and triggering margin
+	$this->AutoPageBreak = $auto;
+	$this->bMargin = $margin;
+	$this->PageBreakTrigger = $this->h-$margin;
+}
+
+function SetDisplayMode($zoom, $layout='default')
+{
+	// Set display mode in viewer
+	if($zoom=='fullpage' || $zoom=='fullwidth' || $zoom=='real' || $zoom=='default' || !is_string($zoom))
+		$this->ZoomMode = $zoom;
+	else
+		$this->Error('Incorrect zoom display mode: '.$zoom);
+	if($layout=='single' || $layout=='continuous' || $layout=='two' || $layout=='default')
+		$this->LayoutMode = $layout;
+	else
+		$this->Error('Incorrect layout display mode: '.$layout);
+}
+
+function SetCompression($compress)
+{
+	// Set page compression
+	if(function_exists('gzcompress'))
+		$this->compress = $compress;
+	else
+		$this->compress = false;
+}
+
+function SetTitle($title, $isUTF8=false)
+{
+	// Title of document
+	$this->metadata['Title'] = $isUTF8 ? $title : $this->_UTF8encode($title);
+}
+
+function SetAuthor($author, $isUTF8=false)
+{
+	// Author of document
+	$this->metadata['Author'] = $isUTF8 ? $author : $this->_UTF8encode($author);
+}
+
+function SetSubject($subject, $isUTF8=false)
+{
+	// Subject of document
+	$this->metadata['Subject'] = $isUTF8 ? $subject : $this->_UTF8encode($subject);
+}
+
+function SetKeywords($keywords, $isUTF8=false)
+{
+	// Keywords of document
+	$this->metadata['Keywords'] = $isUTF8 ? $keywords : $this->_UTF8encode($keywords);
+}
+
+function SetCreator($creator, $isUTF8=false)
+{
+	// Creator of document
+	$this->metadata['Creator'] = $isUTF8 ? $creator : $this->_UTF8encode($creator);
+}
+
+function AliasNbPages($alias='{nb}')
+{
+	// Define an alias for total number of pages
+	$this->AliasNbPages = $alias;
+}
+
+function Error($msg)
+{
+	// Fatal error
+	throw new Exception('FPDF error: '.$msg);
+}
+
+function Close()
+{
+	// Terminate document
+	if($this->state==3)
+		return;
+	if($this->page==0)
+		$this->AddPage();
+	// Page footer
+	$this->InFooter = true;
+	$this->Footer();
+	$this->InFooter = false;
+	// Close page
+	$this->_endpage();
+	// Close document
+	$this->_enddoc();
+}
+
+function AddPage($orientation='', $size='', $rotation=0)
+{
+	// Start a new page
+	if($this->state==3)
+		$this->Error('The document is closed');
+	$family = $this->FontFamily;
+	$style = $this->FontStyle.($this->underline ? 'U' : '');
+	$fontsize = $this->FontSizePt;
+	$lw = $this->LineWidth;
+	$dc = $this->DrawColor;
+	$fc = $this->FillColor;
+	$tc = $this->TextColor;
+	$cf = $this->ColorFlag;
+	if($this->page>0)
+	{
+		// Page footer
+		$this->InFooter = true;
+		$this->Footer();
+		$this->InFooter = false;
+		// Close page
+		$this->_endpage();
+	}
+	// Start new page
+	$this->_beginpage($orientation,$size,$rotation);
+	// Set line cap style to square
+	$this->_out('2 J');
+	// Set line width
+	$this->LineWidth = $lw;
+	$this->_out(sprintf('%.2F w',$lw*$this->k));
+	// Set font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Set colors
+	$this->DrawColor = $dc;
+	if($dc!='0 G')
+		$this->_out($dc);
+	$this->FillColor = $fc;
+	if($fc!='0 g')
+		$this->_out($fc);
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+	// Page header
+	$this->InHeader = true;
+	$this->Header();
+	$this->InHeader = false;
+	// Restore line width
+	if($this->LineWidth!=$lw)
+	{
+		$this->LineWidth = $lw;
+		$this->_out(sprintf('%.2F w',$lw*$this->k));
+	}
+	// Restore font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Restore colors
+	if($this->DrawColor!=$dc)
+	{
+		$this->DrawColor = $dc;
+		$this->_out($dc);
+	}
+	if($this->FillColor!=$fc)
+	{
+		$this->FillColor = $fc;
+		$this->_out($fc);
+	}
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+}
+
+function Header()
+{
+	// To be implemented in your own inherited class
+}
+
+function Footer()
+{
+	// To be implemented in your own inherited class
+}
+
+function PageNo()
+{
+	// Get current page number
+	return $this->page;
+}
+
+function SetDrawColor($r, $g=null, $b=null)
+{
+	// Set color for all stroking operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->DrawColor = sprintf('%.3F G',$r/255);
+	else
+		$this->DrawColor = sprintf('%.3F %.3F %.3F RG',$r/255,$g/255,$b/255);
+	if($this->page>0)
+		$this->_out($this->DrawColor);
+}
+
+function SetFillColor($r, $g=null, $b=null)
+{
+	// Set color for all filling operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->FillColor = sprintf('%.3F g',$r/255);
+	else
+		$this->FillColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+	if($this->page>0)
+		$this->_out($this->FillColor);
+}
+
+function SetTextColor($r, $g=null, $b=null)
+{
+	// Set color for text
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->TextColor = sprintf('%.3F g',$r/255);
+	else
+		$this->TextColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+}
+
+function GetStringWidth($s)
+{
+	// Get width of a string in the current font
+	$cw = $this->CurrentFont['cw'];
+	$w = 0;
+	$s = (string)$s;
+	$l = strlen($s);
+	for($i=0;$i<$l;$i++)
+		$w += $cw[$s[$i]];
+	return $w*$this->FontSize/1000;
+}
+
+function SetLineWidth($width)
+{
+	// Set line width
+	$this->LineWidth = $width;
+	if($this->page>0)
+		$this->_out(sprintf('%.2F w',$width*$this->k));
+}
+
+function Line($x1, $y1, $x2, $y2)
+{
+	// Draw a line
+	$this->_out(sprintf('%.2F %.2F m %.2F %.2F l S',$x1*$this->k,($this->h-$y1)*$this->k,$x2*$this->k,($this->h-$y2)*$this->k));
+}
+
+function Rect($x, $y, $w, $h, $style='')
+{
+	// Draw a rectangle
+	if($style=='F')
+		$op = 'f';
+	elseif($style=='FD' || $style=='DF')
+		$op = 'B';
+	else
+		$op = 'S';
+	$this->_out(sprintf('%.2F %.2F %.2F %.2F re %s',$x*$this->k,($this->h-$y)*$this->k,$w*$this->k,-$h*$this->k,$op));
+}
+
+function AddFont($family, $style='', $file='', $dir='')
+{
+	// Add a TrueType, OpenType or Type1 font
+	$family = strtolower($family);
+	if($file=='')
+		$file = str_replace(' ','',$family).strtolower($style).'.php';
+	$style = strtoupper($style);
+	if($style=='IB')
+		$style = 'BI';
+	$fontkey = $family.$style;
+	if(isset($this->fonts[$fontkey]))
+		return;
+	if(strpos($file,'/')!==false || strpos($file,"\\")!==false)
+		$this->Error('Incorrect font definition file name: '.$file);
+	if($dir=='')
+		$dir = $this->fontpath;
+	if(substr($dir,-1)!='/' && substr($dir,-1)!='\\')
+		$dir .= '/';
+	$info = $this->_loadfont($dir.$file);
+	$info['i'] = count($this->fonts)+1;
+	if(!empty($info['file']))
+	{
+		// Embedded font
+		$info['file'] = $dir.$info['file'];
+		if($info['type']=='TrueType')
+			$this->FontFiles[$info['file']] = array('length1'=>$info['originalsize']);
+		else
+			$this->FontFiles[$info['file']] = array('length1'=>$info['size1'], 'length2'=>$info['size2']);
+	}
+	$this->fonts[$fontkey] = $info;
+}
+
+function SetFont($family, $style='', $size=0)
+{
+	// Select a font; size given in points
+	if($family=='')
+		$family = $this->FontFamily;
+	else
+		$family = strtolower($family);
+	$style = strtoupper($style);
+	if(strpos($style,'U')!==false)
+	{
+		$this->underline = true;
+		$style = str_replace('U','',$style);
+	}
+	else
+		$this->underline = false;
+	if($style=='IB')
+		$style = 'BI';
+	if($size==0)
+		$size = $this->FontSizePt;
+	// Test if font is already selected
+	if($this->FontFamily==$family && $this->FontStyle==$style && $this->FontSizePt==$size)
+		return;
+	// Test if font is already loaded
+	$fontkey = $family.$style;
+	if(!isset($this->fonts[$fontkey]))
+	{
+		// Test if one of the core fonts
+		if($family=='arial')
+			$family = 'helvetica';
+		if(in_array($family,$this->CoreFonts))
+		{
+			if($family=='symbol' || $family=='zapfdingbats')
+				$style = '';
+			$fontkey = $family.$style;
+			if(!isset($this->fonts[$fontkey]))
+				$this->AddFont($family,$style);
+		}
+		else
+			$this->Error('Undefined font: '.$family.' '.$style);
+	}
+	// Select it
+	$this->FontFamily = $family;
+	$this->FontStyle = $style;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	$this->CurrentFont = $this->fonts[$fontkey];
+	if($this->page>0)
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function SetFontSize($size)
+{
+	// Set font size in points
+	if($this->FontSizePt==$size)
+		return;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	if($this->page>0 && isset($this->CurrentFont))
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function AddLink()
+{
+	// Create a new internal link
+	$n = count($this->links)+1;
+	$this->links[$n] = array(0, 0);
+	return $n;
+}
+
+function SetLink($link, $y=0, $page=-1)
+{
+	// Set destination of internal link
+	if($y==-1)
+		$y = $this->y;
+	if($page==-1)
+		$page = $this->page;
+	$this->links[$link] = array($page, $y);
+}
+
+function Link($x, $y, $w, $h, $link)
+{
+	// Put a link on the page
+	$this->PageLinks[$this->page][] = array($x*$this->k, $this->hPt-$y*$this->k, $w*$this->k, $h*$this->k, $link);
+}
+
+function Text($x, $y, $txt)
+{
+	// Output a string
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$txt = (string)$txt;
+	$s = sprintf('BT %.2F %.2F Td (%s) Tj ET',$x*$this->k,($this->h-$y)*$this->k,$this->_escape($txt));
+	if($this->underline && $txt!=='')
+		$s .= ' '.$this->_dounderline($x,$y,$txt);
+	if($this->ColorFlag)
+		$s = 'q '.$this->TextColor.' '.$s.' Q';
+	$this->_out($s);
+}
+
+function AcceptPageBreak()
+{
+	// Accept automatic page break or not
+	return $this->AutoPageBreak;
+}
+
+function Cell($w, $h=0, $txt='', $border=0, $ln=0, $align='', $fill=false, $link='')
+{
+	// Output a cell
+	$k = $this->k;
+	if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+	{
+		// Automatic page break
+		$x = $this->x;
+		$ws = $this->ws;
+		if($ws>0)
+		{
+			$this->ws = 0;
+			$this->_out('0 Tw');
+		}
+		$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+		$this->x = $x;
+		if($ws>0)
+		{
+			$this->ws = $ws;
+			$this->_out(sprintf('%.3F Tw',$ws*$k));
+		}
+	}
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$s = '';
+	if($fill || $border==1)
+	{
+		if($fill)
+			$op = ($border==1) ? 'B' : 'f';
+		else
+			$op = 'S';
+		$s = sprintf('%.2F %.2F %.2F %.2F re %s ',$this->x*$k,($this->h-$this->y)*$k,$w*$k,-$h*$k,$op);
+	}
+	if(is_string($border))
+	{
+		$x = $this->x;
+		$y = $this->y;
+		if(strpos($border,'L')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,$x*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'T')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-$y)*$k);
+		if(strpos($border,'R')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',($x+$w)*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'B')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-($y+$h))*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+	}
+	$txt = (string)$txt;
+	if($txt!=='')
+	{
+		if(!isset($this->CurrentFont))
+			$this->Error('No font has been set');
+		if($align=='R')
+			$dx = $w-$this->cMargin-$this->GetStringWidth($txt);
+		elseif($align=='C')
+			$dx = ($w-$this->GetStringWidth($txt))/2;
+		else
+			$dx = $this->cMargin;
+		if($this->ColorFlag)
+			$s .= 'q '.$this->TextColor.' ';
+		$s .= sprintf('BT %.2F %.2F Td (%s) Tj ET',($this->x+$dx)*$k,($this->h-($this->y+.5*$h+.3*$this->FontSize))*$k,$this->_escape($txt));
+		if($this->underline)
+			$s .= ' '.$this->_dounderline($this->x+$dx,$this->y+.5*$h+.3*$this->FontSize,$txt);
+		if($this->ColorFlag)
+			$s .= ' Q';
+		if($link)
+			$this->Link($this->x+$dx,$this->y+.5*$h-.5*$this->FontSize,$this->GetStringWidth($txt),$this->FontSize,$link);
+	}
+	if($s)
+		$this->_out($s);
+	$this->lasth = $h;
+	if($ln>0)
+	{
+		// Go to next line
+		$this->y += $h;
+		if($ln==1)
+			$this->x = $this->lMargin;
+	}
+	else
+		$this->x += $w;
+}
+
+function MultiCell($w, $h, $txt, $border=0, $align='J', $fill=false)
+{
+	// Output text with automatic or explicit line breaks
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	if($nb>0 && $s[$nb-1]=="\n")
+		$nb--;
+	$b = 0;
+	if($border)
+	{
+		if($border==1)
+		{
+			$border = 'LTRB';
+			$b = 'LRT';
+			$b2 = 'LR';
+		}
+		else
+		{
+			$b2 = '';
+			if(strpos($border,'L')!==false)
+				$b2 .= 'L';
+			if(strpos($border,'R')!==false)
+				$b2 .= 'R';
+			$b = (strpos($border,'T')!==false) ? $b2.'T' : $b2;
+		}
+	}
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$ns = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			if($this->ws>0)
+			{
+				$this->ws = 0;
+				$this->_out('0 Tw');
+			}
+			$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+			continue;
+		}
+		if($c==' ')
+		{
+			$sep = $i;
+			$ls = $l;
+			$ns++;
+		}
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($i==$j)
+					$i++;
+				if($this->ws>0)
+				{
+					$this->ws = 0;
+					$this->_out('0 Tw');
+				}
+				$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			}
+			else
+			{
+				if($align=='J')
+				{
+					$this->ws = ($ns>1) ? ($wmax-$ls)/1000*$this->FontSize/($ns-1) : 0;
+					$this->_out(sprintf('%.3F Tw',$this->ws*$this->k));
+				}
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),$b,2,$align,$fill);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($this->ws>0)
+	{
+		$this->ws = 0;
+		$this->_out('0 Tw');
+	}
+	if($border && strpos($border,'B')!==false)
+		$b .= 'B';
+	$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+	$this->x = $this->lMargin;
+}
+
+function Write($h, $txt, $link='')
+{
+	// Output text in flowing mode
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+			continue;
+		}
+		if($c==' ')
+			$sep = $i;
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($this->x>$this->lMargin)
+				{
+					// Move to next line
+					$this->x = $this->lMargin;
+					$this->y += $h;
+					$w = $this->w-$this->rMargin-$this->x;
+					$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+					$i++;
+					$nl++;
+					continue;
+				}
+				if($i==$j)
+					$i++;
+				$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			}
+			else
+			{
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),0,2,'',false,$link);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($i!=$j)
+		$this->Cell($l/1000*$this->FontSize,$h,substr($s,$j),0,0,'',false,$link);
+}
+
+function Ln($h=null)
+{
+	// Line feed; default value is the last cell height
+	$this->x = $this->lMargin;
+	if($h===null)
+		$this->y += $this->lasth;
+	else
+		$this->y += $h;
+}
+
+function Image($file, $x=null, $y=null, $w=0, $h=0, $type='', $link='')
+{
+	// Put an image on the page
+	if($file=='')
+		$this->Error('Image file name is empty');
+	if(!isset($this->images[$file]))
+	{
+		// First use of this image, get info
+		if($type=='')
+		{
+			$pos = strrpos($file,'.');
+			if(!$pos)
+				$this->Error('Image file has no extension and no type was specified: '.$file);
+			$type = substr($file,$pos+1);
+		}
+		$type = strtolower($type);
+		if($type=='jpeg')
+			$type = 'jpg';
+		$mtd = '_parse'.$type;
+		if(!method_exists($this,$mtd))
+			$this->Error('Unsupported image type: '.$type);
+		$info = $this->$mtd($file);
+		$info['i'] = count($this->images)+1;
+		$this->images[$file] = $info;
+	}
+	else
+		$info = $this->images[$file];
+
+	// Automatic width and height calculation if needed
+	if($w==0 && $h==0)
+	{
+		// Put image at 96 dpi
+		$w = -96;
+		$h = -96;
+	}
+	if($w<0)
+		$w = -$info['w']*72/$w/$this->k;
+	if($h<0)
+		$h = -$info['h']*72/$h/$this->k;
+	if($w==0)
+		$w = $h*$info['w']/$info['h'];
+	if($h==0)
+		$h = $w*$info['h']/$info['w'];
+
+	// Flowing mode
+	if($y===null)
+	{
+		if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+		{
+			// Automatic page break
+			$x2 = $this->x;
+			$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+			$this->x = $x2;
+		}
+		$y = $this->y;
+		$this->y += $h;
+	}
+
+	if($x===null)
+		$x = $this->x;
+	$this->_out(sprintf('q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q',$w*$this->k,$h*$this->k,$x*$this->k,($this->h-($y+$h))*$this->k,$info['i']));
+	if($link)
+		$this->Link($x,$y,$w,$h,$link);
+}
+
+function GetPageWidth()
+{
+	// Get current page width
+	return $this->w;
+}
+
+function GetPageHeight()
+{
+	// Get current page height
+	return $this->h;
+}
+
+function GetX()
+{
+	// Get x position
+	return $this->x;
+}
+
+function SetX($x)
+{
+	// Set x position
+	if($x>=0)
+		$this->x = $x;
+	else
+		$this->x = $this->w+$x;
+}
+
+function GetY()
+{
+	// Get y position
+	return $this->y;
+}
+
+function SetY($y, $resetX=true)
+{
+	// Set y position and optionally reset x
+	if($y>=0)
+		$this->y = $y;
+	else
+		$this->y = $this->h+$y;
+	if($resetX)
+		$this->x = $this->lMargin;
+}
+
+function SetXY($x, $y)
+{
+	// Set x and y positions
+	$this->SetX($x);
+	$this->SetY($y,false);
+}
+
+function Output($dest='', $name='', $isUTF8=false)
+{
+	// Output PDF to some destination
+	$this->Close();
+	if(strlen($name)==1 && strlen($dest)!=1)
+	{
+		// Fix parameter order
+		$tmp = $dest;
+		$dest = $name;
+		$name = $tmp;
+	}
+	if($dest=='')
+		$dest = 'I';
+	if($name=='')
+		$name = 'doc.pdf';
+	switch(strtoupper($dest))
+	{
+		case 'I':
+			// Send to standard output
+			$this->_checkoutput();
+			if(PHP_SAPI!='cli')
+			{
+				// We send to a browser
+				header('Content-Type: application/pdf');
+				header('Content-Disposition: inline; '.$this->_httpencode('filename',$name,$isUTF8));
+				header('Cache-Control: private, max-age=0, must-revalidate');
+				header('Pragma: public');
+			}
+			echo $this->buffer;
+			break;
+		case 'D':
+			// Download file
+			$this->_checkoutput();
+			header('Content-Type: application/pdf');
+			header('Content-Disposition: attachment; '.$this->_httpencode('filename',$name,$isUTF8));
+			header('Cache-Control: private, max-age=0, must-revalidate');
+			header('Pragma: public');
+			echo $this->buffer;
+			break;
+		case 'F':
+			// Save to local file
+			if(!file_put_contents($name,$this->buffer))
+				$this->Error('Unable to create output file: '.$name);
+			break;
+		case 'S':
+			// Return as a string
+			return $this->buffer;
+		default:
+			$this->Error('Incorrect output destination: '.$dest);
+	}
+	return '';
+}
+
+/*******************************************************************************
+*                              Protected methods                               *
+*******************************************************************************/
+
+protected function _checkoutput()
+{
+	if(PHP_SAPI!='cli')
+	{
+		if(headers_sent($file,$line))
+			$this->Error("Some data has already been output, can't send PDF file (output started at $file:$line)");
+	}
+	if(ob_get_length())
+	{
+		// The output buffer is not empty
+		if(preg_match('/^(\xEF\xBB\xBF)?\s*$/',ob_get_contents()))
+		{
+			// It contains only a UTF-8 BOM and/or whitespace, let's clean it
+			ob_clean();
+		}
+		else
+			$this->Error("Some data has already been output, can't send PDF file");
+	}
+}
+
+protected function _getpagesize($size)
+{
+	if(is_string($size))
+	{
+		$size = strtolower($size);
+		if(!isset($this->StdPageSizes[$size]))
+			$this->Error('Unknown page size: '.$size);
+		$a = $this->StdPageSizes[$size];
+		return array($a[0]/$this->k, $a[1]/$this->k);
+	}
+	else
+	{
+		if($size[0]>$size[1])
+			return array($size[1], $size[0]);
+		else
+			return $size;
+	}
+}
+
+protected function _beginpage($orientation, $size, $rotation)
+{
+	$this->page++;
+	$this->pages[$this->page] = '';
+	$this->PageLinks[$this->page] = array();
+	$this->state = 2;
+	$this->x = $this->lMargin;
+	$this->y = $this->tMargin;
+	$this->FontFamily = '';
+	// Check page size and orientation
+	if($orientation=='')
+		$orientation = $this->DefOrientation;
+	else
+		$orientation = strtoupper($orientation[0]);
+	if($size=='')
+		$size = $this->DefPageSize;
+	else
+		$size = $this->_getpagesize($size);
+	if($orientation!=$this->CurOrientation || $size[0]!=$this->CurPageSize[0] || $size[1]!=$this->CurPageSize[1])
+	{
+		// New size or orientation
+		if($orientation=='P')
+		{
+			$this->w = $size[0];
+			$this->h = $size[1];
+		}
+		else
+		{
+			$this->w = $size[1];
+			$this->h = $size[0];
+		}
+		$this->wPt = $this->w*$this->k;
+		$this->hPt = $this->h*$this->k;
+		$this->PageBreakTrigger = $this->h-$this->bMargin;
+		$this->CurOrientation = $orientation;
+		$this->CurPageSize = $size;
+	}
+	if($orientation!=$this->DefOrientation || $size[0]!=$this->DefPageSize[0] || $size[1]!=$this->DefPageSize[1])
+		$this->PageInfo[$this->page]['size'] = array($this->wPt, $this->hPt);
+	if($rotation!=0)
+	{
+		if($rotation%90!=0)
+			$this->Error('Incorrect rotation value: '.$rotation);
+		$this->PageInfo[$this->page]['rotation'] = $rotation;
+	}
+	$this->CurRotation = $rotation;
+}
+
+protected function _endpage()
+{
+	$this->state = 1;
+}
+
+protected function _loadfont($path)
+{
+	// Load a font definition file
+	include($path);
+	if(!isset($name))
+		$this->Error('Could not include font definition file: '.$path);
+	if(isset($enc))
+		$enc = strtolower($enc);
+	if(!isset($subsetted))
+		$subsetted = false;
+	return get_defined_vars();
+}
+
+protected function _isascii($s)
+{
+	// Test if string is ASCII
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		if(ord($s[$i])>127)
+			return false;
+	}
+	return true;
+}
+
+protected function _httpencode($param, $value, $isUTF8)
+{
+	// Encode HTTP header field parameter
+	if($this->_isascii($value))
+		return $param.'="'.$value.'"';
+	if(!$isUTF8)
+		$value = $this->_UTF8encode($value);
+	return $param."*=UTF-8''".rawurlencode($value);
+}
+
+protected function _UTF8encode($s)
+{
+	// Convert ISO-8859-1 to UTF-8
+	if($this->iconv)
+		return iconv('ISO-8859-1','UTF-8',$s);
+	$res = '';
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		$c = $s[$i];
+		$v = ord($c);
+		if($v>=128)
+		{
+			$res .= chr(0xC0 | ($v >> 6));
+			$res .= chr(0x80 | ($v & 0x3F));
+		}
+		else
+			$res .= $c;
+	}
+	return $res;
+}
+
+protected function _UTF8toUTF16($s)
+{
+	// Convert UTF-8 to UTF-16BE with BOM
+	$res = "\xFE\xFF";
+	if($this->iconv)
+		return $res.iconv('UTF-8','UTF-16BE',$s);
+	$nb = strlen($s);
+	$i = 0;
+	while($i<$nb)
+	{
+		$c1 = ord($s[$i++]);
+		if($c1>=224)
+		{
+			// 3-byte character
+			$c2 = ord($s[$i++]);
+			$c3 = ord($s[$i++]);
+			$res .= chr((($c1 & 0x0F)<<4) + (($c2 & 0x3C)>>2));
+			$res .= chr((($c2 & 0x03)<<6) + ($c3 & 0x3F));
+		}
+		elseif($c1>=192)
+		{
+			// 2-byte character
+			$c2 = ord($s[$i++]);
+			$res .= chr(($c1 & 0x1C)>>2);
+			$res .= chr((($c1 & 0x03)<<6) + ($c2 & 0x3F));
+		}
+		else
+		{
+			// Single-byte character
+			$res .= "\0".chr($c1);
+		}
+	}
+	return $res;
+}
+
+protected function _escape($s)
+{
+	// Escape special characters
+	if(strpos($s,'(')!==false || strpos($s,')')!==false || strpos($s,'\\')!==false || strpos($s,"\r")!==false)
+		return str_replace(array('\\','(',')',"\r"), array('\\\\','\\(','\\)','\\r'), $s);
+	else
+		return $s;
+}
+
+protected function _textstring($s)
+{
+	// Format a text string
+	if(!$this->_isascii($s))
+		$s = $this->_UTF8toUTF16($s);
+	return '('.$this->_escape($s).')';
+}
+
+protected function _dounderline($x, $y, $txt)
+{
+	// Underline text
+	$up = $this->CurrentFont['up'];
+	$ut = $this->CurrentFont['ut'];
+	$w = $this->GetStringWidth($txt)+$this->ws*substr_count($txt,' ');
+	return sprintf('%.2F %.2F %.2F %.2F re f',$x*$this->k,($this->h-($y-$up/1000*$this->FontSize))*$this->k,$w*$this->k,-$ut/1000*$this->FontSizePt);
+}
+
+protected function _parsejpg($file)
+{
+	// Extract info from a JPEG file
+	$a = getimagesize($file);
+	if(!$a)
+		$this->Error('Missing or incorrect image file: '.$file);
+	if($a[2]!=2)
+		$this->Error('Not a JPEG file: '.$file);
+	if(!isset($a['channels']) || $a['channels']==3)
+		$colspace = 'DeviceRGB';
+	elseif($a['channels']==4)
+		$colspace = 'DeviceCMYK';
+	else
+		$colspace = 'DeviceGray';
+	$bpc = isset($a['bits']) ? $a['bits'] : 8;
+	$data = file_get_contents($file);
+	return array('w'=>$a[0], 'h'=>$a[1], 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'DCTDecode', 'data'=>$data);
+}
+
+protected function _parsepng($file)
+{
+	// Extract info from a PNG file
+	$f = fopen($file,'rb');
+	if(!$f)
+		$this->Error('Can\'t open image file: '.$file);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _parsepngstream($f, $file)
+{
+	// Check signature
+	if($this->_readstream($f,8)!=chr(137).'PNG'.chr(13).chr(10).chr(26).chr(10))
+		$this->Error('Not a PNG file: '.$file);
+
+	// Read header chunk
+	$this->_readstream($f,4);
+	if($this->_readstream($f,4)!='IHDR')
+		$this->Error('Incorrect PNG file: '.$file);
+	$w = $this->_readint($f);
+	$h = $this->_readint($f);
+	$bpc = ord($this->_readstream($f,1));
+	if($bpc>8)
+		$this->Error('16-bit depth not supported: '.$file);
+	$ct = ord($this->_readstream($f,1));
+	if($ct==0 || $ct==4)
+		$colspace = 'DeviceGray';
+	elseif($ct==2 || $ct==6)
+		$colspace = 'DeviceRGB';
+	elseif($ct==3)
+		$colspace = 'Indexed';
+	else
+		$this->Error('Unknown color type: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown compression method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown filter method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Interlacing not supported: '.$file);
+	$this->_readstream($f,4);
+	$dp = '/Predictor 15 /Colors '.($colspace=='DeviceRGB' ? 3 : 1).' /BitsPerComponent '.$bpc.' /Columns '.$w;
+
+	// Scan chunks looking for palette, transparency and image data
+	$pal = '';
+	$trns = '';
+	$data = '';
+	do
+	{
+		$n = $this->_readint($f);
+		$type = $this->_readstream($f,4);
+		if($type=='PLTE')
+		{
+			// Read palette
+			$pal = $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='tRNS')
+		{
+			// Read transparency info
+			$t = $this->_readstream($f,$n);
+			if($ct==0)
+				$trns = array(ord(substr($t,1,1)));
+			elseif($ct==2)
+				$trns = array(ord(substr($t,1,1)), ord(substr($t,3,1)), ord(substr($t,5,1)));
+			else
+			{
+				$pos = strpos($t,chr(0));
+				if($pos!==false)
+					$trns = array($pos);
+			}
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IDAT')
+		{
+			// Read image data block
+			$data .= $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IEND')
+			break;
+		else
+			$this->_readstream($f,$n+4);
+	}
+	while($n);
+
+	if($colspace=='Indexed' && empty($pal))
+		$this->Error('Missing palette in '.$file);
+	$info = array('w'=>$w, 'h'=>$h, 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'FlateDecode', 'dp'=>$dp, 'pal'=>$pal, 'trns'=>$trns);
+	if($ct>=4)
+	{
+		// Extract alpha channel
+		if(!function_exists('gzuncompress'))
+			$this->Error('Zlib not available, can\'t handle alpha channel: '.$file);
+		$data = gzuncompress($data);
+		$color = '';
+		$alpha = '';
+		if($ct==4)
+		{
+			// Gray image
+			$len = 2*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.)./s','$1',$line);
+				$alpha .= preg_replace('/.(.)/s','$1',$line);
+			}
+		}
+		else
+		{
+			// RGB image
+			$len = 4*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.{3})./s','$1',$line);
+				$alpha .= preg_replace('/.{3}(.)/s','$1',$line);
+			}
+		}
+		unset($data);
+		$data = gzcompress($color);
+		$info['smask'] = gzcompress($alpha);
+		$this->WithAlpha = true;
+		if($this->PDFVersion<'1.4')
+			$this->PDFVersion = '1.4';
+	}
+	$info['data'] = $data;
+	return $info;
+}
+
+protected function _readstream($f, $n)
+{
+	// Read n bytes from stream
+	$res = '';
+	while($n>0 && !feof($f))
+	{
+		$s = fread($f,$n);
+		if($s===false)
+			$this->Error('Error while reading stream');
+		$n -= strlen($s);
+		$res .= $s;
+	}
+	if($n>0)
+		$this->Error('Unexpected end of stream');
+	return $res;
+}
+
+protected function _readint($f)
+{
+	// Read a 4-byte integer from stream
+	$a = unpack('Ni',$this->_readstream($f,4));
+	return $a['i'];
+}
+
+protected function _parsegif($file)
+{
+	// Extract info from a GIF file (via PNG conversion)
+	if(!function_exists('imagepng'))
+		$this->Error('GD extension is required for GIF support');
+	if(!function_exists('imagecreatefromgif'))
+		$this->Error('GD has no GIF read support');
+	$im = imagecreatefromgif($file);
+	if(!$im)
+		$this->Error('Missing or incorrect image file: '.$file);
+	imageinterlace($im,0);
+	ob_start();
+	imagepng($im);
+	$data = ob_get_clean();
+	imagedestroy($im);
+	$f = fopen('php://temp','rb+');
+	if(!$f)
+		$this->Error('Unable to create memory stream');
+	fwrite($f,$data);
+	rewind($f);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _out($s)
+{
+	// Add a line to the current page
+	if($this->state==2)
+		$this->pages[$this->page] .= $s."\n";
+	elseif($this->state==0)
+		$this->Error('No page has been added yet');
+	elseif($this->state==1)
+		$this->Error('Invalid call');
+	elseif($this->state==3)
+		$this->Error('The document is closed');
+}
+
+protected function _put($s)
+{
+	// Add a line to the document
+	$this->buffer .= $s."\n";
+}
+
+protected function _getoffset()
+{
+	return strlen($this->buffer);
+}
+
+protected function _newobj($n=null)
+{
+	// Begin a new object
+	if($n===null)
+		$n = ++$this->n;
+	$this->offsets[$n] = $this->_getoffset();
+	$this->_put($n.' 0 obj');
+}
+
+protected function _putstream($data)
+{
+	$this->_put('stream');
+	$this->_put($data);
+	$this->_put('endstream');
+}
+
+protected function _putstreamobject($data)
+{
+	if($this->compress)
+	{
+		$entries = '/Filter /FlateDecode ';
+		$data = gzcompress($data);
+	}
+	else
+		$entries = '';
+	$entries .= '/Length '.strlen($data);
+	$this->_newobj();
+	$this->_put('<<'.$entries.'>>');
+	$this->_putstream($data);
+	$this->_put('endobj');
+}
+
+protected function _putlinks($n)
+{
+	foreach($this->PageLinks[$n] as $pl)
+	{
+		$this->_newobj();
+		$rect = sprintf('%.2F %.2F %.2F %.2F',$pl[0],$pl[1],$pl[0]+$pl[2],$pl[1]-$pl[3]);
+		$s = '<</Type /Annot /Subtype /Link /Rect ['.$rect.'] /Border [0 0 0] ';
+		if(is_string($pl[4]))
+			$s .= '/A <</S /URI /URI '.$this->_textstring($pl[4]).'>>>>';
+		else
+		{
+			$l = $this->links[$pl[4]];
+			if(isset($this->PageInfo[$l[0]]['size']))
+				$h = $this->PageInfo[$l[0]]['size'][1];
+			else
+				$h = ($this->DefOrientation=='P') ? $this->DefPageSize[1]*$this->k : $this->DefPageSize[0]*$this->k;
+			$s .= sprintf('/Dest [%d 0 R /XYZ 0 %.2F null]>>',$this->PageInfo[$l[0]]['n'],$h-$l[1]*$this->k);
+		}
+		$this->_put($s);
+		$this->_put('endobj');
+	}
+}
+
+protected function _putpage($n)
+{
+	$this->_newobj();
+	$this->_put('<</Type /Page');
+	$this->_put('/Parent 1 0 R');
+	if(isset($this->PageInfo[$n]['size']))
+		$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$this->PageInfo[$n]['size'][0],$this->PageInfo[$n]['size'][1]));
+	if(isset($this->PageInfo[$n]['rotation']))
+		$this->_put('/Rotate '.$this->PageInfo[$n]['rotation']);
+	$this->_put('/Resources 2 0 R');
+	if(!empty($this->PageLinks[$n]))
+	{
+		$s = '/Annots [';
+		foreach($this->PageLinks[$n] as $pl)
+			$s .= $pl[5].' 0 R ';
+		$s .= ']';
+		$this->_put($s);
+	}
+	if($this->WithAlpha)
+		$this->_put('/Group <</Type /Group /S /Transparency /CS /DeviceRGB>>');
+	$this->_put('/Contents '.($this->n+1).' 0 R>>');
+	$this->_put('endobj');
+	// Page content
+	if(!empty($this->AliasNbPages))
+		$this->pages[$n] = str_replace($this->AliasNbPages,$this->page,$this->pages[$n]);
+	$this->_putstreamobject($this->pages[$n]);
+	// Link annotations
+	$this->_putlinks($n);
+}
+
+protected function _putpages()
+{
+	$nb = $this->page;
+	$n = $this->n;
+	for($i=1;$i<=$nb;$i++)
+	{
+		$this->PageInfo[$i]['n'] = ++$n;
+		$n++;
+		foreach($this->PageLinks[$i] as &$pl)
+			$pl[5] = ++$n;
+		unset($pl);
+	}
+	for($i=1;$i<=$nb;$i++)
+		$this->_putpage($i);
+	// Pages root
+	$this->_newobj(1);
+	$this->_put('<</Type /Pages');
+	$kids = '/Kids [';
+	for($i=1;$i<=$nb;$i++)
+		$kids .= $this->PageInfo[$i]['n'].' 0 R ';
+	$kids .= ']';
+	$this->_put($kids);
+	$this->_put('/Count '.$nb);
+	if($this->DefOrientation=='P')
+	{
+		$w = $this->DefPageSize[0];
+		$h = $this->DefPageSize[1];
+	}
+	else
+	{
+		$w = $this->DefPageSize[1];
+		$h = $this->DefPageSize[0];
+	}
+	$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$w*$this->k,$h*$this->k));
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putfonts()
+{
+	foreach($this->FontFiles as $file=>$info)
+	{
+		// Font file embedding
+		$this->_newobj();
+		$this->FontFiles[$file]['n'] = $this->n;
+		$font = file_get_contents($file);
+		if(!$font)
+			$this->Error('Font file not found: '.$file);
+		$compressed = (substr($file,-2)=='.z');
+		if(!$compressed && isset($info['length2']))
+			$font = substr($font,6,$info['length1']).substr($font,6+$info['length1']+6,$info['length2']);
+		$this->_put('<</Length '.strlen($font));
+		if($compressed)
+			$this->_put('/Filter /FlateDecode');
+		$this->_put('/Length1 '.$info['length1']);
+		if(isset($info['length2']))
+			$this->_put('/Length2 '.$info['length2'].' /Length3 0');
+		$this->_put('>>');
+		$this->_putstream($font);
+		$this->_put('endobj');
+	}
+	foreach($this->fonts as $k=>$font)
+	{
+		// Encoding
+		if(isset($font['diff']))
+		{
+			if(!isset($this->encodings[$font['enc']]))
+			{
+				$this->_newobj();
+				$this->_put('<</Type /Encoding /BaseEncoding /WinAnsiEncoding /Differences ['.$font['diff'].']>>');
+				$this->_put('endobj');
+				$this->encodings[$font['enc']] = $this->n;
+			}
+		}
+		// ToUnicode CMap
+		if(isset($font['uv']))
+		{
+			if(isset($font['enc']))
+				$cmapkey = $font['enc'];
+			else
+				$cmapkey = $font['name'];
+			if(!isset($this->cmaps[$cmapkey]))
+			{
+				$cmap = $this->_tounicodecmap($font['uv']);
+				$this->_putstreamobject($cmap);
+				$this->cmaps[$cmapkey] = $this->n;
+			}
+		}
+		// Font object
+		$this->fonts[$k]['n'] = $this->n+1;
+		$type = $font['type'];
+		$name = $font['name'];
+		if($font['subsetted'])
+			$name = 'AAAAAA+'.$name;
+		if($type=='Core')
+		{
+			// Core font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /Type1');
+			if($name!='Symbol' && $name!='ZapfDingbats')
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+		}
+		elseif($type=='Type1' || $type=='TrueType')
+		{
+			// Additional Type1 or TrueType/OpenType font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /'.$type);
+			$this->_put('/FirstChar 32 /LastChar 255');
+			$this->_put('/Widths '.($this->n+1).' 0 R');
+			$this->_put('/FontDescriptor '.($this->n+2).' 0 R');
+			if(isset($font['diff']))
+				$this->_put('/Encoding '.$this->encodings[$font['enc']].' 0 R');
+			else
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+			// Widths
+			$this->_newobj();
+			$cw = $font['cw'];
+			$s = '[';
+			for($i=32;$i<=255;$i++)
+				$s .= $cw[chr($i)].' ';
+			$this->_put($s.']');
+			$this->_put('endobj');
+			// Descriptor
+			$this->_newobj();
+			$s = '<</Type /FontDescriptor /FontName /'.$name;
+			foreach($font['desc'] as $k=>$v)
+				$s .= ' /'.$k.' '.$v;
+			if(!empty($font['file']))
+				$s .= ' /FontFile'.($type=='Type1' ? '' : '2').' '.$this->FontFiles[$font['file']]['n'].' 0 R';
+			$this->_put($s.'>>');
+			$this->_put('endobj');
+		}
+		else
+		{
+			// Allow for additional types
+			$mtd = '_put'.strtolower($type);
+			if(!method_exists($this,$mtd))
+				$this->Error('Unsupported font type: '.$type);
+			$this->$mtd($font);
+		}
+	}
+}
+
+protected function _tounicodecmap($uv)
+{
+	$ranges = '';
+	$nbr = 0;
+	$chars = '';
+	$nbc = 0;
+	foreach($uv as $c=>$v)
+	{
+		if(is_array($v))
+		{
+			$ranges .= sprintf("<%02X> <%02X> <%04X>\n",$c,$c+$v[1]-1,$v[0]);
+			$nbr++;
+		}
+		else
+		{
+			$chars .= sprintf("<%02X> <%04X>\n",$c,$v);
+			$nbc++;
+		}
+	}
+	$s = "/CIDInit /ProcSet findresource begin\n";
+	$s .= "12 dict begin\n";
+	$s .= "begincmap\n";
+	$s .= "/CIDSystemInfo\n";
+	$s .= "<</Registry (Adobe)\n";
+	$s .= "/Ordering (UCS)\n";
+	$s .= "/Supplement 0\n";
+	$s .= ">> def\n";
+	$s .= "/CMapName /Adobe-Identity-UCS def\n";
+	$s .= "/CMapType 2 def\n";
+	$s .= "1 begincodespacerange\n";
+	$s .= "<00> <FF>\n";
+	$s .= "endcodespacerange\n";
+	if($nbr>0)
+	{
+		$s .= "$nbr beginbfrange\n";
+		$s .= $ranges;
+		$s .= "endbfrange\n";
+	}
+	if($nbc>0)
+	{
+		$s .= "$nbc beginbfchar\n";
+		$s .= $chars;
+		$s .= "endbfchar\n";
+	}
+	$s .= "endcmap\n";
+	$s .= "CMapName currentdict /CMap defineresource pop\n";
+	$s .= "end\n";
+	$s .= "end";
+	return $s;
+}
+
+protected function _putimages()
+{
+	foreach(array_keys($this->images) as $file)
+	{
+		$this->_putimage($this->images[$file]);
+		unset($this->images[$file]['data']);
+		unset($this->images[$file]['smask']);
+	}
+}
+
+protected function _putimage(&$info)
+{
+	$this->_newobj();
+	$info['n'] = $this->n;
+	$this->_put('<</Type /XObject');
+	$this->_put('/Subtype /Image');
+	$this->_put('/Width '.$info['w']);
+	$this->_put('/Height '.$info['h']);
+	if($info['cs']=='Indexed')
+		$this->_put('/ColorSpace [/Indexed /DeviceRGB '.(strlen($info['pal'])/3-1).' '.($this->n+1).' 0 R]');
+	else
+	{
+		$this->_put('/ColorSpace /'.$info['cs']);
+		if($info['cs']=='DeviceCMYK')
+			$this->_put('/Decode [1 0 1 0 1 0 1 0]');
+	}
+	$this->_put('/BitsPerComponent '.$info['bpc']);
+	if(isset($info['f']))
+		$this->_put('/Filter /'.$info['f']);
+	if(isset($info['dp']))
+		$this->_put('/DecodeParms <<'.$info['dp'].'>>');
+	if(isset($info['trns']) && is_array($info['trns']))
+	{
+		$trns = '';
+		for($i=0;$i<count($info['trns']);$i++)
+			$trns .= $info['trns'][$i].' '.$info['trns'][$i].' ';
+		$this->_put('/Mask ['.$trns.']');
+	}
+	if(isset($info['smask']))
+		$this->_put('/SMask '.($this->n+1).' 0 R');
+	$this->_put('/Length '.strlen($info['data']).'>>');
+	$this->_putstream($info['data']);
+	$this->_put('endobj');
+	// Soft mask
+	if(isset($info['smask']))
+	{
+		$dp = '/Predictor 15 /Colors 1 /BitsPerComponent 8 /Columns '.$info['w'];
+		$smask = array('w'=>$info['w'], 'h'=>$info['h'], 'cs'=>'DeviceGray', 'bpc'=>8, 'f'=>$info['f'], 'dp'=>$dp, 'data'=>$info['smask']);
+		$this->_putimage($smask);
+	}
+	// Palette
+	if($info['cs']=='Indexed')
+		$this->_putstreamobject($info['pal']);
+}
+
+protected function _putxobjectdict()
+{
+	foreach($this->images as $image)
+		$this->_put('/I'.$image['i'].' '.$image['n'].' 0 R');
+}
+
+protected function _putresourcedict()
+{
+	$this->_put('/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
+	$this->_put('/Font <<');
+	foreach($this->fonts as $font)
+		$this->_put('/F'.$font['i'].' '.$font['n'].' 0 R');
+	$this->_put('>>');
+	$this->_put('/XObject <<');
+	$this->_putxobjectdict();
+	$this->_put('>>');
+}
+
+protected function _putresources()
+{
+	$this->_putfonts();
+	$this->_putimages();
+	// Resource dictionary
+	$this->_newobj(2);
+	$this->_put('<<');
+	$this->_putresourcedict();
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putinfo()
+{
+	$date = @date('YmdHisO',$this->CreationDate);
+	$this->metadata['CreationDate'] = 'D:'.substr($date,0,-2)."'".substr($date,-2)."'";
+	foreach($this->metadata as $key=>$value)
+		$this->_put('/'.$key.' '.$this->_textstring($value));
+}
+
+protected function _putcatalog()
+{
+	$n = $this->PageInfo[1]['n'];
+	$this->_put('/Type /Catalog');
+	$this->_put('/Pages 1 0 R');
+	if($this->ZoomMode=='fullpage')
+		$this->_put('/OpenAction ['.$n.' 0 R /Fit]');
+	elseif($this->ZoomMode=='fullwidth')
+		$this->_put('/OpenAction ['.$n.' 0 R /FitH null]');
+	elseif($this->ZoomMode=='real')
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null 1]');
+	elseif(!is_string($this->ZoomMode))
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null '.sprintf('%.2F',$this->ZoomMode/100).']');
+	if($this->LayoutMode=='single')
+		$this->_put('/PageLayout /SinglePage');
+	elseif($this->LayoutMode=='continuous')
+		$this->_put('/PageLayout /OneColumn');
+	elseif($this->LayoutMode=='two')
+		$this->_put('/PageLayout /TwoColumnLeft');
+}
+
+protected function _putheader()
+{
+	$this->_put('%PDF-'.$this->PDFVersion);
+}
+
+protected function _puttrailer()
+{
+	$this->_put('/Size '.($this->n+1));
+	$this->_put('/Root '.$this->n.' 0 R');
+	$this->_put('/Info '.($this->n-1).' 0 R');
+}
+
+protected function _enddoc()
+{
+	$this->CreationDate = time();
+	$this->_putheader();
+	$this->_putpages();
+	$this->_putresources();
+	// Info
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putinfo();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Catalog
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putcatalog();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Cross-ref
+	$offset = $this->_getoffset();
+	$this->_put('xref');
+	$this->_put('0 '.($this->n+1));
+	$this->_put('0000000000 65535 f ');
+	for($i=1;$i<=$this->n;$i++)
+		$this->_put(sprintf('%010d 00000 n ',$this->offsets[$i]));
+	// Trailer
+	$this->_put('trailer');
+	$this->_put('<<');
+	$this->_puttrailer();
+	$this->_put('>>');
+	$this->_put('startxref');
+	$this->_put($offset);
+	$this->_put('%%EOF');
+	$this->state = 3;
+}
+}
+?>

--- a/zxtec-intranet/uninstall.php
+++ b/zxtec-intranet/uninstall.php
@@ -1,0 +1,29 @@
+<?php
+// If uninstall not called from WordPress, exit
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Remove custom role
+remove_role( 'zxtec_colaborador' );
+
+// Delete user meta
+$meta_keys = array( 'zxtec_lat', 'zxtec_lng', 'zxtec_specialty', 'zxtec_cost_km', 'zxtec_notifications' );
+$users = get_users();
+foreach ( $users as $user ) {
+    foreach ( $meta_keys as $key ) {
+        delete_user_meta( $user->ID, $key );
+    }
+}
+
+// Delete custom posts
+$post_types = array( 'zxtec_client', 'zxtec_service', 'zxtec_order', 'zxtec_contract', 'zxtec_expense' );
+foreach ( $post_types as $pt ) {
+    $posts = get_posts( array( 'post_type' => $pt, 'numberposts' => -1, 'post_status' => 'any' ) );
+    foreach ( $posts as $p ) {
+        wp_delete_post( $p->ID, true );
+    }
+}
+
+// Remove options
+delete_option( 'zxtec_commission' );

--- a/zxtec-intranet/zxtec-intranet.php
+++ b/zxtec-intranet/zxtec-intranet.php
@@ -1,0 +1,20 @@
+<?php
+/*
+Plugin Name: ZX Tec
+Description: Sistema interno de gestao de clientes, servicos e colaboradores.
+ Version: 2.6.2
+Author: ZX Tec
+License: GPL2
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-zxtec-intranet.php';
+
+function zxtec_intranet_init() {
+    \ZXTEC_Intranet::instance();
+}
+add_action( 'plugins_loaded', 'zxtec_intranet_init' );
+


### PR DESCRIPTION
## Summary
- split address fields for clients and orders
- auto-fill street, neighborhood, city and state from CEP
- alert when number or complement are missing
- bump plugin version to 2.6
- document the new version and features

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840dce461588325a8b21a4b62269b8f