### PR TITLE
Add webhook image generator demo

### DIFF
--- a/webhook-demo/index.html
+++ b/webhook-demo/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gerador de Imagens</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        #images img { max-width: 100%; margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Gerador de Imagens</h1>
+    <button id="trigger">Gerar</button>
+    <div id="status"></div>
+    <div id="images"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/webhook-demo/script.js
+++ b/webhook-demo/script.js
@@ -1,0 +1,28 @@
+const button = document.getElementById('trigger');
+const statusDiv = document.getElementById('status');
+const imagesDiv = document.getElementById('images');
+
+button.addEventListener('click', async () => {
+    statusDiv.textContent = 'Gerando...';
+    imagesDiv.innerHTML = '';
+    try {
+        const response = await fetch('https://webhook.domingoscreativetest.tech/webhook/gerador', {
+            method: 'POST'
+        });
+        if (!response.ok) throw new Error('Erro ao disparar o webhook');
+        const data = await response.json();
+        // espera que o webhook retorne { images: [url1, url2] }
+        if (Array.isArray(data.images)) {
+            data.images.forEach(src => {
+                const img = document.createElement('img');
+                img.src = src;
+                imagesDiv.appendChild(img);
+            });
+            statusDiv.textContent = 'Concluído';
+        } else {
+            statusDiv.textContent = 'Resposta inesperada';
+        }
+    } catch (err) {
+        statusDiv.textContent = 'Erro: ' + err.message;
+    }
+});


### PR DESCRIPTION
## Summary
- add simple demo page that posts to webhook and displays returned images

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686fd48018a0832b829d9b7d5423a5a6