### PR TITLE
Add crypto dashboard web app

### DIFF
--- a/crypto-dashboard/app.js
+++ b/crypto-dashboard/app.js
@@ -1,0 +1,144 @@
+let dados = JSON.parse(localStorage.getItem('cryptoDashboard')) || {transacoes:[], ganhos:[]};
+let graficoLinha, graficoPizza;
+
+function salvar(){
+    localStorage.setItem('cryptoDashboard', JSON.stringify(dados));
+}
+
+function showTab(id){
+    document.querySelectorAll('.tab').forEach(t => t.style.display='none');
+    document.getElementById(id).style.display='block';
+    if(id==='dashboard') updateDashboard();
+    if(id==='transacoes') renderTransacoes();
+    if(id==='taxas') renderTaxas();
+    if(id==='rentabilidade') renderGanhos();
+}
+
+function adicionarTransacao(e){
+    e.preventDefault();
+    const t = {
+        tipo: document.getElementById('tipo').value,
+        data: document.getElementById('data').value,
+        moeda: document.getElementById('moeda').value,
+        valor: parseFloat(document.getElementById('valor').value),
+        origem: document.getElementById('origem').value,
+        taxas: parseFloat(document.getElementById('taxas').value||0),
+        obs: document.getElementById('obs').value
+    };
+    dados.transacoes.push(t);
+    salvar();
+    e.target.reset();
+    renderTransacoes();
+}
+
+function adicionarGanho(e){
+    e.preventDefault();
+    const g = {
+        moeda: document.getElementById('moedaGanho').value,
+        valor: parseFloat(document.getElementById('valorGanho').value)
+    };
+    dados.ganhos.push(g);
+    salvar();
+    e.target.reset();
+    renderGanhos();
+}
+
+function renderTransacoes(){
+    const ul = document.getElementById('transacoesSalvas');
+    ul.innerHTML='';
+    dados.transacoes.forEach((t,i)=>{
+        const li=document.createElement('li');
+        li.textContent=`${t.data} - ${t.tipo} ${t.moeda} ${t.valor}`;
+        const btn=document.createElement('button');
+        btn.textContent='Excluir';
+        btn.onclick=()=>{dados.transacoes.splice(i,1); salvar(); renderTransacoes();};
+        li.appendChild(btn);
+        ul.appendChild(li);
+    });
+}
+
+function renderTaxas(){
+    const nao = document.getElementById('taxasNao');
+    const reemb = document.getElementById('taxasReemb');
+    nao.innerHTML='';
+    reemb.innerHTML='';
+    dados.transacoes.filter(t=>t.tipo.includes('Taxa')).forEach((t,i)=>{
+        const li=document.createElement('li');
+        li.textContent=`${t.data} - ${t.tipo} ${t.valor}`;
+        if(t.tipo==='Taxa Reembolsável'){
+            const btn=document.createElement('button');
+            btn.textContent='Marcar Reembolsada';
+            btn.onclick=()=>{t.tipo='Taxa Não Reembolsável'; salvar(); renderTaxas();};
+            li.appendChild(btn);
+            reemb.appendChild(li);
+        }else{
+            nao.appendChild(li);
+        }
+    });
+}
+
+function renderGanhos(){
+    const ul=document.getElementById('listaGanhos');
+    ul.innerHTML='';
+    dados.ganhos.forEach((g,i)=>{
+        const li=document.createElement('li');
+        li.textContent=`${g.moeda} +${g.valor}`;
+        const btn=document.createElement('button');
+        btn.textContent='Excluir';
+        btn.onclick=()=>{dados.ganhos.splice(i,1); salvar(); renderGanhos();};
+        li.appendChild(btn);
+        ul.appendChild(li);
+    });
+    gerarGraficos();
+}
+
+function updateDashboard(){
+    const cot=parseFloat(document.getElementById('cotacao').value||1);
+    const totals={};
+    dados.transacoes.forEach(t=>{
+        totals[t.origem]=(totals[t.origem]||0)+(t.valor);
+    });
+    const div=document.getElementById('totais');
+    div.innerHTML='';
+    let totalGeral=0;
+    for(const k in totals){
+        totalGeral+=totals[k];
+        const p=document.createElement('p');
+        p.textContent=`${k}: ${totals[k]} (${(totals[k]*cot).toFixed(2)} BRL)`;
+        div.appendChild(p);
+    }
+    const p=document.createElement('p');
+    p.innerHTML=`<strong>Total Geral: ${totalGeral} USDT (${(totalGeral*cot).toFixed(2)} BRL)</strong>`;
+    div.appendChild(p);
+    const lista=document.getElementById('listaTransacoes');
+    lista.innerHTML='';
+    dados.transacoes.slice(-5).reverse().forEach(t=>{
+        const li=document.createElement('li');
+        li.textContent=`${t.data} - ${t.tipo} ${t.moeda} ${t.valor}`;
+        lista.appendChild(li);
+    });
+    gerarGraficos();
+}
+
+function gerarGraficos(){
+    const ctx=document.getElementById('graficoLinha');
+    const ctxP=document.getElementById('graficoPizza');
+    const datas=dados.transacoes.map(t=>t.data);
+    const valores=dados.transacoes.map(t=>t.valor);
+    if(graficoLinha){graficoLinha.destroy();}
+    graficoLinha=new Chart(ctx,{type:'line',data:{labels:datas,datasets:[{label:'Valores',data:valores,borderColor:'blue'}]}});
+    const ganhosPorMoeda={};
+    dados.ganhos.forEach(g=>{ganhosPorMoeda[g.moeda]=(ganhosPorMoeda[g.moeda]||0)+g.valor;});
+    if(graficoPizza){graficoPizza.destroy();}
+    graficoPizza=new Chart(ctxP,{type:'pie',data:{labels:Object.keys(ganhosPorMoeda),datasets:[{data:Object.values(ganhosPorMoeda)}]}});
+}
+
+function exportData(){
+    const dataStr="data:text/json;charset=utf-8,"+encodeURIComponent(JSON.stringify(dados));
+    const link=document.createElement('a');
+    link.setAttribute('href',dataStr);
+    link.setAttribute('download','dados.json');
+    link.click();
+}
+
+showTab('dashboard');

--- a/crypto-dashboard/index.html
+++ b/crypto-dashboard/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard de Cripto</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Dashboard de Criptomoedas</h1>
+    <nav>
+        <button onclick="showTab('dashboard')">Visão Geral</button>
+        <button onclick="showTab('transacoes')">Transações</button>
+        <button onclick="showTab('taxas')">Taxas</button>
+        <button onclick="showTab('rentabilidade')">Rentabilidade</button>
+        <button onclick="exportData()">Exportar dados</button>
+    </nav>
+
+    <section id="dashboard" class="tab">
+        <h2>Visão Geral</h2>
+        <label>Cotação USDT/BRL: <input type="number" id="cotacao" value="5" step="0.01" onchange="updateDashboard()"></label>
+        <div id="totais"></div>
+        <canvas id="graficoLinha"></canvas>
+        <h3>Últimas Transações</h3>
+        <ul id="listaTransacoes"></ul>
+    </section>
+
+    <section id="transacoes" class="tab" style="display:none">
+        <h2>Nova Transação</h2>
+        <form id="formTransacao" onsubmit="adicionarTransacao(event)">
+            <label>Tipo
+                <select id="tipo">
+                    <option>Compra</option>
+                    <option>Venda</option>
+                    <option>Transferência</option>
+                    <option>Taxa</option>
+                    <option>Depósito</option>
+                    <option>Saque</option>
+                    <option>Pool</option>
+                    <option>Staking</option>
+                    <option>Recompensa</option>
+                    <option>Taxa Reembolsável</option>
+                    <option>Taxa Não Reembolsável</option>
+                </select>
+            </label>
+            <label>Data <input type="date" id="data" required></label>
+            <label>Moeda <input type="text" id="moeda" required></label>
+            <label>Valor <input type="number" id="valor" step="0.0001" required></label>
+            <label>Carteira/Corretora <input type="text" id="origem" required></label>
+            <label>Taxas <input type="number" id="taxas" step="0.0001"></label>
+            <label>Observações <input type="text" id="obs"></label>
+            <button type="submit">Salvar</button>
+        </form>
+        <h3>Transações Salvas</h3>
+        <ul id="transacoesSalvas"></ul>
+    </section>
+
+    <section id="taxas" class="tab" style="display:none">
+        <h2>Taxas</h2>
+        <div>
+            <h3>Não Reembolsáveis</h3>
+            <ul id="taxasNao"></ul>
+        </div>
+        <div>
+            <h3>Reembolsáveis</h3>
+            <ul id="taxasReemb"></ul>
+        </div>
+    </section>
+
+    <section id="rentabilidade" class="tab" style="display:none">
+        <h2>Rentabilidade</h2>
+        <form id="formGanho" onsubmit="adicionarGanho(event)">
+            <label>Moeda <input type="text" id="moedaGanho" required></label>
+            <label>Valor <input type="number" id="valorGanho" step="0.0001" required></label>
+            <button type="submit">Adicionar</button>
+        </form>
+        <ul id="listaGanhos"></ul>
+        <canvas id="graficoPizza"></canvas>
+    </section>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/crypto-dashboard/style.css
+++ b/crypto-dashboard/style.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav button { margin-right: 5px; }
+.tab { margin-top: 20px; }
+label { display:block; margin:5px 0; }
+form label { display:block; }
+ul { list-style: none; padding:0; }
+li { margin:5px 0; }


### PR DESCRIPTION
## Summary
- create front-end crypto dashboard with tabs for transactions, fees and returns
- store info in localStorage and visualize totals and charts with Chart.js

## Testing
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851e83f088083259184b2a1994390b3