### PR TITLE
Support MercadoPago Pix credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Todos os recursos listados abaixo estão disponíveis na release 2.8.2.
    - Histórico de concursos e estatísticas de frequência
    - Horários limite configuráveis para recebimento de novas apostas
    - Exportação também disponível em JSON
-  - Pagamento via Mercado Pago com criação automática do link de checkout
-  - Várias contas Mercado Pago com seleção da ativa nas configurações
+  - Pagamento via Mercado Pago com Pix e QR Code
+  - Credenciais separadas para produção e teste com modo ativo
   - Valor da aposta configurável e página de logs de pagamento
    - Formulário de perfil para atualizar seus dados
    - Login estilizado com link "Perdeu a senha?" e formulário para troca de senha

--- a/bolao-x/assets/css/bolao-x.css
+++ b/bolao-x/assets/css/bolao-x.css
@@ -423,4 +423,25 @@
         font-size: 0.85rem;
     }
 }
+.bolaox-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+.bolaox-modal.active { display: flex; }
+.bolaox-modal-content {
+    background: var(--bx-bg);
+    padding: 20px;
+    border-radius: var(--bx-radius);
+    text-align: center;
+}
+.bolaox-modal-content img { max-width: 260px; }
+.bolaox-modal-close { cursor: pointer; display: inline-block; margin-top: 10px; }
 .bolaox-widget .bolaox-progress{height:16px;}

--- a/bolao-x/assets/js/bolao-x.js
+++ b/bolao-x/assets/js/bolao-x.js
@@ -102,5 +102,20 @@
         });
       });
     });
+
+    document.querySelectorAll('.bolaox-open-modal').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        var target = btn.getAttribute('data-target');
+        var modal = document.querySelector(target);
+        if(modal) modal.classList.add('active');
+      });
+    });
+    document.querySelectorAll('.bolaox-modal-close').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var modal = btn.closest('.bolaox-modal');
+        if(modal) modal.classList.remove('active');
+      });
+    });
   });
 })();

--- a/bolao-x/bolao-x.php
+++ b/bolao-x/bolao-x.php
@@ -60,8 +60,11 @@ class BOLAOX_Plugin {
 
     public function register_settings() {
         register_setting( 'bolaox', 'bolaox_cutoffs' );
-        register_setting( 'bolaox', 'bolaox_mp_tokens' );
-        register_setting( 'bolaox', 'bolaox_mp_active' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_public' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_token' );
+        register_setting( 'bolaox', 'bolaox_mp_test_public' );
+        register_setting( 'bolaox', 'bolaox_mp_test_token' );
+        register_setting( 'bolaox', 'bolaox_mp_mode' );
         register_setting( 'bolaox', 'bolaox_lowest_info' );
         register_setting( 'bolaox', 'bolaox_form_page' );
         register_setting( 'bolaox', 'bolaox_price' );
@@ -112,22 +115,20 @@ class BOLAOX_Plugin {
         return home_url( '/' );
     }
 
-    private function get_mp_tokens() {
-        $str = get_option( 'bolaox_mp_tokens', '' );
-        $tokens = array_filter( array_map( 'trim', explode( "\n", $str ) ) );
-        return $tokens;
+    private function get_mp_access_token() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_token', '' ) );
+        }
+        return trim( get_option( 'bolaox_mp_test_token', '' ) );
     }
 
-    private function get_active_mp_token() {
-        $tokens = $this->get_mp_tokens();
-        $active = trim( get_option( 'bolaox_mp_active', '' ) );
-        if ( ! $active ) {
-            $active = $tokens ? $tokens[0] : '';
+    private function get_mp_public_key() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_public', '' ) );
         }
-        if ( $active && ! in_array( $active, $tokens, true ) ) {
-            $tokens[] = $active;
-        }
-        return trim( $active );
+        return trim( get_option( 'bolaox_mp_test_public', '' ) );
     }
 
     private function log_mp_error( $msg ) {
@@ -138,24 +139,41 @@ class BOLAOX_Plugin {
         error_log( $entry, 3, $this->log_file );
     }
 
-    private function create_mp_preference( $post_id ) {
-        $token = $this->get_active_mp_token();
-        if ( ! $token ) {
-            return '';
+    private function verify_mp_payment( $payment_id ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token || ! $payment_id ) {
+            return false;
         }
-        $url  = 'https://api.mercadopago.com/checkout/preferences';
+        $url  = 'https://api.mercadopago.com/v1/payments/' . intval( $payment_id );
+        $args = array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $token,
+            ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            return false;
+        }
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        return ( isset( $body['status'] ) && 'approved' === $body['status'] );
+    }
+
+    private function create_mp_pix_payment( $ref ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token ) {
+            return array();
+        }
+        $url   = 'https://api.mercadopago.com/v1/payments';
         $price = floatval( get_option( 'bolaox_price', 10 ) );
         $body  = array(
-            'items' => array(
-                array(
-                    'title'       => 'Aposta ' . $post_id,
-                    'quantity'    => 1,
-                    'unit_price'  => $price,
-                    'currency_id' => 'BRL',
-                ),
-            ),
-            'external_reference' => (string) $post_id,
+            'transaction_amount' => $price,
+            'description'        => 'Aposta ' . $ref,
+            'payment_method_id'  => 'pix',
+            'external_reference' => (string) $ref,
             'notification_url'   => home_url( '/wp-json/bolao-x/v1/mp?token=' . self::MP_WEBHOOK_TOKEN ),
+            'payer'              => array( 'email' => 'apostador@example.com' ),
         );
         $args = array(
             'headers' => array(
@@ -167,16 +185,21 @@ class BOLAOX_Plugin {
         );
         $res = wp_remote_post( $url, $args );
         if ( is_wp_error( $res ) ) {
-            $this->log_mp_error( 'Erro ao criar preferência: ' . $res->get_error_message() );
-            return '';
+            $this->log_mp_error( 'Erro ao criar pagamento: ' . $res->get_error_message() );
+            return array();
         }
         $data = json_decode( wp_remote_retrieve_body( $res ), true );
-        if ( isset( $data['init_point'] ) ) {
-            update_post_meta( $post_id, '_bolaox_mp_pref', sanitize_text_field( $data['id'] ) );
-            return esc_url_raw( $data['init_point'] );
+        if ( isset( $data['id'], $data['point_of_interaction']['transaction_data']['qr_code'] ) ) {
+            if ( is_numeric( $ref ) ) {
+                update_post_meta( intval( $ref ), '_bolaox_mp_pref', sanitize_text_field( $data['id'] ) );
+            }
+            return array(
+                'id'      => $data['id'],
+                'qr_code' => $data['point_of_interaction']['transaction_data']['qr_code'],
+            );
         }
         $this->log_mp_error( 'Resposta inesperada da API: ' . wp_remote_retrieve_body( $res ) );
-        return '';
+        return array();
     }
 
     public function admin_notices() {
@@ -342,16 +365,12 @@ class BOLAOX_Plugin {
                 }
                 update_option( 'bolaox_cutoffs', $new );
             }
-            if ( isset( $_POST['bolaox_mp_tokens'] ) ) {
-                $tokens = sanitize_textarea_field( $_POST['bolaox_mp_tokens'] );
-                update_option( 'bolaox_mp_tokens', $tokens );
-                $keys_arr = array_filter( array_map( 'trim', explode( "\n", $tokens ) ) );
-                $active = isset( $_POST['bolaox_mp_active'] ) ? sanitize_text_field( $_POST['bolaox_mp_active'] ) : '';
-                if ( ! $active && $keys_arr ) {
-                    $active = $keys_arr[0];
-                }
-                update_option( 'bolaox_mp_active', $active );
-            }
+            update_option( 'bolaox_mp_prod_public', sanitize_text_field( $_POST['bolaox_mp_prod_public'] ?? '' ) );
+            update_option( 'bolaox_mp_prod_token', sanitize_text_field( $_POST['bolaox_mp_prod_token'] ?? '' ) );
+            update_option( 'bolaox_mp_test_public', sanitize_text_field( $_POST['bolaox_mp_test_public'] ?? '' ) );
+            update_option( 'bolaox_mp_test_token', sanitize_text_field( $_POST['bolaox_mp_test_token'] ?? '' ) );
+            $mode = in_array( $_POST['bolaox_mp_mode'] ?? 'test', array( 'prod', 'test' ), true ) ? $_POST['bolaox_mp_mode'] : 'test';
+            update_option( 'bolaox_mp_mode', $mode );
             if ( isset( $_POST['bolaox_price'] ) ) {
                 $price = floatval( sanitize_text_field( $_POST['bolaox_price'] ) );
                 if ( $price <= 0 ) {
@@ -362,8 +381,11 @@ class BOLAOX_Plugin {
             echo '<div class="updated"><p>' . esc_html__( 'Configurações salvas.', self::TEXT_DOMAIN ) . '</p></div>';
         }
         $cutoffs = get_option( 'bolaox_cutoffs', array() );
-        $tokens = get_option( 'bolaox_mp_tokens', '' );
-        $active   = get_option( 'bolaox_mp_active', '' );
+        $prod_public = get_option( 'bolaox_mp_prod_public', '' );
+        $prod_token  = get_option( 'bolaox_mp_prod_token', '' );
+        $test_public = get_option( 'bolaox_mp_test_public', '' );
+        $test_token  = get_option( 'bolaox_mp_test_token', '' );
+        $mode        = get_option( 'bolaox_mp_mode', 'test' );
         $price = get_option( 'bolaox_price', 10 );
         echo '<div class="wrap"><h1>' . esc_html__( 'Configurações', self::TEXT_DOMAIN ) . '</h1>';
         echo '<form method="post">';
@@ -374,15 +396,18 @@ class BOLAOX_Plugin {
             echo '<tr><th scope="row">' . esc_html( $label ) . '</th><td>';
             echo '<input type="time" name="bolaox_cutoffs[' . $idx . ']" value="' . esc_attr( $val ) . '" /></td></tr>';
         }
-        echo '<tr><th scope="row">' . esc_html__( 'Tokens Mercado Pago', self::TEXT_DOMAIN ) . '</th><td><textarea name="bolaox_mp_tokens" rows="4" class="large-text">' . esc_textarea( $tokens ) . '</textarea></td></tr>';
-        $keys_arr = array_filter( array_map( 'trim', explode( "\n", $tokens ) ) );
-        if ( $keys_arr ) {
-            echo '<tr><th scope="row">' . esc_html__( 'Conta ativa', self::TEXT_DOMAIN ) . '</th><td><select name="bolaox_mp_active">';
-            foreach ( $keys_arr as $k ) {
-                echo '<option value="' . esc_attr( $k ) . '"' . selected( $active, $k, false ) . '>' . esc_html( $k ) . '</option>';
-            }
-            echo '</select></td></tr>';
-        }
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Produção', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_prod_public" value="' . esc_attr( $prod_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_prod_token" value="' . esc_attr( $prod_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Teste', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_test_public" value="' . esc_attr( $test_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_test_token" value="' . esc_attr( $test_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Modo ativo', self::TEXT_DOMAIN ) . '</th><td><select name="bolaox_mp_mode">';
+        echo '<option value="test"' . selected( $mode, 'test', false ) . '>Teste</option>';
+        echo '<option value="prod"' . selected( $mode, 'prod', false ) . '>Produção</option>';
+        echo '</select></td></tr>';
         echo '<tr><th scope="row">' . esc_html__( 'Preço da aposta (R$)', self::TEXT_DOMAIN ) . '</th><td><input type="number" step="0.01" name="bolaox_price" value="' . esc_attr( $price ) . '" /></td></tr>';
         echo '</tbody></table>';
         submit_button();
@@ -804,44 +829,63 @@ class BOLAOX_Plugin {
                 $countdown = '<div class="bolaox-countdown" data-end="' . esc_attr( $cutoff_ts ) . '" data-expired="' . esc_attr__( 'Tempo esgotado', self::TEXT_DOMAIN ) . '"></div>';
             }
         }
+        $pix = array();
+        $payment_id = '';
+        if ( ! isset( $_POST['bolaox_submit'] ) ) {
+            $pix        = $this->create_mp_pix_payment( 'tmp-' . wp_generate_password( 8, false, false ) );
+            $payment_id = isset( $pix['id'] ) ? $pix['id'] : '';
+        }
+
         if ( isset( $_POST['bolaox_submit'] ) && isset( $_POST['bolaox_nonce'] ) && wp_verify_nonce( $_POST['bolaox_nonce'], 'bolaox_form' ) ) {
-            $name = sanitize_text_field( $_POST['bolaox_name'] );
-            $numbers = sanitize_text_field( $_POST['bolaox_numbers'] );
-            $numbers = $this->validate_numbers( $numbers );
-            if ( false === $numbers ) {
-                return $this->wrap_app( '<p>' . esc_html__( 'Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN ) . '</p>' );
-            }
-           $post_id = wp_insert_post( array(
-                'post_type'   => 'bolaox_aposta',
-                'post_title'  => $name,
-                'post_status' => 'publish',
-                'post_author' => get_current_user_id(),
-            ) );
-            if ( $post_id ) {
-                update_post_meta( $post_id, '_bolaox_numbers', $numbers );
-                update_post_meta( $post_id, '_bolaox_payment', 'pending' );
-                $url = $this->create_mp_preference( $post_id );
-                $msg  = '<h3 class="bolaox-success-title">' . esc_html__( 'Aposta registrada com sucesso!', self::TEXT_DOMAIN ) . '</h3>';
-                $msg .= '<p class="bolaox-success-label">' . esc_html__( 'Sua aposta:', self::TEXT_DOMAIN ) . '</p>';
-                $msg .= '<div class="bolaox-numlist">';
-                foreach ( array_map( 'trim', explode( ',', $numbers ) ) as $n ) {
-                    $msg .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+            $payment_id = sanitize_text_field( $_POST['bolaox_payment_id'] );
+            if ( ! $this->verify_mp_payment( $payment_id ) ) {
+                $this->notice = __( 'Pagamento via Pix não confirmado.', self::TEXT_DOMAIN );
+                $pix        = $this->create_mp_pix_payment( 'tmp-' . wp_generate_password( 8, false, false ) );
+                $payment_id = isset( $pix['id'] ) ? $pix['id'] : '';
+            } else {
+                $name    = sanitize_text_field( $_POST['bolaox_name'] );
+                $numbers = sanitize_text_field( $_POST['bolaox_numbers'] );
+                $numbers = $this->validate_numbers( $numbers );
+                if ( false === $numbers ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN ) . '</p>' );
                 }
-                $msg .= '</div>';
-                if ( $url ) {
-                    $msg .= '<p class="bolaox-price">' . sprintf( esc_html__( 'Valor da aposta: R$ %s', self::TEXT_DOMAIN ), number_format( $price, 2, ',', '.' ) ) . '</p>';
-                    $msg .= '<p class="bolaox-pay-label">' . esc_html__( 'Pague com Mercado Pago', self::TEXT_DOMAIN ) . '</p>';
-                    $msg .= '<p><a class="button" href="' . esc_url( $url ) . '" target="_blank">' . esc_html__( 'Realizar Pagamento', self::TEXT_DOMAIN ) . '</a></p>';
+                $post_id = wp_insert_post( array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => $name,
+                    'post_status' => 'publish',
+                    'post_author' => get_current_user_id(),
+                ) );
+                if ( $post_id ) {
+                    update_post_meta( $post_id, '_bolaox_numbers', $numbers );
+                    update_post_meta( $post_id, '_bolaox_payment', 'paid' );
+                    update_post_meta( $post_id, '_bolaox_mp_pref', $payment_id );
+                    $msg  = '<h3 class="bolaox-success-title">' . esc_html__( 'Aposta registrada com sucesso!', self::TEXT_DOMAIN ) . '</h3>';
+                    $msg .= '<p class="bolaox-success-label">' . esc_html__( 'Sua aposta:', self::TEXT_DOMAIN ) . '</p>';
+                    $msg .= '<div class="bolaox-numlist">';
+                    foreach ( array_map( 'trim', explode( ',', $numbers ) ) as $n ) {
+                        $msg .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+                    }
+                    $msg .= '</div>';
+                    return $this->wrap_app( $msg );
                 }
-                return $this->wrap_app( $msg );
             }
         }
+
         $html  = '<div class="bolaox-form">';
+        $html .= '<div id="bolaox-pix-modal" class="bolaox-modal"><div class="bolaox-modal-content">';
+        if ( $pix ) {
+            $urlqr = 'https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=' . rawurlencode( $pix['qr_code'] );
+            $html .= '<p><img src="' . esc_url( $urlqr ) . '" alt="Pix QR" /></p>';
+            $html .= '<p><input type="text" value="' . esc_attr( $pix['qr_code'] ) . '" readonly onclick="this.select();" class="bolaox-pix-code" /></p>';
+        }
+        $html .= '<p><span class="button bolaox-modal-close">' . esc_html__( 'Fechar', self::TEXT_DOMAIN ) . '</span></p></div></div>';
+
         $html .= '<form method="post" class="bolaox-form-inner">';
         if ( $countdown ) {
             $html .= $countdown;
         }
         $html .= wp_nonce_field( 'bolaox_form', 'bolaox_nonce', true, false );
+        $html .= '<input type="hidden" name="bolaox_payment_id" value="' . esc_attr( $payment_id ) . '" />';
         $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Como quer ser chamado?', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_name" required /></label></p>';
         $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Escolha 10 dezenas', self::TEXT_DOMAIN ) . '</label>';
         $html .= '<div class="bolaox-numbers">';
@@ -851,6 +895,7 @@ class BOLAOX_Plugin {
         }
         $html .= '<input type="hidden" name="bolaox_numbers" required />';
         $html .= '</div></p>';
+        $html .= '<p><a href="#" class="button bolaox-open-modal" data-target="#bolaox-pix-modal">' . esc_html__( 'Pagar com Pix', self::TEXT_DOMAIN ) . '</a></p>';
         $html .= '<p class="bolaox-price">' . sprintf( esc_html__( 'Valor da aposta: R$ %s', self::TEXT_DOMAIN ), number_format( $price, 2, ',', '.' ) ) . '</p>';
         $html .= '<p class="bolaox-field"><input type="submit" name="bolaox_submit" value="' . esc_attr__( 'APOSTE AGORA', self::TEXT_DOMAIN ) . '" class="button bolaox-submit" /></p>';
         $html .= '</form></div>';
@@ -1153,7 +1198,7 @@ class BOLAOX_Plugin {
         $url  = 'https://api.mercadopago.com/v1/payments/' . $payment_id;
         $args = array(
             'headers' => array(
-                'Authorization' => 'Bearer ' . $this->get_active_mp_token(),
+                'Authorization' => 'Bearer ' . $this->get_mp_access_token(),
             ),
             'timeout' => 20,
         );

--- a/bolao-x/readme.txt
+++ b/bolao-x/readme.txt
@@ -33,8 +33,9 @@ Plugin para gerenciamento de bolão com cadastro de apostas e conferência autom
 
 == Usage ==
 1. No menu **Bolao X**, abra a tela **Configurações**.
-2. Insira os tokens do Mercado Pago (um por linha) e escolha qual conta ficará ativa.
-3. Defina o valor da aposta em reais e salve as alterações.
+2. Informe as credenciais do Mercado Pago para produção e teste (Public Key e Access Token).
+3. Escolha o modo ativo (Teste ou Produção) e defina o valor da aposta em reais.
+4. Salve as alterações.
 
 == Development ==
 Certifique-se de ter o PHP CLI e a extensão GD instalados (`apt-get install php-cli php8.3-gd`).

--- a/bolao-x/uninstall.php
+++ b/bolao-x/uninstall.php
@@ -15,6 +15,19 @@ foreach ( $posts as $post ) {
 
 delete_option( 'bolaox_result' );
 delete_option( 'bolaox_cutoffs' );
-delete_option( 'bolaox_mp_tokens' );
-delete_option( 'bolaox_mp_active' );
+delete_option( 'bolaox_mp_prod_public' );
+delete_option( 'bolaox_mp_prod_token' );
+delete_option( 'bolaox_mp_test_public' );
+delete_option( 'bolaox_mp_test_token' );
+delete_option( 'bolaox_mp_mode' );
+delete_option( 'bolaox_price' );
+
+$upload = wp_upload_dir();
+$dir    = trailingslashit( $upload['basedir'] ) . 'bolao-x';
+if ( file_exists( $dir . '/mp-error.log' ) ) {
+    unlink( $dir . '/mp-error.log' );
+}
+if ( is_dir( $dir ) ) {
+    rmdir( $dir );
+}
 


### PR DESCRIPTION
## Summary
- separate Mercado Pago credentials into production and test keys
- store active environment choice
- generate Pix payment via MercadoPago and show QR code
- clean up settings uninstall
- update usage instructions
- document Pix mode setup
- add modal Pix payment with verification before final bet

## Testing
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6866869da884832b9d08638b63e67169