### PR TITLE
Support MercadoPago Pix credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Todos os recursos listados abaixo estão disponíveis na release 2.8.2.
    - Histórico de concursos e estatísticas de frequência
    - Horários limite configuráveis para recebimento de novas apostas
    - Exportação também disponível em JSON
-  - Pagamento via Mercado Pago com criação automática do link de checkout
-  - Várias contas Mercado Pago com seleção da ativa nas configurações
+  - Pagamento via Mercado Pago com Pix e QR Code
+  - Credenciais separadas para produção e teste com modo ativo
   - Valor da aposta configurável e página de logs de pagamento
    - Formulário de perfil para atualizar seus dados
    - Login estilizado com link "Perdeu a senha?" e formulário para troca de senha

--- a/bolao-x/readme.txt
+++ b/bolao-x/readme.txt
@@ -33,8 +33,9 @@ Plugin para gerenciamento de bolão com cadastro de apostas e conferência autom
 
 == Usage ==
 1. No menu **Bolao X**, abra a tela **Configurações**.
-2. Insira os tokens do Mercado Pago (um por linha) e escolha qual conta ficará ativa.
-3. Defina o valor da aposta em reais e salve as alterações.
+2. Informe as credenciais do Mercado Pago para produção e teste (Public Key e Access Token).
+3. Escolha o modo ativo (Teste ou Produção) e defina o valor da aposta em reais.
+4. Salve as alterações.
 
 == Development ==
 Certifique-se de ter o PHP CLI e a extensão GD instalados (`apt-get install php-cli php8.3-gd`).

--- a/bolao-x/uninstall.php
+++ b/bolao-x/uninstall.php
@@ -15,6 +15,19 @@ foreach ( $posts as $post ) {
 
 delete_option( 'bolaox_result' );
 delete_option( 'bolaox_cutoffs' );
-delete_option( 'bolaox_mp_tokens' );
-delete_option( 'bolaox_mp_active' );
+delete_option( 'bolaox_mp_prod_public' );
+delete_option( 'bolaox_mp_prod_token' );
+delete_option( 'bolaox_mp_test_public' );
+delete_option( 'bolaox_mp_test_token' );
+delete_option( 'bolaox_mp_mode' );
+delete_option( 'bolaox_price' );
+
+$upload = wp_upload_dir();
+$dir    = trailingslashit( $upload['basedir'] ) . 'bolao-x';
+if ( file_exists( $dir . '/mp-error.log' ) ) {
+    unlink( $dir . '/mp-error.log' );
+}
+if ( is_dir( $dir ) ) {
+    rmdir( $dir );
+}
 


### PR DESCRIPTION
## Summary
- separate Mercado Pago credentials into production and test keys
- store active environment choice
- generate Pix payment via MercadoPago and show QR code
- clean up settings uninstall
- update usage instructions
- document Pix mode setup

## Testing
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6866869da884832b9d08638b63e67169