### PR TITLE
Add simple static test site

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Todos os recursos listados abaixo estão disponíveis na release 2.8.3.
 ## Development
 Instale o PHP CLI e extensões necessárias executando `scripts/install-deps.sh`.
 Depois rode `scripts/test.sh` para validar o código PHP.
+
+## Test Site
+Um exemplo de site estático encontra-se em `test-site/`. Abra `index.html` para visualizar a página de demonstração.
+

--- a/test-site/README.md
+++ b/test-site/README.md
@@ -1,0 +1,4 @@
+# Site de Teste
+
+Esta pasta contém um pequeno exemplo de site estático para fins de demonstração.
+Abra `index.html` em seu navegador para visualizar a página.

--- a/test-site/index.html
+++ b/test-site/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Site de Teste</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        header { background: #f0f0f0; padding: 20px; text-align: center; }
+        section { margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Bem-vindo ao Site de Teste</h1>
+    </header>
+    <section>
+        <p>Esta página é um exemplo simples para demonstração do repositório.</p>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal static site in `test-site/`
- document the example site in README

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d57d5ab18832bb6fddb1fd3a4bd4f