### PR TITLE
Improve login redirects

### DIFF
--- a/bolao-x/assets/css/bolao-x-admin.css
+++ b/bolao-x/assets/css/bolao-x-admin.css
@@ -1,0 +1,131 @@
+/* Admin styles for Bolao X plugin - modern 2025 look */
+:root {
+    --bx-primary: #1e734c;
+    --bx-secondary: #259f3c;
+    --bx-highlight: #b9d938;
+    --bx-bg: #ffffff;
+    --bx-text: #333333;
+    --bx-glass: rgba(255,255,255,0.9);
+    --bx-radius: 12px;
+    --bx-color1: #bb2649; /* Viva Magenta */
+    --bx-color2: #ffbe98; /* Peach Fuzz */
+    --bx-color3: #6667ab; /* Very Peri */
+    --bx-color4: var(--bx-secondary);
+    --bx-color5: var(--bx-highlight);
+}
+.bolaox-admin {
+    max-width: 960px;
+    margin: 20px auto;
+    padding: 20px;
+    background: linear-gradient(180deg, #e8f5e9, #f1f8e9);
+    border-radius: var(--bx-radius);
+}
+.bolaox-admin h1 {
+    background: linear-gradient(45deg, var(--bx-primary), var(--bx-secondary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    font-family: 'Poppins', sans-serif;
+}
+.bolaox-admin table.form-table input,
+.bolaox-admin table.form-table select {
+    border-radius: 6px;
+}
+.bolaox-admin .button-primary {
+    background: linear-gradient(135deg, var(--bx-primary), var(--bx-secondary));
+    border: none;
+}
+.bolaox-cutoffs input[type="time"] {
+    width: 6rem;
+}
+@media (max-width: 782px) {
+    .bolaox-admin {
+        margin: 10px;
+        padding: 15px;
+    }
+    .bolaox-admin table.form-table input,
+    .bolaox-admin table.form-table select {
+        width: 100%;
+    }
+    .bolaox-cutoffs th,
+    .bolaox-cutoffs td {
+        display: block;
+        width: 100%;
+    }
+    .bolaox-cutoffs input[type="time"] {
+        width: 100%;
+    }
+}
+.bolaox-dashboard-analytics{
+    margin-top:20px;
+}
+.bx-info-circle{
+    margin:20px auto;
+    width:320px;
+    height:320px;
+    border-radius:50%;
+    border:8px solid var(--bx-secondary);
+    background:var(--bx-glass);
+    box-shadow:0 4px 12px rgba(0,0,0,0.06);
+    position:relative;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-weight:600;
+}
+.bx-info-circle div{
+    position:absolute;
+    left:10%;
+    width:80%;
+    text-align:center;
+    color:var(--bx-primary);
+}
+.bx-info-circle .bx-ci-visits{top:10%;}
+.bx-info-circle .bx-ci-users{top:25%;}
+.bx-info-circle .bx-ci-today{top:40%;}
+.bx-info-circle .bx-ci-country{top:58%;}
+.bx-info-circle .bx-ci-platform{top:73%;}
+.bx-info-circle .bx-ci-browser{top:88%;}
+
+/* rectangular analytics tabs replacing circular style */
+.bx-info-tabs{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+    gap:20px;
+    margin:30px 0;
+}
+.bx-info-tab{
+    padding:20px;
+    border-radius:var(--bx-radius);
+    color:#fff;
+    text-align:center;
+    font-weight:600;
+    box-shadow:0 6px 12px rgba(0,0,0,0.15);
+}
+.bx-info-tab span{
+    display:block;
+    font-size:14px;
+    margin-bottom:8px;
+    text-transform:uppercase;
+}
+.bx-info-tab strong{
+    display:block;
+    font-size:20px;
+}
+.bx-info-tab:nth-child(1){background:var(--bx-color1);}
+.bx-info-tab:nth-child(2){background:var(--bx-color2);}
+.bx-info-tab:nth-child(3){background:var(--bx-color3);}
+.bx-info-tab:nth-child(4){background:var(--bx-color4);}
+.bx-info-tab:nth-child(5){background:var(--bx-color5);}
+
+.bolaox-stats{
+    list-style: none;
+    margin: 0 0 20px;
+    padding: 0;
+}
+.bolaox-stats li{
+    margin-bottom: 4px;
+}
+
+.bolaox-contest-form select{
+    margin-right:10px;
+}

--- a/bolao-x/assets/css/bolao-x.css
+++ b/bolao-x/assets/css/bolao-x.css
@@ -1,0 +1,688 @@
+/* Modern 2025 style for Bolao X forms */
+/* Poppins font is optional and will fall back to system fonts */
+
+:root {
+    --bx-primary: #1e734c;
+    --bx-secondary: #259f3c;
+    --bx-highlight: #b9d938;
+    --bx-bg: #ffffff;
+    --bx-text: #333333;
+    --bx-glass: rgba(255, 255, 255, 0.9);
+    --bx-radius: 12px;
+}
+
+.bolaox-app {
+    max-width: 960px;
+    margin: 30px auto;
+    padding: 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    animation: fadeInUp 0.5s ease-out;
+}
+.bx-logged-in .bolaox-guest { display: none; }
+.bx-logged-out .bolaox-user { display: none; }
+
+@media (min-width: 1024px) {
+    .bolaox-app {
+        max-width: 1200px;
+    }
+}
+.bolaox-center { text-align: center; }
+
+.bolaox-result {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.bolaox-form {
+    max-width: 720px;
+    margin: 10px 150px;
+    background: var(--bx-bg);
+    padding: 40px;
+    border-radius: var(--bx-radius);
+    color: var(--bx-text);
+    font-family: 'Poppins', sans-serif;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #eee;
+}
+.bolaox-form-inner {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+.bolaox-field label {
+    display: block;
+    width: 100%;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+.bolaox-field input[type="text"],
+.bolaox-field input[type="number"] {
+    width: 100%;
+    display: block;
+    padding: 10px;
+    border: none;
+    border-radius: 6px;
+    font-size: 1rem;
+}
+.bolaox-field input[type="submit"],
+.bolaox-field .button {
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background 0.3s, transform 0.3s;
+}
+
+.bolaox-add-bet {
+    display: block;
+    width: 100%;
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background 0.3s, transform 0.3s;
+}
+
+.bolaox-add-bet:hover {
+    transform: scale(1.05);
+}
+
+/* Pix button styled like the main action but in teal */
+.bolaox-pix-btn {
+    display: block;
+    width: 100%;
+    background: #03d0ad;
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 6px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.3s;
+    text-decoration: none;
+    text-transform: uppercase;
+    text-align: center;
+}
+.bolaox-pix-btn::before {
+    content: '';
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 6px;
+    vertical-align: middle;
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB8AAAAeCAYAAADU8sWcAAACaUlEQVRIia2XuWsVURyFv5cFwSAIRgQRF7RxCcRSbTRYiIKNC2KlKCpWwUaIVtoIIigW1grBxj9AomhhIxIsjCAuKLjHJRglcUn0kwsz+DKZmTf3mQPTvPdmvsO959z5vZpKE1oMbAKWAJ+AO8BQ9GMCPPLarj5U//hPb9RetT3mWbHgHep78/VDPRFjYKbAqaIMzCQ42sBMg6MMVAEPR4JTTagn1VlFz28pKUINGAFOAdeAsYgSPQcuAs+A9kJAQc83AiuBSWAYuA/0AOeAzgbgW0BvaDHQBXQAH4DrwK8pvyxY6nd1yzep3lZXq7vVjyVLfVNdrh5Iup9qTD2utpXteVm47qlrSgyk4EPq15zvv2cNxKa6yEAjcK6BFLxefd0AnGcgLO1ARXCqcXV/Cm9VL1cE1xvoVlepi9QjFcGpBtXOkPbOJKFdEVUKepokeAGwLUl1VY0Cm9uSPrdGgoPmAsuAecCsyHsDsyUcMl+AR5E3PwH2AEeBXcDpaR0u1yvgZRq4LepIxf16rG5Qe9ShJC8Lk6P0Z4X7w7lxrD7tYe8Pq6MR4Bd1n/dXNPBbPa/Ozva8lqS2yEARuKqBFNxRdMLVCmozlJwFReCsgb7MM6aBw5X3Ygkh3Al0AxPJi2UAWAFcApY2CNNVoC8ZLtcBc4C3wBXg25TIF7zVSOrQXTep7gXmV0zzINAPPADuAuO5vyoZJIKxfREtyCpMt2fTcDUzybQ0CGGRwh5fyO5xMzNcoxZklRuu/5leqxqoDI6Bl9WwKXAsPDVwMDMiBQVDZ2LART2vorXA1qTLn4EbyZ/FcC5UE/AXeRkchGS668MAAAAASUVORK5CYII=') no-repeat center/contain;
+}
+.bolaox-pix-btn:hover {
+    transform: scale(1.05);
+}
+.bolaox-countdown {
+    margin-bottom: 10px;
+    font-weight: 600;
+    text-align: center;
+    animation: pulse 1s infinite alternate;
+    font-variant-numeric: tabular-nums;
+}
+
+@keyframes pulse {
+    from { opacity: 0.7; }
+    to { opacity: 1; }
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes pop {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.bolaox-profile,
+.bolaox-pass-form {
+    font-family: 'Poppins', sans-serif;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+.bolaox-input {
+    width: 100%;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+    background: #fafafa;
+    box-shadow: inset 0 1px 3px rgba(0,0,0,0.1);
+    margin-bottom: 12px;
+    font-size: 1rem;
+    transition: box-shadow 0.3s, border-color 0.3s;
+    font-family: 'Poppins', sans-serif;
+}
+.bolaox-input::placeholder {
+    color: #999;
+}
+.bolaox-input:focus {
+    outline: none;
+    border-color: var(--bx-highlight);
+    box-shadow: 0 0 0 2px var(--bx-highlight);
+}
+.bolaox-avatar-preview {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+.bolaox-avatar-img {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+.bolaox-avatar-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 6px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+.bolaox-delete-avatar {
+    background: transparent;
+    color: var(--bx-primary);
+    border: 1px solid var(--bx-primary);
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+.bolaox-delete-avatar:hover {
+    background: var(--bx-primary);
+    color: #fff;
+}
+.bolaox-submit,
+.bolaox-submit.button {
+    width: 100%;
+    text-transform: uppercase;
+    text-align: center;
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+    color: #fff;
+    border: none;
+    padding: 10px 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background 0.3s, transform 0.3s;
+    position: relative;
+    z-index: 2;
+}
+.bolaox-pay-label {
+    font-weight: 600;
+    margin-top: 10px;
+    text-align: center;
+}
+.bolaox-price {
+    font-weight: 600;
+    margin: 10px 0;
+    text-align: center;
+}
+.bolaox-copy {
+    margin-left: 8px;
+}
+.bolaox-login,
+.bolaox-profile,
+.bolaox-pass-form {
+    background: var(--bx-glass);
+    padding: 20px;
+    border-radius: var(--bx-radius);
+    animation: fadeInUp 0.5s ease-out;
+}
+.bolaox-login-tabs { display: flex; flex-direction: column; gap: 15px; }
+.bolaox-tabs { list-style: none; padding: 0; margin: 0; display: flex; gap: 10px; }
+.bolaox-tabs li { flex: 1; text-align: center; padding: 8px; border-radius: var(--bx-radius); cursor: pointer; background: var(--bx-glass); }
+.bolaox-tabs li.active { background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%); color:#fff; }
+.bolaox-tab-content { display: none; }
+.bolaox-tab-content.active { display: block; }
+.bolaox-error {
+    color: #d32f2f;
+    margin-bottom: 10px;
+}
+.bolaox-success {
+    color: var(--bx-primary);
+    margin-bottom: 10px;
+}
+.bolaox-lost {
+    text-align: right;
+}
+.bolaox-field input[type="submit"]:hover,
+.bolaox-field .button:hover {
+    transform: scale(1.05);
+}
+.bolaox-table {
+    margin-top: 20px;
+    border-collapse: collapse;
+    width: 100%;
+    background: rgba(255,255,255,0.6);
+}
+.bolaox-table thead th {
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+    color: #fff;
+}
+.bolaox-table th,
+.bolaox-table td {
+    padding: 8px 10px;
+    border: 1px solid #eee;
+}
+.bolaox-table .col-index{width:40px;text-align:center;font-weight:600;}
+.bolaox-table .col-name{width:30%;text-align:left;}
+.bolaox-table .col-percent{width:160px;}
+.bolaox-table tbody tr:hover {
+    background: rgba(0,0,0,0.05);
+}
+.bolaox-hit-10 { background: #3ccf4e; color: #fff; }
+.bolaox-hit-9 { background: #ff9800; color: #fff; }
+.bolaox-hit-8 { background: #ff5722; color: #fff; }
+.bolaox-lowest {
+    background: linear-gradient(135deg, var(--bx-highlight) 0%, #fff176 100%);
+    color: #000;
+    font-weight: 600;
+    box-shadow: 0 0 5px rgba(0,0,0,0.2);
+}
+
+.bolaox-low-card,
+.bolaox-high-card {
+    margin-top: 20px;
+    padding: 15px;
+    color: #fff;
+    border-radius: var(--bx-radius);
+    text-align: center;
+    font-weight: 600;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+}
+.bolaox-low-card {
+    background: linear-gradient(135deg, var(--bx-secondary) 0%, var(--bx-primary) 100%);
+}
+.bolaox-high-card {
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+}
+
+.bolaox-res-num {
+    font-size: 1.2rem;
+    font-weight: 600;
+    text-align: left;
+}
+
+.bolaox-table-wrapper {
+    overflow-x: auto;
+    margin: 0 auto;
+    width: 100%;
+}
+.bolaox-scroll .bolaox-table {
+    width: 100%;
+}
+
+.bolaox-progress {
+    position: relative;
+    width: 100%;
+    height: 24px;
+    background-color: #b9d938b5;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: inset 0 0 6px rgba(0,0,0,0.05);
+}
+
+.bolaox-progress::before {
+    content: attr(data-progress);
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #fff;
+    font-family: 'Poppins', sans-serif;
+    z-index: 1;
+}
+
+.bolaox-progress span {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, var(--bx-primary), var(--bx-secondary));
+    background-size: 200% 100%;
+    animation: bx-shift 3s linear infinite;
+    transition: width 1s ease-out;
+}
+
+@keyframes bx-shift {
+    from { background-position: 0 0; }
+    to { background-position: 200% 0; }
+}
+
+.bolaox-dup {
+    color: #ff3b3b;
+    font-weight: bold;
+}
+
+/* number styling in result tables */
+.bolaox-number.hit,
+.bolaox-number.drawn {
+    background: var(--bx-highlight);
+    border-color: var(--bx-highlight);
+    color: #000;
+}
+
+.bolaox-number.dup {
+    background: #ffcdd2;
+    border-color: #ff3b3b;
+    color: #000;
+}
+
+.bolaox-board .bolaox-number {
+    cursor: default;
+    width: 48px;
+    height: 48px;
+    line-height: 48px;
+    margin: 2px;
+}
+.bolaox-board { display: flex; flex-wrap: wrap; justify-content: center; }
+.bolaox-scroll .bolaox-board { width: 100%; }
+
+.bolaox-numlist {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+}
+.bolaox-scroll .bolaox-numlist { width: 100%; }
+
+.bolaox-numlist .bolaox-number {
+    width: 48px;
+    height: 48px;
+    line-height: 48px;
+    font-size: 0.9rem;
+}
+
+/* smaller numbers on winners page */
+.bolaox-contemplados .bolaox-numlist .bolaox-number {
+    width: 36px;
+    height: 36px;
+    line-height: 36px;
+    font-size: 0.8rem;
+}
+
+.bolaox-dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 20px;
+    margin-bottom: 20px;
+}
+.bolaox-card {
+    background: var(--bx-glass);
+    border-radius: var(--bx-radius);
+    text-align: center;
+    padding: 15px;
+    cursor: pointer;
+    transition: transform 0.3s, box-shadow 0.3s;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+.bolaox-card span {
+    display: block;
+}
+.bolaox-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+.bolaox-card .dashicons {
+    font-size: 32px;
+    color: var(--bx-primary);
+    margin-bottom: 6px;
+}
+.bolaox-section {
+    animation: fadeInUp 0.5s ease-out;
+}
+
+
+.bolaox-success-title {
+    text-transform: uppercase;
+    font-size: 1.4rem;
+    margin-top: 20px;
+    font-weight: 600;
+    color: var(--bx-primary);
+}
+.bolaox-success-label {
+    margin-top: 5px;
+    font-weight: 600;
+}
+
+.bolaox-result h3 {
+    margin-top: 20px;
+}
+.bolaox-section-title{
+    margin-top:20px;
+    text-transform:uppercase;
+    font-weight:600;
+    text-align:center;
+    color:var(--bx-primary);
+}
+.bolaox-pagination{text-align:center;margin-top:20px;}
+.bolaox-pagination a{padding:4px 8px;margin:0 2px;border:1px solid var(--bx-primary);color:var(--bx-primary);border-radius:4px;text-decoration:none;}
+.bolaox-pagination a.current{background:var(--bx-primary);color:#fff;}
+
+@media(min-width:1024px){
+    .bolaox-result .bolaox-table-wrapper{max-width:100%;}
+}
+
+.bolaox-history {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.bolaox-history-item {
+    background: var(--bx-glass);
+    padding: 15px;
+    border-radius: var(--bx-radius);
+}
+
+.bolaox-history-date {
+    margin: 0 0 10px;
+    font-size: 1.2rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--bx-primary);
+}
+
+.bolaox-stats tr:nth-child(odd) {
+    background: rgba(255,255,255,0.05);
+}
+.bolaox-stats th {
+    text-align: center;
+}
+.bolaox-stats td:nth-child(3),
+.bolaox-stats th:nth-child(3) {
+    min-width: 200px;
+}
+
+/* number picker */
+.bolaox-numbers {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    gap: 12px;
+    margin-top: 10px;
+    justify-content: center;
+}
+
+.bolaox-number {
+    color: var(--bx-primary);
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    line-height: 60px;
+    font-size: 1.1rem;
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.3s, transform 0.3s;
+    font-weight: 600;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#fff, #fff) padding-box,
+        linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%) border-box;
+}
+
+.bolaox-number:hover {
+    transform: scale(1.1);
+    background:
+        linear-gradient(#f0f0f0, #f0f0f0) padding-box,
+        linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%) border-box;
+}
+
+.bolaox-number.selected {
+    background: linear-gradient(135deg, var(--bx-primary) 0%, var(--bx-secondary) 100%);
+    transform: scale(1.15);
+    color: #fff;
+    border-color: transparent;
+    animation: pop 0.3s ease;
+}
+
+.bolaox-cart {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 10px 0;
+}
+
+.bolaox-cart-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--bx-glass);
+    padding: 10px;
+    border-radius: var(--bx-radius);
+    border: 2px solid var(--bx-primary);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.bolaox-remove-bet {
+    background: linear-gradient(135deg, #bb2649, #e53935);
+    color: #fff;
+    border: none;
+    padding: 6px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+@media (max-width: 480px) {
+    .bolaox-app {
+        margin: 10px;
+        padding: 10px;
+    }
+    .bolaox-form {
+        margin: 10px;
+        padding: 20px;
+    }
+    .bolaox-numbers {
+        grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+    }
+    .bolaox-number {
+        width: 40px;
+        height: 40px;
+        line-height: 40px;
+        font-size: 0.9rem;
+    }
+    .bolaox-table {
+        font-size: 0.85rem;
+    }
+    .bolaox-stats td:nth-child(3),
+    .bolaox-stats th:nth-child(3) {
+        min-width: 200px;
+    }
+    .bolaox-scroll .bolaox-table,
+    .bolaox-scroll .bolaox-board,
+    .bolaox-scroll .bolaox-numlist {
+        width: max-content;
+    }
+}
+.bolaox-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+.bolaox-modal.active { display: flex; }
+.bolaox-modal-content {
+    background: var(--bx-bg);
+    padding: 20px;
+    border-radius: var(--bx-radius);
+    text-align: center;
+}
+.bolaox-modal-close { cursor: pointer; display: inline-block; margin-top: 10px; }
+.bolaox-widget .bolaox-progress{height:16px;}
+
+.bolaox-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+@media (min-width: 600px) {
+    .bolaox-scroll {
+        overflow-x: visible;
+    }
+    .bolaox-scroll .bolaox-table,
+    .bolaox-scroll .bolaox-board,
+    .bolaox-scroll .bolaox-numlist {
+        width: 100%;
+    }
+}
+
+/* results and history pages use theme typography */
+.bolaox-result,
+.bolaox-history,
+.bolaox-table,
+.bolaox-stats,
+.bolaox-res-num {
+    color: #000;
+    font-weight: 800;
+    font-family: inherit;
+}
+
+/* Logo shown only on small screens */
+.bolaox-mobile-logo {
+    display: block;
+    width: 160px;
+    margin: 0 auto 20px;
+}
+@media (min-width: 783px) {
+    .bolaox-mobile-logo {
+        display: none;
+    }
+}

--- a/bolao-x/assets/js/bolao-x.js
+++ b/bolao-x/assets/js/bolao-x.js
@@ -1,0 +1,317 @@
+(function(){
+  function animateBar(bar){
+    var target = parseInt(bar.getAttribute('data-progress'),10) || 0;
+    var span = bar.querySelector('span');
+    var start = null;
+    function step(timestamp){
+      if(!start) start = timestamp;
+      var progress = Math.min((timestamp - start)/1000,1);
+      var value = Math.floor(progress * target);
+      span.style.width = value + '%';
+      bar.setAttribute('data-progress', value + '%');
+      bar.setAttribute('aria-valuenow', value);
+      if(progress < 1){
+        requestAnimationFrame(step);
+      }else{
+        span.style.width = target + '%';
+        bar.setAttribute('data-progress', target + '%');
+        bar.setAttribute('aria-valuenow', target);
+      }
+    }
+    requestAnimationFrame(step);
+  }
+  document.addEventListener('DOMContentLoaded', function(){
+    if(window.bolaoxData){
+      document.querySelectorAll('.bolaox-app').forEach(function(el){
+        if(bolaoxData.logged_in){
+          el.classList.add('bx-logged-in');
+          el.classList.remove('bx-logged-out');
+        }else{
+          el.classList.add('bx-logged-out');
+          el.classList.remove('bx-logged-in');
+        }
+        el.setAttribute('data-logged-in', bolaoxData.logged_in ? '1' : '0');
+      });
+    }
+    document.querySelectorAll('.bolaox-progress').forEach(animateBar);
+    var cd = document.querySelector('.bolaox-countdown');
+    if(cd){
+      var end = parseInt(cd.getAttribute('data-end'),10)*1000;
+      var expired = cd.getAttribute('data-expired') || 'Encerrado';
+      function tick(){
+        var diff = Math.max(0, Math.floor((end - Date.now())/1000));
+        var h = Math.floor(diff/3600).toString().padStart(2,'0');
+        var m = Math.floor((diff%3600)/60).toString().padStart(2,'0');
+        var s = (diff%60).toString().padStart(2,'0');
+        cd.textContent = h+':'+m+':'+s;
+        if(diff>0){
+          requestAnimationFrame(tick);
+        }else{
+          cd.textContent = expired;
+        }
+      }
+      tick();
+    }
+    document.querySelectorAll('.bolaox-numbers').forEach(function(container){
+      var hidden = container.querySelector('input[type="hidden"]');
+      container.querySelectorAll('.bolaox-number').forEach(function(btn){
+        btn.addEventListener('click', function(){
+          if(btn.classList.contains('selected')){
+            btn.classList.remove('selected');
+          } else {
+            if(container.querySelectorAll('.bolaox-number.selected').length >= 10) return;
+            btn.classList.add('selected');
+          }
+          var arr = [];
+          container.querySelectorAll('.bolaox-number.selected').forEach(function(el){
+            arr.push(el.textContent);
+          });
+          hidden.value = arr.join(',');
+        });
+      });
+    });
+
+    document.querySelectorAll('.bolaox-phone').forEach(function(inp){
+      inp.addEventListener('input', function(){
+        var v = inp.value.replace(/\D/g,'').slice(0,11);
+        var f = v;
+        if(v.length > 10){
+          f = '('+v.slice(0,2)+') '+v.slice(2,7)+'-'+v.slice(7,11);
+        }else if(v.length > 5){
+          f = '('+v.slice(0,2)+') '+v.slice(2,6)+'-'+v.slice(6);
+        }else if(v.length > 2){
+          f = '('+v.slice(0,2)+') '+v.slice(2);
+        }
+        inp.value = f;
+      });
+    });
+
+    document.querySelectorAll('.bolaox-tabs').forEach(function(tabs){
+      var items = tabs.querySelectorAll('li');
+      var contents = tabs.parentElement.querySelectorAll('.bolaox-tab-content');
+      items.forEach(function(li,idx){
+        li.addEventListener('click', function(){
+          items.forEach(function(o){o.classList.remove('active');});
+          contents.forEach(function(o){o.classList.remove('active');});
+          li.classList.add('active');
+          if(contents[idx]) contents[idx].classList.add('active');
+        });
+      });
+    });
+
+    var success = document.querySelector('.bolaox-login-success, .bolaox-register-success');
+    if(success){
+      var url = success.getAttribute('data-redirect') || '/participe?bx_sec=mybets';
+      setTimeout(function(){
+        window.location.href = url;
+      }, 1500);
+    }
+
+    var params = new URLSearchParams(window.location.search);
+    var open = params.get('bx_sec');
+    var sections = document.querySelectorAll('.bolaox-section');
+    if(sections.length){
+      var target = open ? 'bx-' + open : sections[0].id;
+      sections.forEach(function(sec){
+        sec.style.display = sec.id === target ? 'block' : 'none';
+      });
+    }
+
+    // Load and animate the "Minhas Apostas" table
+    var mybets = document.querySelector('#bolaox-my-bets');
+    if(mybets){
+      var url = mybets.getAttribute('data-mybets-url');
+      if(url && window.bolaoxData){
+        fetch(url, {
+          headers:{'X-WP-Nonce': bolaoxData.nonce},
+          credentials:'same-origin'
+        }).then(function(r){
+          if(!r.ok){ throw new Error('HTTP '+r.status); }
+          return r.json();
+        }).then(function(data){
+          var html = data.html || data;
+          mybets.innerHTML = html;
+          mybets.querySelectorAll('.bolaox-progress').forEach(animateBar);
+        }).catch(function(){
+          mybets.querySelectorAll('.bolaox-progress').forEach(animateBar);
+        });
+      }else{
+        mybets.querySelectorAll('.bolaox-progress').forEach(animateBar);
+      }
+    }
+
+    document.querySelectorAll('.bolaox-card[data-target]').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var target = btn.getAttribute('data-target');
+        document.querySelectorAll('.bolaox-section').forEach(function(sec){
+          sec.style.display = sec.id === target ? 'block' : 'none';
+        });
+      });
+    });
+
+    document.querySelectorAll('.bolaox-open-modal').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        var target = btn.getAttribute('data-target');
+        var modal = document.querySelector(target);
+        if(modal) modal.classList.add('active');
+      });
+    });
+    document.querySelectorAll('.bolaox-modal-close').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var modal = btn.closest('.bolaox-modal');
+        if(modal) modal.classList.remove('active');
+      });
+    });
+
+    document.querySelectorAll('.bolaox-copy').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var target = btn.getAttribute('data-target');
+        var input = document.querySelector(target);
+        if(input){
+          input.select();
+          if(window.navigator && navigator.clipboard){
+            navigator.clipboard.writeText(input.value).catch(function(){});
+          }else{
+            document.execCommand('copy');
+          }
+          btn.textContent = 'Copiado!';
+          setTimeout(function(){ btn.textContent = 'Copiar'; }, 1000);
+        }
+      });
+    });
+
+    document.querySelectorAll('.bolaox-validate-creds').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var msg = btn.nextElementSibling;
+        msg.textContent = '...';
+        var modeSel = document.querySelector('select[name="bolaox_mp_mode"]');
+        var mode = modeSel ? modeSel.value : 'test';
+        fetch('/wp-json/bolao-x/v1/validate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-WP-Nonce': btn.getAttribute('data-nonce')
+          },
+          body: JSON.stringify({mode: mode})
+        }).then(function(r){
+          if(r.ok){ msg.textContent = 'OK'; }
+          else{ msg.textContent = 'Inválido'; }
+        }).catch(function(){ msg.textContent = 'Erro'; });
+      });
+    });
+
+    var cart = [];
+    var cartBox = document.querySelector('.bolaox-cart');
+    var priceEl = document.querySelector('.bolaox-price');
+    var unitPrice = priceEl ? parseFloat(priceEl.getAttribute('data-price')) : 0;
+    function updatePixBtn(){
+      document.querySelectorAll('.bolaox-pix-btn').forEach(function(b){
+        b.style.display = cart.length ? 'block' : 'none';
+      });
+    }
+
+    function updateAddLabel(){
+      document.querySelectorAll('.bolaox-add-bet').forEach(function(b){
+        var init = b.dataset.labelInit || 'Adicionar Jogo';
+        var more = b.dataset.labelMore || 'Adicionar mais um Jogo';
+        b.textContent = cart.length ? more : init;
+      });
+    }
+
+    updateAddLabel();
+    updatePixBtn();
+
+    function updatePrice(){
+      if(!priceEl) return;
+      var total = (unitPrice * cart.length).toFixed(2).replace('.',',');
+      priceEl.textContent = 'Valor total: R$ ' + total;
+    }
+
+    document.querySelectorAll('.bolaox-add-bet').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var container = document.querySelector('.bolaox-numbers');
+        var hidden = container.querySelector('input[type="hidden"]');
+        if(!hidden.value || hidden.value.split(',').length !== 10) return;
+        cart.push(hidden.value);
+        var item = document.createElement('div');
+        item.className = 'bolaox-cart-item';
+        var span = document.createElement('div');
+        span.className = 'bolaox-numlist';
+        hidden.value.split(',').forEach(function(n){
+          var s = document.createElement('span');
+          s.className = 'bolaox-number drawn';
+          s.textContent = n;
+          span.appendChild(s);
+        });
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'bolaox-remove-bet button';
+        remove.textContent = 'Remover';
+        remove.addEventListener('click', function(){
+          var idx = Array.prototype.indexOf.call(cartBox.children, item);
+          if(idx>=0){ cart.splice(idx,1); }
+          item.remove();
+          updatePrice();
+          updateAddLabel();
+        });
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'bolaox_numbers[]';
+        input.value = hidden.value;
+        item.appendChild(span);
+        item.appendChild(remove);
+        item.appendChild(input);
+        cartBox.appendChild(item);
+        container.querySelectorAll('.bolaox-number.selected').forEach(function(el){el.classList.remove('selected');});
+        hidden.value='';
+        updatePrice();
+        updateAddLabel();
+        updatePixBtn();
+      });
+    });
+
+    document.querySelectorAll('.bolaox-pix-btn').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        var qty = cart.length;
+        if(qty === 0) return;
+        fetch('/wp-json/bolao-x/v1/create-payment',{
+          method:'POST',
+          headers:{'Content-Type':'application/json','X-WP-Nonce': bolaoxData ? bolaoxData.nonce : ''},
+          body: JSON.stringify({qty: qty})
+        }).then(function(r){ return r.json(); }).then(function(data){
+          var modal = document.querySelector(btn.getAttribute('data-target'));
+          if(!modal) return;
+          var img = modal.querySelector('img');
+          var code = modal.querySelector('#bolaox-pix-code');
+          if(img){
+            if(data.qr_code_base64){
+              img.src = 'data:image/png;base64,'+data.qr_code_base64;
+            }else{
+              img.src = 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl='+encodeURIComponent(data.qr_code);
+            }
+          }
+          if(code){ code.value = data.qr_code; }
+          var pid = document.querySelector('input[name="bolaox_payment_id"]');
+          if(pid) pid.value = data.id;
+          modal.classList.add('active');
+        });
+      });
+    });
+
+    // Fallback for iOS Safari not triggering form submission on styled buttons
+    document.querySelectorAll('.bolaox-submit').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var form = btn.closest('form');
+        if(form){
+          if(form.requestSubmit){
+            form.requestSubmit(btn);
+          } else {
+            form.submit();
+          }
+        }
+      });
+    });
+  });
+})();

--- a/bolao-x/bolao-x.php
+++ b/bolao-x/bolao-x.php
@@ -1,0 +1,2371 @@
+<?php
+/*
+Plugin Name: Bolao X
+Description: Sistema de gerenciamento de bolão com conferência automática, histórico de resultados, exportação em PDF e Excel e pagamento via Mercado Pago.
+Version: 2.8.19
+Text Domain: bolao-x
+Domain Path: /languages
+Author: Bolao X
+License: GPL2
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+
+class BOLAOX_Plugin {
+    private static $instance = null;
+    private $notice = '';
+    private $log_file = '';
+    private $general_log_file = '';
+    const TEXT_DOMAIN = 'bolao-x';
+    const VERSION = '2.8.19';
+    const MP_WEBHOOK_TOKEN = 'CwbzYUaV8TNfv*J$Dua6JiHy@';
+    const MP_API_URL = 'https://api.mercadopago.com';
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', array( $this, 'register_post_type' ) );
+        add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+        add_action( 'save_post', array( $this, 'save_meta' ) );
+        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+        add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+        add_filter( 'gettext', array( $this, 'filter_gettext' ), 10, 3 );
+        add_filter( 'enter_title_here', array( $this, 'title_placeholder' ), 10, 2 );
+        add_action( 'init', array( $this, 'track_visit' ) );
+        add_action( 'save_post_bolaox_result', array( $this, 'clear_pending_payments' ), 10, 3 );
+        add_action( 'save_post_bolaox_concurso', array( $this, 'auto_create_result' ), 10, 3 );
+        add_action( 'admin_menu', array( $this, 'pending_payments_menu' ) );
+        add_action( 'wp_logout', array( $this, 'logout_session' ) );
+        add_filter( 'manage_bolaox_aposta_posts_columns', array( $this, 'aposta_columns' ) );
+        add_action( 'manage_bolaox_aposta_posts_custom_column', array( $this, 'aposta_column_content' ), 10, 2 );
+        add_filter( 'manage_bolaox_result_posts_columns', array( $this, 'result_columns' ) );
+        add_action( 'manage_bolaox_result_posts_custom_column', array( $this, 'result_column_content' ), 10, 2 );
+        add_action( 'restrict_manage_posts', array( $this, 'aposta_filter' ) );
+        add_action( 'restrict_manage_posts', array( $this, 'result_filter' ) );
+        add_filter( 'pre_get_posts', array( $this, 'aposta_filter_query' ) );
+        add_filter( 'pre_get_posts', array( $this, 'result_filter_query' ) );
+
+        $upload = wp_upload_dir();
+        $dir    = trailingslashit( $upload['basedir'] ) . 'bolao-x';
+        if ( ! file_exists( $dir ) ) {
+            wp_mkdir_p( $dir );
+        }
+        $this->log_file        = $dir . '/mp-error.log';
+        $this->general_log_file = $dir . '/general.log';
+        add_shortcode( 'bolao_x_form', array( $this, 'render_form_shortcode' ) );
+        add_shortcode( 'bolao_x_results', array( $this, 'render_results_shortcode' ) );
+        add_shortcode( 'bolao_x_history', array( $this, 'render_history_shortcode' ) );
+        add_shortcode( 'bolao_x_my_bets', array( $this, 'render_my_bets_shortcode' ) );
+        add_shortcode( 'bolao_x_stats', array( $this, 'render_stats_shortcode' ) );
+        add_shortcode( 'bolao_x_profile', array( $this, 'render_profile_shortcode' ) );
+        add_shortcode( 'bolao_x_login', array( $this, 'render_login_shortcode' ) );
+        add_shortcode( 'bolao_x_dashboard', array( $this, 'render_dashboard_shortcode' ) );
+        add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
+    }
+
+    public function register_settings() {
+        register_setting( 'bolaox', 'bolaox_cutoffs' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_public' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_token' );
+        register_setting( 'bolaox', 'bolaox_mp_test_public' );
+        register_setting( 'bolaox', 'bolaox_mp_test_token' );
+        register_setting( 'bolaox', 'bolaox_pix_key' );
+        register_setting( 'bolaox', 'bolaox_mp_mode' );
+        register_setting( 'bolaox', 'bolaox_lowest_info' );
+        register_setting( 'bolaox', 'bolaox_form_page' );
+        register_setting( 'bolaox', 'bolaox_price' );
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain( 'bolao-x', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    private function validate_numbers( $numbers ) {
+        $nums = array_map( 'trim', explode( ',', $numbers ) );
+        if ( count( $nums ) !== 10 ) {
+            return false;
+        }
+        $clean = array();
+        foreach ( $nums as $n ) {
+            if ( $n === '00' || $n === '0' ) {
+                $clean[] = '00';
+                continue;
+            }
+            if ( ! ctype_digit( $n ) || (int) $n < 1 || (int) $n > 99 ) {
+                return false;
+            }
+            $clean[] = sprintf( '%02d', (int) $n );
+        }
+        return implode( ',', $clean );
+    }
+
+    private function sanitize_phone( $phone ) {
+        return preg_replace( '/\D+/', '', $phone );
+    }
+
+    /**
+     * Ensure the session is restored from the auth cookie when possible.
+     */
+    private function maybe_restore_session() {
+        if ( is_user_logged_in() ) {
+            return;
+        }
+
+        $uid = 0;
+        $cookie = isset( $_COOKIE['bolaox_session'] ) ? $_COOKIE['bolaox_session'] : '';
+        if ( $cookie && strpos( $cookie, ':' ) !== false ) {
+            list( $id, $token ) = explode( ':', $cookie, 2 );
+            $hash = get_user_meta( (int) $id, '_bolaox_token', true );
+            $exp  = intval( get_user_meta( (int) $id, '_bolaox_token_exp', true ) );
+            if ( $hash && $exp > time() && wp_check_password( $token, $hash, $id ) ) {
+                $uid = (int) $id;
+            } else {
+                $this->clear_session_cookie();
+            }
+        } else {
+            $uid = wp_validate_auth_cookie( '', 'logged_in' );
+        }
+
+        if ( $uid ) {
+            wp_set_current_user( $uid );
+        }
+    }
+
+    private function create_session( $user_id ) {
+        $token  = wp_generate_password( 20, false );
+        $hash   = wp_hash_password( $token );
+        update_user_meta( $user_id, '_bolaox_token', $hash );
+        update_user_meta( $user_id, '_bolaox_token_exp', time() + HOUR_IN_SECONDS );
+        $cookie = $user_id . ':' . $token;
+        setcookie( 'bolaox_session', $cookie, array(
+            'expires'  => time() + HOUR_IN_SECONDS,
+            'path'     => COOKIEPATH ? COOKIEPATH : '/',
+            'domain'   => COOKIE_DOMAIN,
+            'secure'   => is_ssl(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ) );
+    }
+
+    private function clear_session_cookie() {
+        if ( isset( $_COOKIE['bolaox_session'] ) ) {
+            setcookie( 'bolaox_session', '', time() - HOUR_IN_SECONDS, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, is_ssl(), true );
+            unset( $_COOKIE['bolaox_session'] );
+        }
+    }
+
+    public function logout_session() {
+        $this->clear_session_cookie();
+    }
+
+    private function get_form_page_url() {
+        $page_id = get_option( 'bolaox_form_page', 0 );
+        if ( $page_id && get_post_status( $page_id ) ) {
+            return get_permalink( $page_id );
+        }
+        $pages = get_posts( array(
+            'post_type'      => 'page',
+            's'              => '[bolao_x_form',
+            'posts_per_page' => 1,
+        ) );
+        if ( $pages ) {
+            $page_id = $pages[0]->ID;
+            update_option( 'bolaox_form_page', $page_id );
+            return get_permalink( $page_id );
+        }
+        return home_url( '/' );
+    }
+
+    private function get_mp_access_token() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_token', '' ) );
+        }
+        return trim( get_option( 'bolaox_mp_test_token', '' ) );
+    }
+
+    private function get_mp_public_key() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_public', '' ) );
+        }
+        return trim( get_option( 'bolaox_mp_test_public', '' ) );
+    }
+
+    private function validate_mp_credentials( $mode ) {
+        $token = ( 'prod' === $mode ) ? get_option( 'bolaox_mp_prod_token', '' ) : get_option( 'bolaox_mp_test_token', '' );
+        if ( ! $token ) {
+            return false;
+        }
+        $url  = self::MP_API_URL . '/users/me';
+        $args = array(
+            'headers' => array( 'Authorization' => 'Bearer ' . $token ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_error( 'Falha ao validar credenciais: ' . $res->get_error_message() );
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
+        if ( $code !== 200 ) {
+            $this->log_error( 'Credenciais inválidas: HTTP ' . $code );
+        }
+        return $code === 200;
+    }
+
+    private function log_mp_error( $msg ) {
+        if ( ! $this->log_file ) {
+            return;
+        }
+        if ( strlen( $msg ) > 1000 ) {
+            $msg = substr( $msg, 0, 1000 ) . '...';
+        }
+        $entry = '[' . current_time( 'mysql' ) . "] " . $msg . "\n";
+        error_log( $entry, 3, $this->log_file );
+    }
+
+    private function log_error( $msg ) {
+        if ( ! $this->general_log_file ) {
+            return;
+        }
+        if ( strlen( $msg ) > 1000 ) {
+            $msg = substr( $msg, 0, 1000 ) . '...';
+        }
+        $entry = '[' . current_time( 'mysql' ) . "] " . $msg . "\n";
+        error_log( $entry, 3, $this->general_log_file );
+    }
+
+
+    private function get_browser_name( $ua ) {
+        if ( strpos( $ua, 'Firefox' ) !== false ) return 'Firefox';
+        if ( strpos( $ua, 'Edg' ) !== false ) return 'Edge';
+        if ( strpos( $ua, 'Chrome' ) !== false ) return 'Chrome';
+        if ( strpos( $ua, 'Safari' ) !== false ) return 'Safari';
+        if ( strpos( $ua, 'Trident' ) !== false || strpos( $ua, 'MSIE' ) !== false ) return 'IE';
+        return 'Outro';
+    }
+
+    private function get_platform_name( $ua ) {
+        $ua = strtolower( $ua );
+        if ( strpos( $ua, 'android' ) !== false ) return 'Android';
+        if ( strpos( $ua, 'iphone' ) !== false || strpos( $ua, 'ipad' ) !== false ) return 'iOS';
+        if ( strpos( $ua, 'windows' ) !== false ) return 'Windows';
+        if ( strpos( $ua, 'mac' ) !== false ) return 'macOS';
+        if ( strpos( $ua, 'linux' ) !== false ) return 'Linux';
+        return 'Outro';
+    }
+
+    public function track_visit() {
+        if ( is_admin() ) {
+            return;
+        }
+        $data = get_option( 'bolaox_visits', array() );
+        $date = current_time( 'Y-m-d' );
+        if ( ! isset( $data['days'][ $date ] ) ) {
+            $data['days'][ $date ] = 0;
+        }
+        $data['days'][ $date ]++;
+
+        $country = $_SERVER['HTTP_CF_IPCOUNTRY'] ?? '??';
+        $data['countries'][ $country ] = ( $data['countries'][ $country ] ?? 0 ) + 1;
+
+        $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $browser = $this->get_browser_name( $ua );
+        $platform = $this->get_platform_name( $ua );
+        $data['browsers'][ $browser ] = ( $data['browsers'][ $browser ] ?? 0 ) + 1;
+        $data['platforms'][ $platform ] = ( $data['platforms'][ $platform ] ?? 0 ) + 1;
+
+        if ( is_user_logged_in() ) {
+            $uid = get_current_user_id();
+            if ( ! isset( $data['users'][ $date ] ) ) {
+                $data['users'][ $date ] = array();
+            }
+            if ( ! in_array( $uid, $data['users'][ $date ], true ) ) {
+                $data['users'][ $date ][] = $uid;
+            }
+        }
+
+        if ( count( $data['days'] ) > 30 ) {
+            $data['days'] = array_slice( $data['days'], -30, true );
+        }
+        if ( isset( $data['users'] ) && count( $data['users'] ) > 30 ) {
+            $data['users'] = array_slice( $data['users'], -30, true );
+        }
+        update_option( 'bolaox_visits', $data );
+
+        $online = get_transient( 'bolaox_online' );
+        if ( ! is_array( $online ) ) {
+            $online = array();
+        }
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $online[ $ip ] = time();
+        foreach ( $online as $k => $t ) {
+            if ( $t < time() - 300 ) {
+                unset( $online[ $k ] );
+            }
+        }
+        set_transient( 'bolaox_online', $online, 5 * MINUTE_IN_SECONDS );
+    }
+
+    public function add_query_vars( $vars ) {
+        $vars[] = 'bolaox_page';
+        return $vars;
+    }
+
+    private function prepare_visit_stats() {
+        $data = get_option( 'bolaox_visits', array() );
+        $days = $data['days'] ?? array();
+        $users = $data['users'] ?? array();
+        $countries = $data['countries'] ?? array();
+        $platforms = $data['platforms'] ?? array();
+        $browsers = $data['browsers'] ?? array();
+        $dates = array();
+        $visit_counts = array();
+        $user_counts = array();
+        $today_views = 0;
+        for ( $i = 14; $i >= 0; $i-- ) {
+            $d = date( 'Y-m-d', strtotime( "-$i days" ) );
+            $dates[] = date_i18n( 'd/m', strtotime( $d ) );
+            $visit_counts[] = intval( $days[ $d ] ?? 0 );
+            $user_counts[]  = isset( $users[ $d ] ) ? count( $users[ $d ] ) : 0;
+            if ( 0 === $i ) {
+                $today_views = intval( $days[ $d ] ?? 0 );
+            }
+        }
+        arsort( $countries );
+        arsort( $platforms );
+        arsort( $browsers );
+        $online = get_transient( 'bolaox_online' );
+        $online_count = is_array( $online ) ? count( $online ) : 0;
+        return array(
+            'dates'       => $dates,
+            'visits'      => $visit_counts,
+            'users'       => $user_counts,
+            'countries'   => array( 'labels' => array_keys( $countries ), 'data' => array_values( $countries ) ),
+            'platforms'   => array( 'labels' => array_keys( $platforms ), 'data' => array_values( $platforms ) ),
+            'browsers'    => array( 'labels' => array_keys( $browsers ), 'data' => array_values( $browsers ) ),
+            'today_views' => $today_views,
+            'online'      => $online_count,
+        );
+    }
+    private function verify_mp_payment( $payment_id, $expected = null ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token || ! $payment_id ) {
+            return false;
+        }
+        $url  = self::MP_API_URL . '/v1/payments/' . intval( $payment_id );
+        $args = array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $token,
+            ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            $this->log_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            return false;
+        }
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $body['status'] ) && 'approved' === $body['status'] ) {
+            if ( null !== $expected && isset( $body['transaction_amount'] ) ) {
+                $amount = floatval( $body['transaction_amount'] );
+                if ( $amount + 0.001 < floatval( $expected ) ) {
+                    $this->log_error( 'Valor do pagamento divergente: ' . $amount );
+                    return false;
+                }
+            }
+            return true;
+        }
+        if ( isset( $body['status'] ) && in_array( $body['status'], array( 'in_process', 'pending' ), true ) ) {
+            $this->log_error( 'Pagamento pendente: ' . wp_remote_retrieve_body( $res ) );
+            return false;
+        }
+        $this->log_error( 'Pagamento não aprovado: ' . wp_remote_retrieve_body( $res ) );
+        return false;
+    }
+
+    private function create_mp_pix_payment( $ref, $qty = 1 ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token ) {
+            return array();
+        }
+        $url   = self::MP_API_URL . '/v1/payments';
+        $price = floatval( get_option( 'bolaox_price', 10 ) );
+        $amount = $price * max( 1, intval( $qty ) );
+        $pix_key = trim( get_option( 'bolaox_pix_key', '' ) );
+        $payer_email = 'apostador@example.com';
+        if ( is_user_logged_in() ) {
+            $user = wp_get_current_user();
+            if ( $user && $user->user_email ) {
+                $payer_email = $user->user_email;
+            }
+        } else {
+            $admin = get_option( 'admin_email' );
+            if ( $admin ) {
+                $payer_email = $admin;
+            }
+        }
+        $idempotency = $ref ? sanitize_text_field( $ref ) : sanitize_text_field( uniqid( 'pix_', true ) );
+        $body  = array(
+            'transaction_amount' => $amount,
+            'description'        => 'Aposta ' . $ref,
+            'payment_method_id'  => 'pix',
+            'external_reference' => (string) $ref,
+            'notification_url'   => home_url( '/wp-json/bolao-x/v1/mp?token=' . self::MP_WEBHOOK_TOKEN ),
+            'payer'              => array( 'email' => $payer_email ),
+        );
+        $args = array(
+            'headers' => array(
+                'Authorization'    => 'Bearer ' . $token,
+                'Content-Type'     => 'application/json',
+                'X-Idempotency-Key' => $idempotency,
+            ),
+            'body'    => wp_json_encode( $body ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_post( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro ao criar pagamento: ' . $res->get_error_message() );
+            $this->log_error( 'Erro ao criar pagamento Pix: ' . $res->get_error_message() );
+            return array();
+        }
+        $data = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $data['id'], $data['point_of_interaction']['transaction_data']['qr_code'] ) ) {
+            if ( is_numeric( $ref ) ) {
+                update_post_meta( intval( $ref ), '_bolaox_mp_pref', sanitize_text_field( $data['id'] ) );
+            }
+            return array(
+                'id'      => $data['id'],
+                'qr_code' => $data['point_of_interaction']['transaction_data']['qr_code'],
+                'qr_code_base64' => isset( $data['point_of_interaction']['transaction_data']['qr_code_base64'] ) ?
+                    $data['point_of_interaction']['transaction_data']['qr_code_base64'] : '',
+            );
+        }
+        $this->log_mp_error( 'Resposta inesperada da API: ' . wp_remote_retrieve_body( $res ) );
+        $this->log_error( 'Resposta inesperada da API Pix: ' . wp_remote_retrieve_body( $res ) );
+        return array();
+    }
+
+    public function admin_notices() {
+        if ( current_user_can( 'manage_options' ) ) {
+            $mode = get_option( 'bolaox_mp_mode', 'test' );
+            $token = 'prod' === $mode ? get_option( 'bolaox_mp_prod_token', '' ) : get_option( 'bolaox_mp_test_token', '' );
+            if ( ! $token ) {
+                $msg = ( 'prod' === $mode ) ? __( 'Informe o Access Token de produção do Mercado Pago em Bolao X > Configurações.', self::TEXT_DOMAIN ) : __( 'Informe o Access Token de teste do Mercado Pago em Bolao X > Configurações.', self::TEXT_DOMAIN );
+                echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
+            }
+        }
+        if ( $this->notice ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $this->notice ) . '</p></div>';
+            $this->notice = '';
+        }
+    }
+
+    public function enqueue_assets() {
+        $this->maybe_restore_session();
+        wp_enqueue_style( 'dashicons' );
+        wp_enqueue_style(
+            'bolaox-fonts',
+            'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap',
+            array(),
+            null
+        );
+        wp_enqueue_style(
+            'bolaox-style',
+            plugin_dir_url( __FILE__ ) . 'assets/css/bolao-x.css',
+            array(),
+            self::VERSION
+        );
+        if ( is_admin() ) {
+            wp_enqueue_style(
+                'bolaox-admin',
+                plugin_dir_url( __FILE__ ) . 'assets/css/bolao-x-admin.css',
+                array(),
+                self::VERSION
+            );
+            // charts were removed, keep CSS only
+        }
+        wp_enqueue_script(
+            'bolaox-js',
+            plugin_dir_url( __FILE__ ) . 'assets/js/bolao-x.js',
+            array(),
+            self::VERSION,
+            true
+        );
+        $user = is_user_logged_in() ? wp_get_current_user() : null;
+        wp_localize_script(
+            'bolaox-js',
+            'bolaoxData',
+            array(
+                'nonce'       => wp_create_nonce( 'wp_rest' ),
+                'logged_in'   => is_user_logged_in(),
+                'user_name'   => $user ? $user->display_name : '',
+                'mybets_url'  => rest_url( 'bolao-x/v1/mybets' ),
+            )
+        );
+    }
+
+    public function register_post_type() {
+        register_post_type( 'bolaox_aposta', array(
+            'labels' => array(
+                'name'          => __( 'Apostas', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Aposta', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Aposta Manual', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Criar Aposta', self::TEXT_DOMAIN ),
+                'not_found'     => __( 'Nenhuma aposta encontrada.', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+
+        register_post_type( 'bolaox_result', array(
+            'labels' => array(
+                'name'          => __( 'Resultados', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Resultado', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Novo Resultado', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Publicar Resultado', self::TEXT_DOMAIN ),
+                'not_found'     => __( 'Nenhum resultado encontrado.', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+
+        register_post_type( 'bolaox_concurso', array(
+            'labels' => array(
+                'name'          => __( 'Concursos', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Concurso', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Novo Concurso', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Criar Concurso', self::TEXT_DOMAIN ),
+                'search_items'  => __( 'Pesquisar Concursos', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+    }
+
+    public function add_meta_boxes() {
+        add_meta_box( 'bolaox_numbers', __( 'Dezenas', self::TEXT_DOMAIN ), array( $this, 'numbers_meta_box' ), 'bolaox_aposta' );
+        add_meta_box( 'bolaox_numbers', __( 'Dezenas', self::TEXT_DOMAIN ), array( $this, 'numbers_meta_box' ), 'bolaox_result' );
+        add_meta_box( 'bolaox_res_concurso', __( 'Concurso', self::TEXT_DOMAIN ), array( $this, 'result_concurso_meta_box' ), 'bolaox_result', 'side' );
+        add_meta_box( 'bolaox_payment', __( 'Status do Pagamento', self::TEXT_DOMAIN ), array( $this, 'payment_meta_box' ), 'bolaox_aposta', 'side' );
+        add_meta_box( 'bolaox_fixed', __( 'Apostador Fixo', self::TEXT_DOMAIN ), array( $this, 'fixed_meta_box' ), 'bolaox_aposta', 'side' );
+        add_meta_box( 'bolaox_concurso_meta', __( 'Detalhes do Concurso', self::TEXT_DOMAIN ), array( $this, 'concurso_meta_box' ), 'bolaox_concurso' );
+    }
+
+    public function numbers_meta_box( $post ) {
+        $numbers = get_post_meta( $post->ID, '_bolaox_numbers', true );
+        echo '<input type="text" name="bolaox_numbers" value="' . esc_attr( $numbers ) . '" placeholder="' . esc_attr__( 'Ex: 05,12,23,34,45,56,67,78,89,90', self::TEXT_DOMAIN ) . '" style="width:100%" />';
+    }
+
+    public function payment_meta_box( $post ) {
+        $status = get_post_meta( $post->ID, '_bolaox_payment', true );
+        if ( ! $status ) {
+            $status = 'pending';
+        }
+        echo '<select name="bolaox_payment">'
+            . '<option value="pending"' . selected( $status, 'pending', false ) . '>' . esc_html__( 'Pendente', self::TEXT_DOMAIN ) . '</option>'
+            . '<option value="paid"' . selected( $status, 'paid', false ) . '>' . esc_html__( 'Pago', self::TEXT_DOMAIN ) . '</option>'
+            . '</select>';
+    }
+
+    public function fixed_meta_box( $post ) {
+        $fixed = get_post_meta( $post->ID, '_bolaox_fixed', true );
+        if ( '' === $fixed && 'auto-draft' === $post->post_status ) {
+            $fixed = '1';
+        }
+        echo '<label><input type="checkbox" name="bolaox_fixed" value="1"' . checked( $fixed, '1', false ) . ' /> ' . esc_html__( 'Manter para próximos concursos', self::TEXT_DOMAIN ) . '</label>';
+    }
+
+    public function concurso_meta_box( $post ) {
+        $start = get_post_meta( $post->ID, '_bolaox_start', true );
+        $end   = get_post_meta( $post->ID, '_bolaox_end', true );
+        $active = get_option( 'bolaox_active_concurso', 0 );
+        echo '<p><label>' . esc_html__( 'Início', self::TEXT_DOMAIN ) . '<br />';
+        echo '<input type="datetime-local" name="bolaox_start" value="' . esc_attr( $start ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Fim', self::TEXT_DOMAIN ) . '<br />';
+        echo '<input type="datetime-local" name="bolaox_end" value="' . esc_attr( $end ) . '" /></label></p>';
+        echo '<p><label><input type="checkbox" name="bolaox_active" value="1"' . checked( $active, $post->ID, false ) . ' /> ' . esc_html__( 'Concurso Ativo', self::TEXT_DOMAIN ) . '</label></p>';
+    }
+
+    public function result_concurso_meta_box( $post ) {
+        $selected = get_post_meta( $post->ID, '_bolaox_concurso', true );
+        $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+        echo '<select name="bolaox_concurso">';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '"' . selected( $selected, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function save_meta( $post_id ) {
+        if ( isset( $_POST['bolaox_numbers'] ) ) {
+            $numbers = sanitize_text_field( $_POST['bolaox_numbers'] );
+            $valid   = $this->validate_numbers( $numbers );
+            if ( false === $valid ) {
+                $this->notice = __( 'Dezenas da aposta inválidas. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN );
+                return;
+            }
+            update_post_meta( $post_id, '_bolaox_numbers', $valid );
+            if ( 'bolaox_result' === get_post_type( $post_id ) ) {
+                update_post_meta( $post_id, '_bolaox_result', $valid );
+            }
+        }
+        if ( isset( $_POST['bolaox_concurso'] ) ) {
+            update_post_meta( $post_id, '_bolaox_concurso', intval( $_POST['bolaox_concurso'] ) );
+        }
+        if ( isset( $_POST['bolaox_payment'] ) ) {
+            $status = in_array( $_POST['bolaox_payment'], array( 'pending', 'paid' ), true ) ? $_POST['bolaox_payment'] : 'pending';
+            update_post_meta( $post_id, '_bolaox_payment', $status );
+        }
+        if ( isset( $_POST['bolaox_fixed'] ) ) {
+            update_post_meta( $post_id, '_bolaox_fixed', '1' );
+        } else {
+            delete_post_meta( $post_id, '_bolaox_fixed' );
+        }
+        if ( isset( $_POST['bolaox_start'] ) || isset( $_POST['bolaox_end'] ) ) {
+            $start = isset( $_POST['bolaox_start'] ) ? sanitize_text_field( $_POST['bolaox_start'] ) : '';
+            $end   = isset( $_POST['bolaox_end'] ) ? sanitize_text_field( $_POST['bolaox_end'] ) : '';
+            update_post_meta( $post_id, '_bolaox_start', $start );
+            update_post_meta( $post_id, '_bolaox_end', $end );
+        }
+        if ( isset( $_POST['bolaox_active'] ) ) {
+            $prev = get_option( 'bolaox_active_concurso', 0 );
+            update_option( 'bolaox_active_concurso', $post_id );
+            if ( $prev != $post_id ) {
+                $this->on_contest_switch( $prev, $post_id );
+            }
+        } elseif ( 'bolaox_concurso' === get_post_type( $post_id ) && get_option( 'bolaox_active_concurso' ) == $post_id ) {
+            delete_option( 'bolaox_active_concurso' );
+        }
+    }
+
+    public function admin_menu() {
+        add_menu_page( 'Bolao X', 'Bolao X', 'manage_options', 'bolaox', array( $this, 'results_page' ) );
+        add_submenu_page( 'bolaox', __( 'Configurações', self::TEXT_DOMAIN ), __( 'Configurações', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-settings', array( $this, 'settings_page' ) );
+        add_submenu_page( 'bolaox', __( 'Importar CSV', self::TEXT_DOMAIN ), __( 'Importar CSV', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-import', array( $this, 'import_page' ) );
+        add_submenu_page( 'bolaox', __( 'Histórico', self::TEXT_DOMAIN ), __( 'Histórico', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-history', array( $this, 'history_page' ) );
+        add_submenu_page( 'bolaox', __( 'Estatísticas', self::TEXT_DOMAIN ), __( 'Estatísticas', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-stats', array( $this, 'stats_page' ) );
+        add_submenu_page( 'bolaox', __( 'Concursos', self::TEXT_DOMAIN ), __( 'Concursos', self::TEXT_DOMAIN ), 'manage_options', 'edit.php?post_type=bolaox_concurso' );
+        add_submenu_page( 'bolaox', __( 'Logs', self::TEXT_DOMAIN ), __( 'Logs', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-logs', array( $this, 'logs_page' ) );
+        add_submenu_page( 'bolaox', __( 'Logs Gerais', self::TEXT_DOMAIN ), __( 'Logs Gerais', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-general-logs', array( $this, 'general_logs_page' ) );
+        add_menu_page( __( 'Contemplados', self::TEXT_DOMAIN ), __( 'Contemplados', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-contemplados', array( $this, 'contemplados_page' ), 'dashicons-awards' );
+    }
+
+    public function results_page() {
+        $stats = $this->prepare_visit_stats();
+        $total_visits = array_sum( $stats['visits'] );
+        $total_users  = array_sum( $stats['users'] );
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Análises Gerais', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<div class="bolaox-dashboard-analytics">';
+        echo '<div class="bx-info-tabs">';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'USUÁRIOS ONLINE', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $stats['online'] ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'USUÁRIOS HOJE', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $stats['today_views'] ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'VISITAS NOS ÚLTIMOS 15 DIAS', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $total_visits ) . '</strong></div>';
+        $browser_lines = array();
+        $browser_total = array_sum( $stats['browsers']['data'] );
+        for ( $i = 0; $i < 3; $i++ ) {
+            $label = $stats['browsers']['labels'][ $i ] ?? '-';
+            $count = $stats['browsers']['data'][ $i ] ?? 0;
+            $pct   = $browser_total ? round( $count / $browser_total * 100 ) : 0;
+            $browser_lines[] = esc_html( $label ) . ' ' . intval( $pct ) . '%';
+        }
+        $platform_lines = array();
+        $platform_total = array_sum( $stats['platforms']['data'] );
+        for ( $i = 0; $i < 3; $i++ ) {
+            $label = $stats['platforms']['labels'][ $i ] ?? '-';
+            $count = $stats['platforms']['data'][ $i ] ?? 0;
+            $pct   = $platform_total ? round( $count / $platform_total * 100 ) : 0;
+            $platform_lines[] = esc_html( $label ) . ' ' . intval( $pct ) . '%';
+        }
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'NAVEGADORES MAIS USADOS', self::TEXT_DOMAIN ) . '</span><strong>' . implode( '<br>', $browser_lines ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'SISTEMAS OPERACIONAIS MAIS USADOS', self::TEXT_DOMAIN ) . '</span><strong>' . implode( '<br>', $platform_lines ) . '</strong></div>';
+        echo '</div></div>';
+        echo '</div>';
+    }
+
+    public function settings_page() {
+        $days = array(
+            1 => __( 'Segunda', self::TEXT_DOMAIN ),
+            2 => __( 'Terça', self::TEXT_DOMAIN ),
+            3 => __( 'Quarta', self::TEXT_DOMAIN ),
+            4 => __( 'Quinta', self::TEXT_DOMAIN ),
+            5 => __( 'Sexta', self::TEXT_DOMAIN ),
+            6 => __( 'Sábado', self::TEXT_DOMAIN ),
+            7 => __( 'Domingo', self::TEXT_DOMAIN ),
+        );
+        if ( isset( $_POST['bolaox_nonce'] ) && wp_verify_nonce( $_POST['bolaox_nonce'], 'bolaox_settings' ) ) {
+            if ( isset( $_POST['bolaox_cutoffs'] ) && is_array( $_POST['bolaox_cutoffs'] ) ) {
+                $new = array();
+                foreach ( $days as $idx => $label ) {
+                    $t = isset( $_POST['bolaox_cutoffs'][ $idx ] ) ? sanitize_text_field( $_POST['bolaox_cutoffs'][ $idx ] ) : '';
+                    $new[ $idx ] = $t;
+                }
+                update_option( 'bolaox_cutoffs', $new );
+            }
+            update_option( 'bolaox_mp_prod_public', sanitize_text_field( $_POST['bolaox_mp_prod_public'] ?? '' ) );
+            update_option( 'bolaox_mp_prod_token', sanitize_text_field( $_POST['bolaox_mp_prod_token'] ?? '' ) );
+            update_option( 'bolaox_mp_test_public', sanitize_text_field( $_POST['bolaox_mp_test_public'] ?? '' ) );
+            update_option( 'bolaox_mp_test_token', sanitize_text_field( $_POST['bolaox_mp_test_token'] ?? '' ) );
+            update_option( 'bolaox_pix_key', sanitize_text_field( $_POST['bolaox_pix_key'] ?? '' ) );
+            $mode = in_array( $_POST['bolaox_mp_mode'] ?? 'test', array( 'prod', 'test' ), true ) ? $_POST['bolaox_mp_mode'] : 'test';
+            update_option( 'bolaox_mp_mode', $mode );
+            if ( isset( $_POST['bolaox_price'] ) ) {
+                $price = floatval( sanitize_text_field( $_POST['bolaox_price'] ) );
+                if ( $price <= 0 ) {
+                    $price = 10;
+                }
+                update_option( 'bolaox_price', $price );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Configurações salvas.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        $cutoffs = get_option( 'bolaox_cutoffs', array() );
+        $prod_public = get_option( 'bolaox_mp_prod_public', '' );
+        $prod_token  = get_option( 'bolaox_mp_prod_token', '' );
+        $test_public = get_option( 'bolaox_mp_test_public', '' );
+        $test_token  = get_option( 'bolaox_mp_test_token', '' );
+        $mode        = get_option( 'bolaox_mp_mode', 'test' );
+        $pix_key     = get_option( 'bolaox_pix_key', '' );
+        $price       = get_option( 'bolaox_price', 10 );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Configurações', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<form method="post">';
+        wp_nonce_field( 'bolaox_settings', 'bolaox_nonce' );
+        echo '<h2>' . esc_html__( 'Horários de Restrição de Apostas', self::TEXT_DOMAIN ) . '</h2>';
+        echo '<table class="form-table bolaox-cutoffs"><tbody>';
+        foreach ( $days as $idx => $label ) {
+            $val = isset( $cutoffs[ $idx ] ) ? $cutoffs[ $idx ] : '';
+            echo '<tr><th scope="row">' . esc_html( $label ) . '</th><td>';
+            echo '<input type="time" name="bolaox_cutoffs[' . $idx . ']" value="' . esc_attr( $val ) . '" /></td></tr>';
+        }
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Produção', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_prod_public" value="' . esc_attr( $prod_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_prod_token" value="' . esc_attr( $prod_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Teste', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_test_public" value="' . esc_attr( $test_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_test_token" value="' . esc_attr( $test_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Modo ativo', self::TEXT_DOMAIN ) . '</th><td><select name="bolaox_mp_mode">';
+        echo '<option value="test"' . selected( $mode, 'test', false ) . '>Teste</option>';
+        echo '<option value="prod"' . selected( $mode, 'prod', false ) . '>Produção</option>';
+        echo '</select></td></tr>';
+        $nonce = wp_create_nonce( 'wp_rest' );
+        echo '<tr><th scope="row">' . esc_html__( 'Validar credenciais', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<button type="button" class="button bolaox-validate-creds" data-nonce="' . esc_attr( $nonce ) . '">' . esc_html__( 'Validar', self::TEXT_DOMAIN ) . '</button> <span class="bolaox-valid-msg"></span>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Chave Pix para exibir', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<input type="text" name="bolaox_pix_key" value="' . esc_attr( $pix_key ) . '" class="regular-text" />';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Preço da aposta (R$)', self::TEXT_DOMAIN ) . '</th><td><input type="number" step="0.01" name="bolaox_price" value="' . esc_attr( $price ) . '" /></td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form></div>';
+    }
+
+    public function import_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Importar Apostas via CSV', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_import_nonce'] ) && wp_verify_nonce( $_POST['bolaox_import_nonce'], 'bolaox_import' ) && ! empty( $_FILES['bolaox_csv']['tmp_name'] ) ) {
+            $count = 0;
+            $fh = fopen( $_FILES['bolaox_csv']['tmp_name'], 'r' );
+            if ( $fh ) {
+                while ( ( $data = fgetcsv( $fh ) ) !== false ) {
+                    if ( count( $data ) < 11 ) {
+                        continue;
+                    }
+                    $name = array_shift( $data );
+                    $numbers = implode( ',', $data );
+                    $numbers = $this->validate_numbers( $numbers );
+                    if ( false === $numbers ) {
+                        continue;
+                    }
+                    $post_id = wp_insert_post( array(
+                        'post_type'   => 'bolaox_aposta',
+                        'post_title'  => sanitize_text_field( $name ),
+                        'post_status' => 'publish',
+                        'post_author' => get_current_user_id(),
+                    ) );
+                    if ( $post_id ) {
+                        update_post_meta( $post_id, '_bolaox_numbers', $numbers );
+                        update_post_meta( $post_id, '_bolaox_fixed', '1' );
+                        if ( get_current_user_id() ) {
+                            update_post_meta( $post_id, '_bolaox_user', get_current_user_id() );
+                        }
+                        $count++;
+                    }
+                }
+                fclose( $fh );
+            }
+            echo '<div class="updated"><p>' . sprintf( esc_html__( 'Importadas %d apostas.', self::TEXT_DOMAIN ), intval( $count ) ) . '</p></div>';
+        }
+        echo '<form method="post" enctype="multipart/form-data">';
+        wp_nonce_field( 'bolaox_import', 'bolaox_import_nonce' );
+        echo '<input type="file" name="bolaox_csv" accept="text/csv" required /> ';
+        submit_button( __( 'Importar', self::TEXT_DOMAIN ) );
+        echo '</form></div>';
+    }
+
+    public function history_page() {
+        if ( isset( $_GET['export'] ) ) {
+            $id = intval( $_GET['export'] );
+            $numbers = get_post_meta( $id, '_bolaox_result', true );
+            if ( $numbers ) {
+                if ( isset( $_GET['type'] ) && 'pdf' === $_GET['type'] ) {
+                    $this->export_pdf( $numbers );
+                } elseif ( isset( $_GET['type'] ) && 'xls' === $_GET['type'] ) {
+                    $this->export_xls( $numbers );
+                } else {
+                    $this->export_csv( $numbers );
+                }
+            }
+        }
+        $posts = get_posts( array( 'post_type' => 'bolaox_result', 'numberposts' => -1, 'orderby' => 'date', 'order' => 'DESC' ) );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Histórico de Resultados', self::TEXT_DOMAIN ) . '</h1>';
+        if ( ! $posts ) {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        echo '<table class="widefat"><thead><tr><th>Data</th><th>Resultado</th><th>Ações</th></tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            $base = admin_url( 'admin.php?page=bolaox-history&export=' . $p->ID );
+            $csv  = esc_url( $base . '&type=csv' );
+            $xls  = esc_url( $base . '&type=xls' );
+            $pdf  = esc_url( $base . '&type=pdf' );
+            echo '<tr><td>' . esc_html( get_the_date( '', $p ) ) . '</td><td>' . esc_html( $nums ) . '</td><td><a class="button" href="' . $csv . '">CSV</a> <a class="button" href="' . $xls . '">Excel</a> <a class="button" href="' . $pdf . '">PDF</a></td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function stats_page() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            echo '<div class="wrap"><h1>' . esc_html__( 'Estatísticas', self::TEXT_DOMAIN ) . '</h1><p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $total = array_sum( $counts );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Estatísticas de Frequência', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Dezena', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Ocorrências', self::TEXT_DOMAIN ) . '</th><th>%</th></tr></thead><tbody>';
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 0 ) {
+                $num  = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+                $perc = round( ( $counts[ $i ] / $total ) * 100 );
+                $bar  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $perc . '" data-progress="' . $perc . '%"><span style="width:' . $perc . '%"></span></div>';
+                echo '<tr><td>' . $num . '</td><td>' . $counts[ $i ] . '</td><td>' . $bar . '</td></tr>';
+            }
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function logs_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Logs de Pagamento', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_clear_logs'] ) && check_admin_referer( 'bolaox_clear_logs' ) ) {
+            if ( file_exists( $this->log_file ) ) {
+                file_put_contents( $this->log_file, '' );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Logs limpos.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        if ( file_exists( $this->log_file ) && filesize( $this->log_file ) ) {
+            $content = file_get_contents( $this->log_file );
+            echo '<textarea readonly rows="20" style="width:100%">' . esc_textarea( $content ) . '</textarea>';
+            echo '<form method="post">';
+            wp_nonce_field( 'bolaox_clear_logs' );
+            echo '<p><input type="submit" name="bolaox_clear_logs" class="button" value="' . esc_attr__( 'Limpar logs', self::TEXT_DOMAIN ) . '" /></p>';
+            echo '</form>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum log encontrado.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        echo '</div>';
+    }
+
+    public function general_logs_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Logs Gerais', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_clear_general'] ) && check_admin_referer( 'bolaox_clear_general' ) ) {
+            if ( file_exists( $this->general_log_file ) ) {
+                file_put_contents( $this->general_log_file, '' );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Logs limpos.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        if ( file_exists( $this->general_log_file ) && filesize( $this->general_log_file ) ) {
+            $content = file_get_contents( $this->general_log_file );
+            echo '<textarea readonly rows="20" style="width:100%">' . esc_textarea( $content ) . '</textarea>';
+            echo '<form method="post">';
+            wp_nonce_field( 'bolaox_clear_general' );
+            echo '<p><input type="submit" name="bolaox_clear_general" class="button" value="' . esc_attr__( 'Limpar logs', self::TEXT_DOMAIN ) . '" /></p>';
+            echo '</form>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum log encontrado.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        echo '</div>';
+    }
+
+    public function pending_payments_menu() {
+        add_submenu_page(
+            'edit.php?post_type=bolaox_aposta',
+            __( 'Pagamentos não confirmados', self::TEXT_DOMAIN ),
+            __( 'Pagamentos não confirmados', self::TEXT_DOMAIN ),
+            'manage_options',
+            'bolaox-pending',
+            array( $this, 'pending_payments_page' )
+        );
+    }
+
+    public function pending_payments_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Pagamentos via Pix não confirmados', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_mark_paid'], $_POST['post_id'] ) && check_admin_referer( 'bolaox_mark_paid_' . intval( $_POST['post_id'] ) ) ) {
+            update_post_meta( intval( $_POST['post_id'] ), '_bolaox_payment', 'paid' );
+            echo '<div class="updated"><p>' . esc_html__( 'Pagamento marcado como pago.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        $contest = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        $posts   = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_payment', 'value' => 'pending' ),
+                array( 'key' => '_bolaox_concurso', 'value' => $contest ),
+            ),
+        ) );
+        if ( ! $posts ) {
+            echo '<p>' . esc_html__( 'Nenhum pagamento pendente.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Aposta', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Ações', self::TEXT_DOMAIN ) . '</th></tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            echo '<tr><td>' . esc_html( $p->post_title ) . '</td><td>' . esc_html( $nums ) . '</td><td>';
+            echo '<form method="post" style="display:inline">';
+            wp_nonce_field( 'bolaox_mark_paid_' . $p->ID );
+            echo '<input type="hidden" name="post_id" value="' . $p->ID . '" />';
+            echo '<input type="submit" name="bolaox_mark_paid" class="button" value="' . esc_attr__( 'Marcar como pago', self::TEXT_DOMAIN ) . '" />';
+            echo '</form></td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function contemplados_page() {
+        $selected = isset( $_GET['contest'] ) ? intval( $_GET['contest'] ) : 0;
+        $order    = isset( $_GET['orderby'] ) && 'date' === $_GET['orderby'] ? 'date' : 'score';
+        $contests = get_posts( array(
+            'post_type'   => 'bolaox_concurso',
+            'numberposts' => -1,
+            'orderby'     => 'date',
+            'order'       => 'DESC',
+        ) );
+
+        $active   = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        if ( ! $selected ) {
+            $selected = $active;
+        }
+
+        echo '<div class="wrap bolaox-contemplados"><h1>' . esc_html__( 'Contemplados', self::TEXT_DOMAIN ) . '</h1>';
+
+        if ( ! $contests ) {
+            echo '<p>' . esc_html__( 'Nenhum concurso cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        echo '<form method="get" class="bolaox-contest-form" style="margin-bottom:15px">';
+        echo '<input type="hidden" name="page" value="bolaox-contemplados" />';
+        echo '<label>' . esc_html__( 'Filtrar por Concurso', self::TEXT_DOMAIN ) . ' ';
+        echo '<select name="contest">';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '"' . selected( $selected, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select></label> ';
+        echo '<label>' . esc_html__( 'Ordenar por', self::TEXT_DOMAIN ) . ' ';
+        echo '<select name="orderby">';
+        echo '<option value="score"' . selected( $order, 'score', false ) . '>' . esc_html__( 'Pontuação', self::TEXT_DOMAIN ) . '</option>';
+        echo '<option value="date"' . selected( $order, 'date', false ) . '>' . esc_html__( 'Data', self::TEXT_DOMAIN ) . '</option>';
+        echo '</select></label> ';
+        submit_button( __( 'Filtrar', self::TEXT_DOMAIN ), 'secondary', '', false );
+        echo '</form>';
+
+        if ( ! $selected ) {
+            echo '<p>' . esc_html__( 'Nenhum concurso ativo.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        if ( isset( $_GET['export'] ) ) {
+            $result_post = get_posts( array(
+                'post_type'   => 'bolaox_result',
+                'numberposts' => 1,
+                'post_status' => 'publish',
+                'meta_query'  => array(
+                    array( 'key' => '_bolaox_concurso', 'value' => $selected ),
+                ),
+            ) );
+            if ( $result_post ) {
+                $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_result', true );
+                $this->export_csv( $numbers );
+            }
+        }
+
+        $result_post = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'numberposts' => 1,
+            'post_status' => 'publish',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $selected ),
+            ),
+        ) );
+        if ( ! $result_post ) {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_result', true );
+        echo '<h2>' . sprintf( esc_html__( 'Resultado do Concurso %s', self::TEXT_DOMAIN ), get_the_title( $selected ) ) . '</h2>';
+        $export_link = esc_url( admin_url( 'admin.php?page=bolaox-contemplados&contest=' . $selected . '&orderby=' . $order . '&export=1' ) );
+        echo '<p><a class="button" href="' . $export_link . '">' . esc_html__( 'Exportar Relatório', self::TEXT_DOMAIN ) . '</a></p>';
+        echo $this->generate_report( $numbers, $selected, $order );
+        echo '</div>';
+    }
+
+
+    public function clear_pending_payments( $post_id, $post, $update ) {
+        if ( 'publish' !== $post->post_status ) {
+            return;
+        }
+        $contest = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        if ( ! $contest ) {
+            return;
+        }
+        $pending = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'fields'      => 'ids',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest ),
+                array( 'key' => '_bolaox_payment', 'value' => 'paid', 'compare' => '!=' ),
+            ),
+        ) );
+        foreach ( $pending as $pid ) {
+            wp_delete_post( $pid, true );
+        }
+    }
+
+    private function generate_report( $result, $contest_id = 0, $order_by = 'score' ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $args = array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+        );
+        if ( $contest_id ) {
+            $args['meta_query'] = array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $rows = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            $hits    = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            $percentage = $hit_count * 10;
+            $progress  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $percentage . '" data-progress="' . $percentage . '%" style="--progress:' . $percentage . '%">';
+            $progress .= '<span></span></div>';
+            $duplicates = array_unique( array_diff_assoc( $nums, array_unique( $nums ) ) );
+            $display_nums = array();
+            foreach ( $nums as $n ) {
+                $n = trim( $n );
+                $classes = array( 'bolaox-number' );
+                if ( in_array( $n, $duplicates ) ) {
+                    $classes[] = 'dup';
+                }
+                if ( in_array( $n, $res_numbers ) ) {
+                    $classes[] = 'hit';
+                }
+                $display_nums[] = sprintf(
+                    '<span class="%s">%s</span>',
+                    esc_attr( implode( ' ', $classes ) ),
+                    esc_html( $n )
+                );
+            }
+            $class = '';
+            if ( $hit_count >= 8 ) {
+                $class = ' class="bolaox-hit-' . $hit_count . '"';
+            }
+            $rows[] = array(
+                'id'      => $p->ID,
+                'hits'    => $hit_count,
+                'date'    => $p->post_date,
+                'class'   => $class,
+                'name'    => esc_html( $p->post_title ),
+                'progress' => $progress,
+                'numbers' => implode( '', $display_nums ),
+            );
+        }
+
+        if ( 'date' === $order_by ) {
+            usort( $rows, function ( $a, $b ) {
+                return strcmp( $b['date'], $a['date'] );
+            } );
+        } else {
+            usort( $rows, function ( $a, $b ) {
+                return $b['hits'] <=> $a['hits'];
+            } );
+        }
+        $max_hits = $rows ? max( wp_list_pluck( $rows, 'hits' ) ) : 0;
+        $min_hits = $rows ? min( wp_list_pluck( $rows, 'hits' ) ) : 0;
+
+        $out = '';
+        $winners_high = array_filter(
+            $rows,
+            function ( $row ) use ( $max_hits ) {
+                return $row['hits'] === $max_hits;
+            }
+        );
+        $winners_low  = array_filter(
+            $rows,
+            function ( $row ) use ( $min_hits ) {
+                return $row['hits'] === $min_hits;
+            }
+        );
+
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'VENCEDORES COM MAIS PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $winners_high );
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'VENCEDORES COM MENOS PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $winners_low );
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'TODAS AS APOSTAS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $rows );
+
+        $total = count( $rows );
+        $avg   = $total ? array_sum( wp_list_pluck( $rows, 'hits' ) ) / $total : 0;
+        $rate  = $avg ? ( $avg / 10 ) * 100 : 0;
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'ESTATÍSTICAS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<ul class="bolaox-stats">';
+        $out .= '<li>' . sprintf( esc_html__( 'Total de Participantes: %d', self::TEXT_DOMAIN ), $total ) . '</li>';
+        $out .= '<li>' . sprintf( esc_html__( 'Média de Pontos: %.2f', self::TEXT_DOMAIN ), $avg ) . '</li>';
+        $out .= '<li>' . sprintf( esc_html__( 'Taxa de Acerto: %s%%', self::TEXT_DOMAIN ), round( $rate ) ) . '</li>';
+        $out .= '</ul>';
+
+        return $this->wrap_app( $out );
+    }
+
+    private function build_results_table( $rows ) {
+        if ( ! $rows ) {
+            return '<p>' . esc_html__( 'Nenhum vencedor.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        $out  = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table"><thead><tr><th>#</th><th>' . esc_html__( 'Apostador', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Acertos', self::TEXT_DOMAIN ) . '</th><th class="col-percent">%</th><th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th></tr></thead><tbody>';
+        $idx  = 1;
+        foreach ( $rows as $row ) {
+            $num   = str_pad( strval( $idx++ ), 2, '0', STR_PAD_LEFT );
+            $out  .= '<tr' . $row['class'] . '><td class="col-index">' . $num . '</td><td class="col-name">' . $row['name'] . '</td><td>' . $row['hits'] . '</td><td class="col-percent">' . $row['progress'] . '</td><td class="bolaox-numlist">' . $row['numbers'] . '</td></tr>';
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    private function export_csv( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        header( 'Content-Type: text/csv' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.csv"' );
+        echo "Aposta,Acertos,Dezenas\n";
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            $title     = str_replace( '"', '""', $p->post_title );
+            echo '"' . $title . '",' . $hit_count . ',"' . implode( ' ', $nums ) . '"' . "\n";
+        }
+        exit;
+    }
+
+    private function export_xls( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        header( 'Content-Type: application/vnd.ms-excel' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.xls"' );
+        echo "Aposta\tAcertos\tDezenas\n";
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            echo $p->post_title . "\t" . $hit_count . "\t" . implode( ' ', $nums ) . "\n";
+        }
+        exit;
+    }
+
+    private function export_pdf( $result ) {
+        require_once __DIR__ . '/lib/fpdf.php';
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        $pdf = new FPDF();
+        $pdf->AddPage();
+        $pdf->SetFont( 'Arial', 'B', 14 );
+        $pdf->Cell( 0, 10, __( 'Relatorio de Apostas', self::TEXT_DOMAIN ), 0, 1, 'C' );
+        $pdf->Ln( 2 );
+        $pdf->SetFont( 'Arial', 'B', 12 );
+        $pdf->Cell( 60, 8, __( 'Aposta', self::TEXT_DOMAIN ), 1 );
+        $pdf->Cell( 30, 8, __( 'Acertos', self::TEXT_DOMAIN ), 1, 0, 'C' );
+        $pdf->Cell( 0, 8, __( 'Dezenas', self::TEXT_DOMAIN ), 1, 1 );
+        $pdf->SetFont( 'Arial', '', 12 );
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            $pdf->Cell( 60, 8, $p->post_title, 1 );
+            $pdf->Cell( 30, 8, $hit_count, 1, 0, 'C' );
+            $pdf->Cell( 0, 8, implode( ' ', $nums ), 1, 1 );
+        }
+        $pdf->Output( 'D', 'bolao-resultados.pdf' );
+        exit;
+    }
+
+    private function export_json( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        $rows = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            $hits    = count( array_intersect( $res_numbers, $nums ) );
+            $rows[] = array(
+                'aposta'  => $p->post_title,
+                'acertos' => $hits,
+                'dezenas' => $nums,
+            );
+        }
+        header( 'Content-Type: application/json' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.json"' );
+        echo wp_json_encode( $rows );
+        exit;
+    }
+
+    private function send_results_email( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        foreach ( $posts as $p ) {
+            $user = get_user_by( 'ID', $p->post_author );
+            if ( ! $user || ! is_email( $user->user_email ) ) {
+                continue;
+            }
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            $hits    = count( array_intersect( $res_numbers, $nums ) );
+            $message  = sprintf( __( 'Olá %s,', self::TEXT_DOMAIN ), $p->post_title ) . "\n\n";
+            $message .= sprintf( __( 'O resultado da semana foi: %s', self::TEXT_DOMAIN ), $result ) . "\n";
+            $message .= sprintf( __( 'Sua aposta: %s', self::TEXT_DOMAIN ), implode( ',', $nums ) ) . "\n";
+            $message .= sprintf( __( 'Acertos: %d', self::TEXT_DOMAIN ), $hits ) . "\n";
+            if ( $hits >= 8 ) {
+                $message .= sprintf( __( 'Parabéns! Você acertou %d dezenas.', self::TEXT_DOMAIN ), $hits );
+            }
+            wp_mail( $user->user_email, __( 'Resultado do Bolão', self::TEXT_DOMAIN ), $message );
+        }
+    }
+
+    private function update_lowest_info( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            update_option( 'bolaox_lowest_info', array( 'id' => 0, 'hits' => 0, 'pool' => 0 ) );
+            return;
+        }
+        $min = null;
+        $ids = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums = array_map( 'trim', explode( ',', $numbers ) );
+            $hits = count( array_intersect( $res_numbers, $nums ) );
+            if ( null === $min || $hits < $min ) {
+                $min = $hits;
+                $ids = array( $p->ID );
+            } elseif ( $hits === $min ) {
+                $ids[] = $p->ID;
+            }
+        }
+        $info = get_option( 'bolaox_lowest_info', array( 'id' => 0, 'hits' => 0, 'pool' => 0 ) );
+        if ( count( $ids ) === 1 ) {
+            $info = array( 'id' => $ids[0], 'hits' => $min, 'pool' => 0 );
+        } else {
+            $pool = isset( $info['pool'] ) ? intval( $info['pool'] ) : 0;
+            $info = array( 'id' => 0, 'hits' => $min, 'pool' => $pool + 1 );
+        }
+        update_option( 'bolaox_lowest_info', $info );
+    }
+
+    private function render_number_board( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $out = '<div class="bolaox-scroll"><div class="bolaox-board">';
+        for ( $i = 0; $i < 100; $i++ ) {
+            $num   = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+            $class = 'bolaox-number';
+            if ( in_array( $num, $res_numbers, true ) ) {
+                $class .= ' drawn';
+            }
+            $out .= '<span class="' . $class . '">' . esc_html( $num ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function render_repeated_numbers( $contest_id = 0 ) {
+        $args = array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+        );
+        if ( $contest_id ) {
+            $args['meta_query'] = array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return '';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $nums = array_map( 'trim', explode( ',', get_post_meta( $p->ID, '_bolaox_numbers', true ) ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $dups = array();
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 1 ) {
+                $dups[] = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+            }
+        }
+        if ( ! $dups ) {
+            return '';
+        }
+        $out  = '<h3>' . esc_html__( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<div class="bolaox-scroll"><div class="bolaox-board">';
+        foreach ( $dups as $n ) {
+            $out .= '<span class="bolaox-number">' . esc_html( $n ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function render_recent_repeated_numbers() {
+        $posts = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            // Analyze the last 12 draws so statistics reset every dozen contests
+            'numberposts' => 12,
+            'post_status' => 'publish',
+            'orderby'     => 'date',
+            'order'       => 'DESC',
+        ) );
+        if ( ! $posts ) {
+            return '';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            }
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $repeats = array();
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 1 ) {
+                $repeats[ $i ] = $counts[ $i ];
+            }
+        }
+        if ( ! $repeats ) {
+            return '';
+        }
+        arsort( $repeats );
+        $out  = '<h3>' . esc_html__( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<div class="bolaox-scroll"><div class="bolaox-board">';
+        foreach ( array_keys( $repeats ) as $n ) {
+            $out .= '<span class="bolaox-number">' . str_pad( strval( $n ), 2, '0', STR_PAD_LEFT ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function wrap_app( $html ) {
+        $logged = is_user_logged_in();
+        $class  = $logged ? 'bx-logged-in' : 'bx-logged-out';
+        $attr   = $logged ? '1' : '0';
+        return '<div class="bolaox-app ' . $class . '" data-logged-in="' . $attr . '">' . $html . '</div>';
+    }
+
+    public function render_form_shortcode() {
+        $this->maybe_restore_session();
+        $cutoffs  = get_option( 'bolaox_cutoffs', array() );
+        $countdown = '';
+        $contest_id = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        $now = current_time( 'timestamp' );
+        if ( ! $contest_id ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum concurso ativo.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $start = get_post_meta( $contest_id, '_bolaox_start', true );
+        $end   = get_post_meta( $contest_id, '_bolaox_end', true );
+        if ( $start && $now < strtotime( $start ) ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Apostas ainda não liberadas.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        if ( $end && $now >= strtotime( $end ) ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Apostas encerradas. Tente novamente no próximo concurso.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $price   = floatval( get_option( 'bolaox_price', 10 ) );
+        $raw_key = get_option( 'bolaox_pix_key', '' );
+        $pix_key = is_string( $raw_key ) ? trim( $raw_key ) : '';
+        $msg     = '';
+        if ( $cutoffs ) {
+            $day  = (int) date( 'N', $now );
+            if ( ! empty( $cutoffs[ $day ] ) ) {
+                $cutoff_ts = strtotime( date( 'Y-m-d ' . $cutoffs[ $day ], $now ) );
+                if ( $now >= $cutoff_ts ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Apostas encerradas. Tente novamente no próximo concurso.', self::TEXT_DOMAIN ) . '</p>' );
+                }
+                $countdown = '<div class="bolaox-countdown" data-end="' . esc_attr( $cutoff_ts ) . '" data-expired="' . esc_attr__( 'Tempo esgotado', self::TEXT_DOMAIN ) . '"></div>';
+            }
+        }
+        $pix        = array();
+        $payment_id = '';
+
+        if ( isset( $_POST['bolaox_submit'] ) && isset( $_POST['bolaox_nonce'] ) && wp_verify_nonce( $_POST['bolaox_nonce'], 'bolaox_form' ) ) {
+            $numbers_raw = isset( $_POST['bolaox_numbers'] ) ? (array) $_POST['bolaox_numbers'] : array();
+            $valid_sets  = array();
+            foreach ( $numbers_raw as $set ) {
+                $clean = $this->validate_numbers( sanitize_text_field( $set ) );
+                if ( false === $clean ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN ) . '</p>' );
+                }
+                $valid_sets[] = $clean;
+            }
+            $qty        = count( $valid_sets );
+            $payment_id = sanitize_text_field( $_POST['bolaox_payment_id'] );
+            $status = 'paid';
+            if ( ! $this->verify_mp_payment( $payment_id, $price * $qty ) ) {
+                $status      = 'pending';
+                $msg         = '<p class="bolaox-error">' . esc_html__( 'Pagamento via Pix não confirmado.', self::TEXT_DOMAIN ) . '</p>';
+                $pix         = $this->create_mp_pix_payment( 'tmp-' . wp_generate_password( 8, false, false ), $qty );
+                $payment_id  = isset( $pix['id'] ) ? $pix['id'] : '';
+            }
+            $name = sanitize_text_field( $_POST['bolaox_name'] );
+            $i    = 1;
+            foreach ( $valid_sets as $set ) {
+                $title   = $qty > 1 ? $name . ' #' . $i : $name;
+                $post_id = wp_insert_post( array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => $title,
+                    'post_status' => 'publish',
+                    'post_author' => get_current_user_id(),
+                ) );
+                if ( $post_id ) {
+                    update_post_meta( $post_id, '_bolaox_numbers', $set );
+                    update_post_meta( $post_id, '_bolaox_payment', $status );
+                    update_post_meta( $post_id, '_bolaox_mp_pref', $payment_id );
+                    update_post_meta( $post_id, '_bolaox_concurso', $contest_id );
+                    update_post_meta( $post_id, '_bolaox_fixed', '0' );
+                    if ( get_current_user_id() ) {
+                        update_post_meta( $post_id, '_bolaox_user', get_current_user_id() );
+                    }
+                }
+                $i++;
+            }
+            if ( 'paid' === $status ) {
+                $msg  = '<h3 class="bolaox-success-title">' . esc_html__( 'Aposta registrada com sucesso!', self::TEXT_DOMAIN ) . '</h3>';
+                foreach ( $valid_sets as $set ) {
+                    $msg .= '<div class="bolaox-numlist">';
+                    foreach ( array_map( 'trim', explode( ',', $set ) ) as $n ) {
+                        $msg .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+                    }
+                    $msg .= '</div>';
+                }
+                return $this->wrap_app( $msg );
+            }
+        }
+
+        $html  = '<div class="bolaox-form">';
+        if ( $msg ) {
+            $html .= $msg;
+        }
+        $html .= '<div id="bolaox-pix-modal" class="bolaox-modal"><div class="bolaox-modal-content">';
+        $src = '';
+        $code = '';
+        if ( $pix ) {
+            if ( ! empty( $pix['qr_code_base64'] ) ) {
+                $src  = 'data:image/png;base64,' . $pix['qr_code_base64'];
+            } elseif ( ! empty( $pix['qr_code'] ) ) {
+                $src  = 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=' . rawurlencode( $pix['qr_code'] );
+            }
+            $code = isset( $pix['qr_code'] ) ? $pix['qr_code'] : '';
+        }
+        $html .= '<p><img src="' . esc_attr( $src ) . '" alt="Pix QR" width="500" height="500" /></p>';
+        $html .= '<p>' . esc_html__( 'Copie o Código:', self::TEXT_DOMAIN ) . '<br />';
+        $html .= '<input type="text" id="bolaox-pix-code" value="' . esc_attr( $code ) . '" readonly class="bolaox-pix-code" />';
+        $html .= '<button type="button" class="button bolaox-copy" data-target="#bolaox-pix-code">' . esc_html__( 'Copiar', self::TEXT_DOMAIN ) . '</button></p>';
+        $html .= '<p><span class="button bolaox-modal-close">' . esc_html__( 'Fechar', self::TEXT_DOMAIN ) . '</span></p></div></div>';
+
+        $html .= '<form method="post" class="bolaox-form-inner">';
+        if ( $countdown ) {
+            $html .= $countdown;
+        }
+        $html .= wp_nonce_field( 'bolaox_form', 'bolaox_nonce', true, false );
+        $html .= '<input type="hidden" name="bolaox_payment_id" value="' . esc_attr( $payment_id ) . '" />';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Como quer ser chamado?', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_name" required /></label></p>';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Escolha 10 dezenas', self::TEXT_DOMAIN ) . '</label>';
+        $html .= '<div class="bolaox-numbers">';
+        for ( $i = 0; $i < 100; $i++ ) {
+            $num = str_pad( (string) $i, 2, '0', STR_PAD_LEFT );
+            $html .= '<span class="bolaox-number">' . esc_html( $num ) . '</span>';
+        }
+        $html .= '<input type="hidden" class="bolaox-current" />';
+        $html .= '</div></p>';
+        $html .= '<p><button type="button" class="button bolaox-add-bet" data-label-init="' . esc_attr__( 'Adicionar Jogo', self::TEXT_DOMAIN ) . '" data-label-more="' . esc_attr__( 'Adicionar mais um Jogo', self::TEXT_DOMAIN ) . '">' . esc_html__( 'Adicionar Jogo', self::TEXT_DOMAIN ) . '</button></p>';
+        $html .= '<div class="bolaox-cart"></div>';
+        $html .= '<p><a href="#" class="button bolaox-pix-btn" data-target="#bolaox-pix-modal">' . esc_html__( 'PAGAR COM PIX', self::TEXT_DOMAIN ) . '</a></p>';
+        $html .= '<p class="bolaox-price" data-price="' . esc_attr( number_format( $price, 2, '.', '' ) ) . '">' . sprintf( esc_html__( 'Valor total: R$ %s', self::TEXT_DOMAIN ), number_format( $price, 2, ',', '.' ) ) . '</p>';
+        $html .= '<p class="bolaox-field"><input type="submit" name="bolaox_submit" value="' . esc_attr__( 'APOSTE AGORA', self::TEXT_DOMAIN ) . '" class="button bolaox-submit" /></p>';
+        $html .= '</form></div>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_results_shortcode() {
+        if ( isset( $_GET['bolaox_all_results'] ) ) {
+            return $this->render_all_results_shortcode();
+        }
+
+        $posts = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'numberposts' => 3,
+            'post_status' => 'publish',
+            'orderby'     => 'date',
+            'order'       => 'DESC',
+        ) );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+
+        $first_nums    = '';
+        $first_contest = 0;
+        $output  = '<div class="bolaox-result">';
+        $output .= '<h3>' . esc_html__( 'ÚLTIMOS RESULTADOS', self::TEXT_DOMAIN ) . '</h3>';
+        foreach ( $posts as $index => $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            }
+            if ( 0 === $index ) {
+                $first_nums    = $nums;
+                $first_contest = intval( get_post_meta( $p->ID, '_bolaox_concurso', true ) );
+            }
+            $title = get_the_title( $p );
+            $output .= '<h4 class="bolaox-result-title">' . esc_html( $title ) . '</h4>';
+            $output .= $this->render_number_board( $nums );
+        }
+        $link   = add_query_arg( 'bolaox_all_results', 1, get_permalink() );
+        $output .= '<p class="bolaox-center"><a href="' . esc_url( $link ) . '" class="bolaox-button bolaox-view-all">' . esc_html__( 'VER TODOS RESULTADOS', self::TEXT_DOMAIN ) . '</a></p>';
+        $output .= $this->render_recent_repeated_numbers();
+        $output .= $this->generate_report( $first_nums, $first_contest, 'score' );
+        $output .= '</div>';
+        return $this->wrap_app( $output );
+    }
+
+    private function render_all_results_shortcode() {
+        $paged    = max( 1, intval( get_query_var( 'bolaox_page' ) ) );
+        $per_page = 6;
+        $query    = new WP_Query( array(
+            'post_type'      => 'bolaox_result',
+            'post_status'    => 'publish',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'posts_per_page' => $per_page,
+            'paged'          => $paged,
+        ) );
+        if ( ! $query->have_posts() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $out = '<ul class="bolaox-history">';
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $nums = get_post_meta( get_the_ID(), '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( get_the_ID(), '_bolaox_numbers', true );
+            }
+            $numlist = '';
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $numlist .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+            }
+            $out .= '<li class="bolaox-history-item"><h3 class="bolaox-history-date">' . esc_html( get_the_title() ) . '</h3><div class="bolaox-scroll"><div class="bolaox-numlist">' . $numlist . '</div></div></li>';
+        }
+        wp_reset_postdata();
+        $out .= '</ul>';
+        $total = $query->max_num_pages;
+        if ( $total > 1 ) {
+            $out .= '<div class="bolaox-pagination">';
+            for ( $i = 1; $i <= $total; $i++ ) {
+                $url   = esc_url( add_query_arg( 'bolaox_page', $i ) );
+                $class = $i === $paged ? ' class="current"' : '';
+                $out  .= '<a href="' . $url . '"' . $class . '>' . $i . '</a> ';
+            }
+            $out .= '</div>';
+        }
+        return $this->wrap_app( $out );
+    }
+
+    public function render_history_shortcode() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_result', 'numberposts' => 5, 'orderby' => 'date', 'order' => 'DESC' ) );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $out = '<ul class="bolaox-history">';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            $date = esc_html( get_the_date( '', $p ) );
+            $numlist = '';
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $numlist .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+            }
+            $out .= '<li class="bolaox-history-item"><h3 class="bolaox-history-date">' . $date . '</h3><div class="bolaox-scroll"><div class="bolaox-numlist">' . $numlist . '</div></div></li>';
+        }
+        $out .= '</ul>';
+        return $this->wrap_app( $out );
+    }
+
+    private function generate_my_bets_table( $user_id ) {
+        $posts = get_posts(
+            array(
+                'post_type'   => 'bolaox_aposta',
+                'post_status' => 'publish',
+                'numberposts' => -1,
+                'meta_query'  => array(
+                    array( 'key' => '_bolaox_user', 'value' => $user_id ),
+                ),
+                'orderby'     => 'date',
+                'order'       => 'DESC',
+            )
+        );
+        if ( ! $posts ) {
+            $posts = get_posts(
+                array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_status' => 'publish',
+                    'numberposts' => -1,
+                    'author'      => $user_id,
+                    'orderby'     => 'date',
+                    'order'       => 'DESC',
+                )
+            );
+        }
+        if ( ! $posts ) {
+            return '<p>' . esc_html__( 'Você ainda não cadastrou apostas.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        $result      = get_option( 'bolaox_result', '' );
+        $res_numbers = $result ? array_map( 'trim', explode( ',', $result ) ) : array();
+        $out  = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table">';
+        $out .= '<thead><tr>' .
+            '<th>' . esc_html__( 'Aposta', self::TEXT_DOMAIN ) . '</th>' .
+            '<th>' . esc_html__( 'Acertos', self::TEXT_DOMAIN ) . '</th>' .
+            '<th>%</th>' .
+            '<th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th>' .
+            '<th>' . esc_html__( 'Status', self::TEXT_DOMAIN ) . '</th>' .
+        '</tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = $result ? array_intersect( $res_numbers, $nums ) : array();
+            $hit_count = count( $hits );
+            $percentage = $hit_count * 10;
+            $progress     = sprintf(
+                '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$d" data-progress="%1$d%%"><span></span></div>',
+                $percentage
+            );
+            $duplicates   = array_unique( array_diff_assoc( $nums, array_unique( $nums ) ) );
+            $display_nums = array();
+            foreach ( $nums as $n ) {
+                $n = trim( $n );
+                $classes = array( 'bolaox-number' );
+                if ( in_array( $n, $duplicates, true ) ) {
+                    $classes[] = 'dup';
+                }
+                if ( in_array( $n, $res_numbers, true ) ) {
+                    $classes[] = 'hit';
+                }
+                $display_nums[] = sprintf(
+                    '<span class="%s">%s</span>',
+                    esc_attr( implode( ' ', $classes ) ),
+                    esc_html( $n )
+                );
+            }
+            $status = get_post_meta( $p->ID, '_bolaox_payment', true );
+            if ( ! $status ) {
+                $status = 'pending';
+            }
+            $label = 'pending' === $status ? __( 'Pendente', self::TEXT_DOMAIN ) : __( 'Pago', self::TEXT_DOMAIN );
+            $out   .= sprintf(
+                '<tr><td>%s</td><td>%d</td><td>%s</td><td class="bolaox-numlist">%s</td><td>%s</td></tr>',
+                esc_html( $p->post_title ),
+                $hit_count,
+                $progress,
+                implode( '', $display_nums ),
+                esc_html( $label )
+            );
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    public function render_my_bets_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            $redirect = esc_url_raw( $_SERVER['REQUEST_URI'] );
+            $url      = esc_url( add_query_arg( 'redirect_to', rawurlencode( $redirect ), home_url( '/login-cadastro' ) ) );
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $url );
+                exit;
+            }
+            return '<script>window.location.href="' . esc_url( $url ) . '";</script>';
+        }
+
+        if ( ! headers_sent() ) {
+            nocache_headers();
+            if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+                define( 'DONOTCACHEPAGE', true );
+            }
+        }
+        $table = $this->generate_my_bets_table( get_current_user_id() );
+        $url   = esc_url( rest_url( 'bolao-x/v1/mybets' ) );
+        $html  = '<div id="bolaox-my-bets" data-mybets-url="' . $url . '">' . $table . '</div>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_stats_shortcode() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return '<p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $total = array_sum( $counts );
+        $out = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table bolaox-stats"><thead><tr><th>Dezena</th><th>Ocorrências</th><th>%</th></tr></thead><tbody>';
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 0 ) {
+                $num  = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+                $perc = round( ( $counts[ $i ] / $total ) * 100 );
+                $bar  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $perc . '" data-progress="' . $perc . '%"><span style="width:' . $perc . '%"></span></div>';
+                $out .= '<tr><td>' . $num . '</td><td>' . $counts[ $i ] . '</td><td>' . $bar . '</td></tr>';
+            }
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    public function render_profile_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            $redirect = esc_url_raw( $_SERVER['REQUEST_URI'] );
+            $url      = esc_url( add_query_arg( 'redirect_to', rawurlencode( $redirect ), home_url( '/login-cadastro' ) ) );
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $url );
+                exit;
+            }
+            return '<script>window.location.href="' . esc_url( $url ) . '";</script>';
+        }
+        $user      = wp_get_current_user();
+        $avatar_id = get_user_meta( $user->ID, 'bolaox_avatar_id', true );
+        $msg = '';
+        if ( isset( $_POST['bolaox_profile_nonce'] ) && wp_verify_nonce( $_POST['bolaox_profile_nonce'], 'bolaox_profile' ) ) {
+            $first = sanitize_text_field( $_POST['bolaox_first_name'] );
+            $last  = sanitize_text_field( $_POST['bolaox_last_name'] );
+            wp_update_user( array( 'ID' => $user->ID, 'first_name' => $first, 'last_name' => $last ) );
+            $msg = '<p>' . esc_html__( 'Dados atualizados com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+        } elseif ( isset( $_POST['bolaox_pass_nonce'] ) && wp_verify_nonce( $_POST['bolaox_pass_nonce'], 'bolaox_pass' ) ) {
+            $p1 = sanitize_text_field( $_POST['bolaox_pass1'] );
+            $p2 = sanitize_text_field( $_POST['bolaox_pass2'] );
+            if ( $p1 && $p1 === $p2 ) {
+                wp_update_user( array( 'ID' => $user->ID, 'user_pass' => $p1 ) );
+                $msg = '<p>' . esc_html__( 'Senha alterada com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+            } else {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'As senhas não conferem.', self::TEXT_DOMAIN ) . '</p>';
+            }
+        }
+        if ( isset( $_POST['bolaox_avatar_nonce'] ) && wp_verify_nonce( $_POST['bolaox_avatar_nonce'], 'bolaox_avatar' ) ) {
+            if ( isset( $_POST['bolaox_delete_avatar'] ) && $avatar_id ) {
+                wp_delete_attachment( $avatar_id, true );
+                delete_user_meta( $user->ID, 'bolaox_avatar_id' );
+                $avatar_id = 0;
+                $msg = '<p>' . esc_html__( 'Avatar removido.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( ! empty( $_FILES['bolaox_avatar']['name'] ) ) {
+                require_once ABSPATH . 'wp-admin/includes/file.php';
+                require_once ABSPATH . 'wp-admin/includes/media.php';
+                require_once ABSPATH . 'wp-admin/includes/image.php';
+                $aid = media_handle_upload( 'bolaox_avatar', 0 );
+                if ( ! is_wp_error( $aid ) ) {
+                    if ( $avatar_id ) {
+                        wp_delete_attachment( $avatar_id, true );
+                    }
+                    update_user_meta( $user->ID, 'bolaox_avatar_id', $aid );
+                    $avatar_id = $aid;
+                    $msg = '<p>' . esc_html__( 'Avatar atualizado.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Falha ao enviar a imagem.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            }
+        }
+        $html  = $msg . '<form method="post" class="bolaox-profile">';
+        $html .= wp_nonce_field( 'bolaox_profile', 'bolaox_profile_nonce', true, false );
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Nome', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_first_name" class="bolaox-input" value="' . esc_attr( $user->first_name ) . '" /></label></p>';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Sobrenome', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_last_name" class="bolaox-input" value="' . esc_attr( $user->last_name ) . '" /></label></p>';
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Salvar', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+
+        $html .= '<form method="post" enctype="multipart/form-data" class="bolaox-avatar-form">';
+        $html .= wp_nonce_field( 'bolaox_avatar', 'bolaox_avatar_nonce', true, false );
+        $html .= '<div class="bolaox-avatar-preview">';
+        if ( $avatar_id ) {
+            $html .= wp_get_attachment_image( $avatar_id, array( 96, 96 ), false, array( 'class' => 'bolaox-avatar-img' ) );
+        } else {
+            $html .= '<span class="dashicons dashicons-admin-users bolaox-avatar-img"></span>';
+        }
+        $html .= '</div>';
+        $html .= '<p class="bolaox-field"><input type="file" name="bolaox_avatar" accept="image/*" /></p>';
+        if ( $avatar_id ) {
+            $html .= '<p class="bolaox-field"><button type="submit" name="bolaox_delete_avatar" value="1" class="bolaox-delete-avatar">' . esc_html__( 'Excluir avatar', self::TEXT_DOMAIN ) . '</button></p>';
+        }
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Salvar avatar', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+
+        $html .= '<form method="post" class="bolaox-pass-form">';
+        $html .= wp_nonce_field( 'bolaox_pass', 'bolaox_pass_nonce', true, false );
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Nova senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_pass1" class="bolaox-input" required /></label></p>';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Confirme a senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_pass2" class="bolaox-input" required /></label></p>';
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Alterar senha', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_login_shortcode() {
+        if ( is_user_logged_in() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Você já está logado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : home_url( '/participe?bx_sec=mybets' );
+        $msg         = '';
+        if ( isset( $_POST['bolaox_login_nonce'] ) && wp_verify_nonce( $_POST['bolaox_login_nonce'], 'bolaox_login' ) ) {
+            $phone = $this->sanitize_phone( $_POST['bolaox_phone'] );
+            $pass  = isset( $_POST['bolaox_password'] ) ? $_POST['bolaox_password'] : '';
+            $users = get_users( array( 'meta_key' => 'bolaox_phone', 'meta_value' => $phone, 'number' => 1 ) );
+            if ( $users ) {
+                $user  = $users[0];
+                if ( wp_check_password( $pass, $user->user_pass, $user->ID ) ) {
+                    wp_set_current_user( $user->ID );
+                    $this->create_session( $user->ID );
+                    $msg = '<p class="bolaox-login-success" data-redirect="' . esc_attr( $redirect_to ) . '">' . esc_html__( 'Login realizado com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Senha incorreta.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            } else {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Telefone não encontrado.', self::TEXT_DOMAIN ) . '</p>';
+            }
+        } elseif ( isset( $_POST['bolaox_register_nonce'] ) && wp_verify_nonce( $_POST['bolaox_register_nonce'], 'bolaox_register' ) ) {
+            $phone   = $this->sanitize_phone( $_POST['bolaox_phone'] );
+            $pass    = isset( $_POST['bolaox_password'] ) ? $_POST['bolaox_password'] : '';
+            $pass2   = isset( $_POST['bolaox_password2'] ) ? $_POST['bolaox_password2'] : '';
+            $display = sanitize_text_field( $_POST['bolaox_display'] );
+            if ( empty( $phone ) || empty( $pass ) || empty( $display ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Preencha todos os campos.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( ! preg_match( '/^\d{10,11}$/', $phone ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Telefone inválido.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( strlen( $pass ) < 6 ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'A senha precisa ter ao menos 6 caracteres.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( $pass !== $pass2 ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'As senhas não conferem.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( get_users( array( 'meta_key' => 'bolaox_phone', 'meta_value' => $phone, 'number' => 1 ) ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Telefone já cadastrado.', self::TEXT_DOMAIN ) . '</p>';
+            } else {
+                $username = 'u' . $phone;
+                $email    = $phone . '@example.com';
+                $user_id  = wp_insert_user( array( 'user_login' => $username, 'user_pass' => $pass, 'user_email' => $email, 'display_name' => $display ) );
+                if ( is_wp_error( $user_id ) ) {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Erro ao criar usuário.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    update_user_meta( $user_id, 'bolaox_phone', $phone );
+                    wp_set_current_user( $user_id );
+                    $this->create_session( $user_id );
+                    $msg = '<p class="bolaox-register-success" data-redirect="' . esc_attr( $redirect_to ) . '">' . esc_html__( 'Cadastro realizado com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            }
+        }
+
+        $login_form  = '<form method="post" class="bolaox-login-form">';
+        $login_form .= wp_nonce_field( 'bolaox_login', 'bolaox_login_nonce', true, false );
+        $login_form .= '<input type="hidden" name="redirect_to" value="' . esc_attr( $redirect_to ) . '" />';
+        $login_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Telefone', self::TEXT_DOMAIN ) . '<br /><input type="tel" name="bolaox_phone" class="bolaox-phone" required /></label></p>';
+        $login_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password" required /></label></p>';
+        $login_form .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Entrar', self::TEXT_DOMAIN ) . '" /></p>';
+        $login_form .= '</form>';
+
+        $register_form  = '<form method="post" class="bolaox-register-form">';
+        $register_form .= wp_nonce_field( 'bolaox_register', 'bolaox_register_nonce', true, false );
+        $register_form .= '<input type="hidden" name="redirect_to" value="' . esc_attr( $redirect_to ) . '" />';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Telefone', self::TEXT_DOMAIN ) . '<br /><input type="tel" name="bolaox_phone" class="bolaox-phone" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Como quer ser chamado?', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_display" class="bolaox-input" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Confirme a senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password2" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Criar conta', self::TEXT_DOMAIN ) . '" /></p>';
+        $register_form .= '</form>';
+
+        $redirect = '';
+        if ( strpos( $msg, 'bolaox-login-success' ) !== false || strpos( $msg, 'bolaox-register-success' ) !== false ) {
+            $redirect = '<script>setTimeout(function(){window.location.href="' . esc_url( $redirect_to ) . '";},1500);</script>';
+        }
+
+        $html  = '<div class="bolaox-login-tabs">' . $msg;
+        $html .= '<ul class="bolaox-tabs"><li class="active">' . esc_html__( 'Acessar', self::TEXT_DOMAIN ) . '</li><li>' . esc_html__( 'Cadastrar', self::TEXT_DOMAIN ) . '</li></ul>';
+        $html .= '<div class="bolaox-tab-content active">' . $login_form . '</div>';
+        $html .= '<div class="bolaox-tab-content">' . $register_form . '</div>';
+        $html .= '</div>' . $redirect;
+        return $this->wrap_app( $html );
+    }
+
+    public function render_dashboard_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Você precisa entrar para acessar o painel.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $avatar_id = get_user_meta( get_current_user_id(), 'bolaox_avatar_id', true );
+        $sections = array(
+            'profile'  => array( 'dashicons-admin-users', __( 'Perfil', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_profile]' ) ),
+            'form'     => array( 'dashicons-edit', __( 'Nova Aposta', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_form]' ) ),
+            'mybets'   => array( 'dashicons-chart-bar', __( 'Minhas Apostas', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_my_bets]' ) ),
+            'results'  => array( 'dashicons-awards', __( 'Resultados', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_results]' ) ),
+            'stats'    => array( 'dashicons-analytics', __( 'Estatísticas', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_stats]' ) ),
+            'history'  => array( 'dashicons-backup', __( 'Histórico', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_history]' ) ),
+            'logout'   => array( 'dashicons-migrate', __( 'Sair', self::TEXT_DOMAIN ), '<p><a class="button bolaox-submit" href="' . esc_url( wp_logout_url( home_url() ) ) . '">' . esc_html__( 'Sair', self::TEXT_DOMAIN ) . '</a></p>' ),
+        );
+        $logo = '<img src="https://www.bolaox.com.br/wp-content/uploads/2025/07/logo-footer.png" class="bolaox-mobile-logo" alt="Bolao X" />';
+        $html = $logo . '<div class="bolaox-dashboard">';
+        foreach ( $sections as $key => $data ) {
+            list( $icon, $label ) = $data;
+            $icon_html = '<span class="dashicons ' . esc_attr( $icon ) . '"></span>';
+            if ( 'profile' === $key && $avatar_id ) {
+                $icon_html = wp_get_attachment_image( $avatar_id, array( 32, 32 ), false, array( 'class' => 'bolaox-avatar-icon' ) );
+            }
+            $html .= '<div class="bolaox-card" data-target="bx-' . esc_attr( $key ) . '">' . $icon_html . '<span>' . esc_html( $label ) . '</span></div>';
+        }
+        $html .= '</div><div class="bolaox-dashboard-sections">';
+        foreach ( $sections as $key => $data ) {
+            $html .= '<div id="bx-' . esc_attr( $key ) . '" class="bolaox-section" style="display:none">' . $data[2] . '</div>';
+        }
+        $html .= '</div>';
+        return $this->wrap_app( $html );
+    }
+
+
+
+    public function register_dashboard_widget() {
+        wp_add_dashboard_widget( 'bolaox_overview', 'Resumo Bolao X', array( $this, 'dashboard_widget' ) );
+    }
+
+    public function dashboard_widget() {
+        $bets = wp_count_posts( 'bolaox_aposta' );
+        $count = $bets && isset( $bets->publish ) ? intval( $bets->publish ) : 0;
+        $result = get_option( 'bolaox_result', '' );
+        $winners = array( '10' => 0, '9' => 0, '8' => 0 );
+        if ( $result ) {
+            $res_numbers = array_map( 'trim', explode( ',', $result ) );
+            $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+            foreach ( $posts as $p ) {
+                $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+                $nums    = array_map( 'trim', explode( ',', $numbers ) );
+                $hits    = count( array_intersect( $res_numbers, $nums ) );
+                if ( $hits >= 8 ) {
+                    $key = strval( $hits );
+                    if ( isset( $winners[ $key ] ) ) {
+                        $winners[ $key ]++;
+                    }
+                }
+            }
+        }
+        echo '<p>' . sprintf( esc_html__( 'Total de apostas: %d', self::TEXT_DOMAIN ), $count ) . '</p>';
+        if ( $result ) {
+            echo '<p>' . esc_html__( 'Acertos:', self::TEXT_DOMAIN ) . '</p><ul>';
+            echo '<li>' . sprintf( esc_html__( '10 dezenas: %d', self::TEXT_DOMAIN ), $winners['10'] ) . '</li>';
+            echo '<li>' . sprintf( esc_html__( '9 dezenas: %d', self::TEXT_DOMAIN ), $winners['9'] ) . '</li>';
+            echo '<li>' . sprintf( esc_html__( '8 dezenas: %d', self::TEXT_DOMAIN ), $winners['8'] ) . '</li>';
+            echo '</ul>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado ainda.', self::TEXT_DOMAIN ) . '</p>';
+        }
+    }
+
+    public function filter_gettext( $translated, $text, $domain ) {
+        if ( 'default' !== $domain || ! function_exists( 'get_current_screen' ) ) {
+            return $translated;
+        }
+        $screen = get_current_screen();
+        if ( ! $screen ) {
+            return $translated;
+        }
+        if ( 'bolaox_aposta' === $screen->post_type ) {
+            if ( in_array( $text, array( 'Add New Post', 'Adicionar post', 'Adicionar novo' ), true ) ) {
+                return __( 'Aposta Manual', self::TEXT_DOMAIN );
+            }
+            if ( 'Publish' === $text || 'Publicar' === $text ) {
+                return __( 'Criar Aposta', self::TEXT_DOMAIN );
+            }
+        } elseif ( 'bolaox_result' === $screen->post_type ) {
+            if ( in_array( $text, array( 'Add New Post', 'Adicionar post', 'Adicionar novo' ), true ) ) {
+                return __( 'Novo Resultado', self::TEXT_DOMAIN );
+            }
+            if ( 'Publish' === $text || 'Publicar' === $text ) {
+                return __( 'Publicar Resultado', self::TEXT_DOMAIN );
+            }
+            if ( in_array( $text, array( 'Edit Post', 'Editar post' ), true ) ) {
+                return __( 'Editar Resultado', self::TEXT_DOMAIN );
+            }
+        }
+        return $translated;
+    }
+
+    public function title_placeholder( $title, $post ) {
+        if ( 'bolaox_aposta' === $post->post_type ) {
+            return __( 'Nome do Apostador', self::TEXT_DOMAIN );
+        } elseif ( 'bolaox_result' === $post->post_type ) {
+            return __( 'Qual resultado deseja publicar?', self::TEXT_DOMAIN );
+        }
+        return $title;
+    }
+
+
+    public function register_routes() {
+        register_rest_route(
+            'bolao-x/v1',
+            '/mp',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'handle_mp_webhook' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/validate',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'rest_validate_credentials' ),
+                'permission_callback' => function () { return current_user_can( 'manage_options' ); },
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/create-payment',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'rest_create_payment' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/mybets',
+            array(
+                'methods'  => 'GET',
+                'callback' => array( $this, 'rest_my_bets' ),
+                'permission_callback' => function () { return is_user_logged_in(); },
+            )
+        );
+    }
+
+    public function handle_mp_webhook( WP_REST_Request $request ) {
+        $token = $request->get_param( 'token' );
+        if ( $token !== self::MP_WEBHOOK_TOKEN ) {
+            return new WP_Error( 'forbidden', 'Token inválido', array( 'status' => 403 ) );
+        }
+        $payment_id = intval( $request->get_param( 'data_id' ) );
+        if ( ! $payment_id ) {
+            return new WP_Error( 'bad_request', 'ID ausente', array( 'status' => 400 ) );
+        }
+        $url  = self::MP_API_URL . '/v1/payments/' . $payment_id;
+        $args = array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $this->get_mp_access_token(),
+            ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            return new WP_Error( 'request_failed', 'Erro na consulta', array( 'status' => 500 ) );
+        }
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $body['status'] ) && 'approved' === $body['status'] ) {
+            $post_id = intval( $body['external_reference'] );
+            if ( $post_id ) {
+                update_post_meta( $post_id, '_bolaox_payment', 'paid' );
+                return array( 'success' => true );
+            }
+        }
+        $this->log_mp_error( 'Pagamento não confirmado: ' . wp_remote_retrieve_body( $res ) );
+        return new WP_Error( 'invalid', 'Pagamento não confirmado', array( 'status' => 400 ) );
+    }
+
+    public function rest_validate_credentials( WP_REST_Request $request ) {
+        $mode = $request->get_param( 'mode' );
+        if ( ! in_array( $mode, array( 'prod', 'test' ), true ) ) {
+            return new WP_Error( 'invalid', 'Modo inválido', array( 'status' => 400 ) );
+        }
+        if ( $this->validate_mp_credentials( $mode ) ) {
+            return array( 'success' => true );
+        }
+        return new WP_Error( 'invalid', 'Credenciais inválidas', array( 'status' => 400 ) );
+    }
+
+    public function rest_create_payment( WP_REST_Request $request ) {
+        $qty = max( 1, intval( $request->get_param( 'qty' ) ) );
+        $pref = sanitize_text_field( $request->get_param( 'ref' ) );
+        $data = $this->create_mp_pix_payment( $pref, $qty );
+        if ( ! $data ) {
+            return new WP_Error( 'failed', 'Erro ao criar pagamento', array( 'status' => 500 ) );
+        }
+        return $data;
+    }
+
+    public function auto_create_result( $post_id, $post, $update ) {
+        if ( wp_is_post_revision( $post_id ) || 'auto-draft' === $post->post_status || 'trash' === $post->post_status ) {
+            return;
+        }
+
+        $existing = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'post_status' => 'any',
+            'numberposts' => 1,
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $post_id ),
+            ),
+        ) );
+
+        $title = sprintf( __( 'Resultado do Concurso %s', self::TEXT_DOMAIN ), $post->post_title );
+
+        if ( $existing ) {
+            $eid = $existing[0]->ID;
+            if ( $existing[0]->post_title !== $title ) {
+                wp_update_post( array( 'ID' => $eid, 'post_title' => $title ) );
+            }
+            return;
+        }
+
+        $res_id = wp_insert_post( array(
+            'post_type'   => 'bolaox_result',
+            'post_title'  => $title,
+            'post_status' => 'draft',
+        ) );
+
+        if ( $res_id ) {
+            update_post_meta( $res_id, '_bolaox_concurso', $post_id );
+        }
+    }
+
+    private function on_contest_switch( $old_id, $new_id ) {
+        if ( $old_id ) {
+            $rotatives = get_posts( array(
+                'post_type'   => 'bolaox_aposta',
+                'numberposts' => -1,
+                'fields'      => 'ids',
+                'meta_query'  => array(
+                    array( 'key' => '_bolaox_concurso', 'value' => $old_id ),
+                    array(
+                        'relation' => 'OR',
+                        array( 'key' => '_bolaox_fixed', 'compare' => 'NOT EXISTS' ),
+                        array( 'key' => '_bolaox_fixed', 'value' => '0' ),
+                    ),
+                ),
+            ) );
+            foreach ( $rotatives as $rid ) {
+                wp_delete_post( $rid, true );
+            }
+        }
+        if ( $new_id && $old_id ) {
+            $fixed = get_posts( array(
+                'post_type'   => 'bolaox_aposta',
+                'numberposts' => -1,
+                'meta_query'  => array(
+                    array( 'key' => '_bolaox_concurso', 'value' => $old_id ),
+                    array( 'key' => '_bolaox_fixed', 'value' => '1' ),
+                ),
+            ) );
+            foreach ( $fixed as $fb ) {
+                $new_post = wp_insert_post( array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => $fb->post_title,
+                    'post_status' => 'publish',
+                    'post_author' => $fb->post_author,
+                ) );
+                if ( $new_post ) {
+                    update_post_meta( $new_post, '_bolaox_numbers', get_post_meta( $fb->ID, '_bolaox_numbers', true ) );
+                    update_post_meta( $new_post, '_bolaox_payment', get_post_meta( $fb->ID, '_bolaox_payment', true ) );
+                    update_post_meta( $new_post, '_bolaox_fixed', '1' );
+                    update_post_meta( $new_post, '_bolaox_concurso', $new_id );
+                }
+            }
+        }
+    }
+
+    public function aposta_columns( $cols ) {
+        $cols['bolaox_fixed'] = __( 'Fixo', self::TEXT_DOMAIN );
+        return $cols;
+    }
+
+    public function aposta_column_content( $col, $post_id ) {
+        if ( 'bolaox_fixed' === $col ) {
+            $val = get_post_meta( $post_id, '_bolaox_fixed', true );
+            echo $val ? '&#10004;' : '&#8211;';
+        }
+    }
+
+    public function aposta_filter() {
+        global $typenow;
+        if ( 'bolaox_aposta' === $typenow ) {
+            $val = $_GET['bolaox_fixed'] ?? '';
+            echo '<select name="bolaox_fixed"><option value="">' . esc_html__( 'Tipo', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="1"' . selected( $val, '1', false ) . '>' . esc_html__( 'Fixas', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="0"' . selected( $val, '0', false ) . '>' . esc_html__( 'Rotativas', self::TEXT_DOMAIN ) . '</option>';
+            echo '</select>';
+        }
+    }
+
+    public function aposta_filter_query( $query ) {
+        global $pagenow;
+        if ( is_admin() && 'edit.php' === $pagenow && 'bolaox_aposta' === ( $query->get( 'post_type' ) ?? '' ) ) {
+            $val = $_GET['bolaox_fixed'] ?? '';
+            if ( $val !== '' ) {
+                $query->set( 'meta_query', array(
+                    array( 'key' => '_bolaox_fixed', 'value' => $val )
+                ) );
+            }
+        }
+    }
+
+    public function result_filter() {
+        global $typenow;
+        if ( 'bolaox_result' === $typenow ) {
+            $val = $_GET['bolaox_concurso'] ?? '';
+            $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+            echo '<select name="bolaox_concurso"><option value="">' . esc_html__( 'Concurso', self::TEXT_DOMAIN ) . '</option>';
+            foreach ( $contests as $c ) {
+                echo '<option value="' . $c->ID . '"' . selected( $val, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+            }
+            echo '</select>';
+        }
+    }
+
+    public function result_filter_query( $query ) {
+        global $pagenow;
+        if ( is_admin() && 'edit.php' === $pagenow && 'bolaox_result' === ( $query->get( 'post_type' ) ?? '' ) ) {
+            $val = $_GET['bolaox_concurso'] ?? '';
+            if ( $val ) {
+                $query->set( 'meta_query', array(
+                    array( 'key' => '_bolaox_concurso', 'value' => intval( $val ) )
+                ) );
+            }
+        }
+    }
+
+    public function result_columns( $cols ) {
+        $cols['bolaox_concurso'] = __( 'Concurso', self::TEXT_DOMAIN );
+        return $cols;
+    }
+
+    public function result_column_content( $col, $post_id ) {
+        if ( 'bolaox_concurso' === $col ) {
+            $cid = get_post_meta( $post_id, '_bolaox_concurso', true );
+            if ( $cid ) {
+                $title = get_the_title( $cid );
+                echo esc_html( $title );
+            } else {
+                echo '&#8211;';
+            }
+        }
+    }
+
+    public function rest_my_bets() {
+        return array(
+            'html' => $this->generate_my_bets_table( get_current_user_id() ),
+        );
+    }
+    public static function activate() {
+        self::instance();
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+
+}
+
+register_activation_hook( __FILE__, array( 'BOLAOX_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'BOLAOX_Plugin', 'deactivate' ) );
+
+if ( extension_loaded( 'gd' ) ) {
+    BOLAOX_Plugin::instance();
+} else {
+    add_action( 'admin_notices', function() {
+        echo '<div class="notice notice-error"><p>' .
+            esc_html__( 'O plugin Bolao X requer a extensão PHP GD para gerar QR Codes.', 'bolao-x' ) .
+            '</p></div>';
+    } );
+}
+

--- a/bolao-x/languages/bolao-x-pt_BR.po
+++ b/bolao-x/languages/bolao-x-pt_BR.po
@@ -1,0 +1,652 @@
+# Portuguese translations for Bolao X package.
+# Copyright (C) 2025 THE Bolao X'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Bolao X package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr "RESULTADO DA SEMANA:"
+"Project-Id-Version: Bolao X 2.8.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-23 15:57+0000\n"
+"PO-Revision-Date: 2025-06-23 15:57+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: bolao-x/bolao-x.php:113
+msgid "Apostas"
+msgstr ""
+
+#: bolao-x/bolao-x.php:114 bolao-x/bolao-x.php:450
+msgid "Aposta"
+msgstr ""
+
+#: bolao-x/bolao-x.php
+msgid "Apostador"
+msgstr "Apostador"
+
+#: bolao-x/bolao-x.php:123
+msgid "Resultados"
+msgstr ""
+
+#: bolao-x/bolao-x.php:124
+msgid "Resultado"
+msgstr ""
+
+#: bolao-x/bolao-x.php:133 bolao-x/bolao-x.php:452 bolao-x/bolao-x.php:532
+msgid "Dezenas"
+msgstr ""
+
+#: bolao-x/bolao-x.php:138
+msgid "Ex: 05,12,23,34,45,56,67,78,89,90"
+msgstr ""
+
+#: bolao-x/bolao-x.php:146
+msgid ""
+"Dezenas da aposta inválidas. Use 10 números de 00 a 99 separados por vírgula."
+msgstr ""
+
+#: bolao-x/bolao-x.php:155 bolao-x/bolao-x.php:233
+msgid "Configurações"
+msgstr ""
+
+#: bolao-x/bolao-x.php:156
+msgid "Importar CSV"
+msgstr ""
+
+#: bolao-x/bolao-x.php:157
+msgid "Histórico"
+msgstr ""
+
+#: bolao-x/bolao-x.php:158 bolao-x/bolao-x.php:320
+msgid "Estatísticas"
+msgstr ""
+
+#: bolao-x/bolao-x.php:165
+msgid ""
+"Resultado semanal inválido. Informe 10 números de 00 a 99 separados por "
+"vírgula."
+msgstr ""
+
+#: bolao-x/bolao-x.php:189
+msgid "Resultado Semanal"
+msgstr ""
+
+#: bolao-x/bolao-x.php:192
+msgid "Ex: 05,19,28,36,44,59,66,71,86,96"
+msgstr ""
+
+#: bolao-x/bolao-x.php:193
+msgid "Salvar"
+msgstr ""
+
+#: bolao-x/bolao-x.php:196
+msgid "Conferência"
+msgstr ""
+
+#: bolao-x/bolao-x.php:200
+msgid "Exportar CSV"
+msgstr ""
+
+#: bolao-x/bolao-x.php:201
+msgid "Exportar Excel"
+msgstr ""
+
+#: bolao-x/bolao-x.php:202
+msgid "Exportar PDF"
+msgstr ""
+
+#: bolao-x/bolao-x.php:229
+msgid "Configurações salvas."
+msgstr ""
+
+#: bolao-x/bolao-x.php:242
+msgid "Chave Pix"
+msgstr ""
+
+msgid "Chaves Pix"
+msgstr "Chaves Pix"
+
+msgid "Chave ativa"
+msgstr "Chave ativa"
+
+msgid "Nome do Recebedor"
+msgstr "Nome do Recebedor"
+
+msgid "Cidade"
+msgstr "Cidade"
+
+#: bolao-x/bolao-x.php:249
+msgid "Importar Apostas via CSV"
+msgstr ""
+
+#: bolao-x/bolao-x.php:276
+#, php-format
+msgid "Importadas %d apostas."
+msgstr ""
+
+#: bolao-x/bolao-x.php:281
+msgid "Importar"
+msgstr ""
+
+#: bolao-x/bolao-x.php:300
+msgid "Histórico de Resultados"
+msgstr ""
+
+#: bolao-x/bolao-x.php:302 bolao-x/bolao-x.php:549 bolao-x/bolao-x.php:561
+msgid "Nenhum resultado cadastrado."
+msgstr ""
+
+#: bolao-x/bolao-x.php:320 bolao-x/bolao-x.php:352 bolao-x/bolao-x.php:607
+msgid "Nenhuma aposta cadastrada."
+msgstr ""
+
+#: bolao-x/bolao-x.php:335
+msgid "Estatísticas de Frequência"
+msgstr ""
+
+#: bolao-x/bolao-x.php:336
+msgid "Dezena"
+msgstr ""
+
+#: bolao-x/bolao-x.php:336
+msgid "Ocorrências"
+msgstr ""
+
+#: bolao-x/bolao-x.php:447
+msgid "Relatorio de Apostas"
+msgstr ""
+
+#: bolao-x/bolao-x.php:451
+msgid "Acertos"
+msgstr ""
+
+#: bolao-x/bolao-x.php:478
+#, php-format
+msgid "Olá %s,"
+msgstr ""
+
+#: bolao-x/bolao-x.php:479
+#, php-format
+msgid "O resultado da semana foi: %s"
+msgstr ""
+
+#: bolao-x/bolao-x.php:480
+#, php-format
+msgid "Sua aposta: %s"
+msgstr ""
+
+#: bolao-x/bolao-x.php
+msgid "Sua aposta:"
+msgstr "Sua aposta:"
+
+#: bolao-x/bolao-x.php:481
+#, php-format
+msgid "Acertos: %d"
+msgstr ""
+
+#: bolao-x/bolao-x.php:483
+#, php-format
+msgid "Parabéns! Você acertou %d dezenas."
+msgstr ""
+
+#: bolao-x/bolao-x.php:485
+msgid "Resultado do Bolão"
+msgstr ""
+
+#: bolao-x/bolao-x.php:497
+msgid "Apostas encerradas. Tente novamente no próximo concurso."
+msgstr ""
+
+#: bolao-x/bolao-x.php:506
+msgid ""
+"Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula."
+msgstr ""
+
+#: bolao-x/bolao-x.php:517
+msgid "Aposta registrada com sucesso!"
+msgstr ""
+
+#: bolao-x/bolao-x.php:523
+#, php-format
+msgid "Pague via Pix usando a chave: %s"
+msgstr ""
+
+#: bolao-x/bolao-x.php:608
+msgid "Como quer ser chamado?"
+msgstr "Como quer ser chamado?"
+
+#: bolao-x/bolao-x.php:609
+msgid "Escolha 10 dezenas"
+msgstr "Escolha 10 dezenas"
+
+#: bolao-x/bolao-x.php:610
+msgid "APOSTE AGORA"
+msgstr "APOSTE AGORA"
+
+#: bolao-x/bolao-x.php:540
+#, php-format
+msgid "Chave Pix: %s"
+msgstr "Chave Pix: %s"
+
+msgid "TXID: %s"
+msgstr "TXID: %s"
+
+#: bolao-x/bolao-x.php:526
+msgid "Copiar"
+msgstr "Copiar"
+
+#: bolao-x/bolao-x.php:552
+msgid "Resultado da Semana:"
+msgstr ""
+
+#: bolao-x/bolao-x.php:875
+msgid "RESULTADO DA SEMANA"
+msgstr "RESULTADO DA SEMANA"
+
+
+#: bolao-x/bolao-x.php:586
+msgid "Você ainda não cadastrou apostas."
+msgstr ""
+
+#: bolao-x/bolao-x.php:658
+#, php-format
+msgid "Total de apostas: %d"
+msgstr ""
+
+#: bolao-x/bolao-x.php:660
+msgid "Acertos:"
+msgstr ""
+
+#: bolao-x/bolao-x.php:661
+#, php-format
+msgid "10 dezenas: %d"
+msgstr ""
+
+#: bolao-x/bolao-x.php:662
+#, php-format
+msgid "9 dezenas: %d"
+msgstr ""
+
+#: bolao-x/bolao-x.php:663
+#, php-format
+msgid "8 dezenas: %d"
+msgstr ""
+
+#: bolao-x/bolao-x.php:666
+msgid "Nenhum resultado cadastrado ainda."
+msgstr ""
+
+#: bolao-x/bolao-x.php:524
+msgid "Pague com Pix"
+msgstr "Pague com Pix"
+
+#: bolao-x/bolao-x.php:726
+msgid "Perdeu a senha?"
+msgstr "Perdeu a senha?"
+
+#: bolao-x/bolao-x.php:742
+msgid "Nova senha"
+msgstr "Nova senha"
+
+#: bolao-x/bolao-x.php:743
+msgid "Confirme a senha"
+msgstr "Confirme a senha"
+
+#: bolao-x/bolao-x.php:744
+msgid "Alterar senha"
+msgstr "Alterar senha"
+
+#: bolao-x/bolao-x.php:736
+msgid "Senha alterada com sucesso."
+msgstr "Senha alterada com sucesso."
+
+#: bolao-x/bolao-x.php:738
+msgid "Você já está logado."
+msgstr "Você já está logado."
+
+#: bolao-x.php:782
+msgid "Senha incorreta."
+msgstr "Senha incorreta."
+
+#: bolao-x.php:784
+msgid "Telefone não encontrado."
+msgstr "Telefone não encontrado."
+
+#: bolao-x.php:790
+msgid "Preencha todos os campos."
+msgstr "Preencha todos os campos."
+
+#: bolao-x.php:792
+msgid "Telefone já cadastrado."
+msgstr "Telefone já cadastrado."
+
+#: bolao-x.php:798
+msgid "Erro ao criar usuário."
+msgstr "Erro ao criar usuário."
+
+#: bolao-x.php:801
+msgid "Cadastro realizado com sucesso."
+msgstr "Cadastro realizado com sucesso."
+
+#: bolao-x.php
+msgid "Nenhum concurso ativo."
+msgstr "Nenhum concurso ativo."
+
+#: bolao-x.php
+msgid "Apostas ainda não liberadas."
+msgstr "Apostas ainda não liberadas."
+
+#: bolao-x.php
+msgid "Adicionar mais um Jogo"
+msgstr "Adicionar mais um Jogo"
+
+#: bolao-x.php
+msgid "Valor da aposta: R$ %s"
+msgstr "Valor da aposta: R$ %s"
+
+#: bolao-x.php
+msgid "Preço da aposta (R$)"
+msgstr "Preço da aposta (R$)"
+
+#: bolao-x.php
+msgid "Logs de Pagamento"
+msgstr "Logs de Pagamento"
+
+#: bolao-x.php
+msgid "Nenhum log encontrado."
+msgstr "Nenhum log encontrado."
+
+#: bolao-x.php
+msgid "Limpar logs"
+msgstr "Limpar logs"
+
+#: bolao-x.php
+msgid "Logs limpos."
+msgstr "Logs limpos."
+
+#: bolao-x.php:1082
+msgid "Você precisa entrar para acessar o painel."
+msgstr "Você precisa entrar para acessar o painel."
+
+#: bolao-x.php:1085
+msgid "Perfil"
+msgstr "Perfil"
+
+#: bolao-x.php:1086
+msgid "Nova Aposta"
+msgstr "Nova Aposta"
+
+#: bolao-x.php:1087
+msgid "Minhas Apostas"
+msgstr "Minhas Apostas"
+
+#: bolao-x.php:1088
+msgid "Resultados"
+msgstr "Resultados"
+
+#: bolao-x.php:1089
+msgid "Estatísticas"
+msgstr "Estatísticas"
+
+#: bolao-x.php:1090
+msgid "Histórico"
+msgstr "Histórico"
+
+#: bolao-x.php:1091
+msgid "Sair"
+msgstr "Sair"
+
+#: bolao-x.php:808
+msgid "Telefone"
+msgstr "Telefone"
+
+#: bolao-x.php:809 bolao-x.php:816
+msgid "Senha"
+msgstr "Senha"
+
+#: bolao-x.php:810
+msgid "Entrar"
+msgstr "Entrar"
+
+#: bolao-x.php:817
+msgid "Criar conta"
+msgstr "Criar conta"
+
+#: bolao-x.php:820
+msgid "Acessar"
+msgstr "Acessar"
+
+#: bolao-x.php:820
+msgid "Cadastrar"
+msgstr "Cadastrar"
+
+#: bolao-x.php
+msgid "Login realizado com sucesso."
+msgstr "Login realizado com sucesso."
+
+#: bolao-x.php
+msgid "Cadastro realizado com sucesso."
+msgstr "Cadastro realizado com sucesso."
+
+#: bolao-x.php
+msgid "Análises Gerais"
+msgstr "Análises Gerais"
+
+#: bolao-x.php
+msgid "Exibicoes hoje: %d | Usuarios online: %d"
+msgstr "Exibi\u00e7\u00f5es hoje: %d | Usu\u00e1rios online: %d"
+
+#: bolao-x.php
+msgid "Visitas nos ultimos 15 dias"
+msgstr "Visitas nos \u00faltimos 15 dias"
+
+#: bolao-x.php
+msgid "Usuarios nos ultimos 15 dias"
+msgstr "Usu\u00e1rios nos \u00faltimos 15 dias"
+
+#: bolao-x.php
+msgid "Visitas por pais"
+msgstr "Visitas por pa\u00eds"
+
+#: bolao-x.php
+msgid "Plataformas usadas"
+msgstr "Plataformas usadas"
+
+#: bolao-x.php
+msgid "Navegadores usados"
+msgstr "Navegadores usados"
+
+#: bolao-x.php
+msgid "Pais mais popular"
+msgstr "Pa\u00eds mais popular"
+
+#: bolao-x.php
+msgid "Plataforma mais usada"
+msgstr "Plataforma mais usada"
+
+#: bolao-x.php
+msgid "Navegadores mais usados"
+msgstr "Navegadores mais usados"
+
+#: bolao-x.php
+msgid "USUÁRIOS ONLINE"
+msgstr "USU\u00c1RIOS ONLINE"
+
+#: bolao-x.php
+msgid "USUÁRIOS HOJE"
+msgstr "USU\u00c1RIOS HOJE"
+
+#: bolao-x.php
+msgid "VISITAS NOS \u00daLTIMOS 15 DIAS"
+msgstr "VISITAS NOS \u00daLTIMOS 15 DIAS"
+
+#: bolao-x.php
+msgid "NAVEGADORES MAIS USADOS"
+msgstr "NAVEGADORES MAIS USADOS"
+
+#: bolao-x.php
+msgid "SISTEMAS OPERACIONAIS MAIS USADOS"
+msgstr "SISTEMAS OPERACIONAIS MAIS USADOS"
+\n#: bolao-x.php
+msgid "Apostador Fixo"
+msgstr "Apostador Fixo"
+\n#: bolao-x.php
+msgid "Manter para próximos concursos"
+msgstr "Manter para próximos concursos"
+
+#: bolao-x.php
+msgid "Tipo"
+msgstr "Tipo"
+
+#: bolao-x.php
+msgid "Fixas"
+msgstr "Fixas"
+
+#: bolao-x.php
+msgid "Rotativas"
+msgstr "Rotativas"
+
+#: bolao-x.php
+msgid "Nome do Apostador"
+msgstr "Nome do Apostador"
+
+#: bolao-x.php
+msgid "Nenhuma aposta encontrada."
+msgstr "Nenhuma aposta encontrada."
+
+#: bolao-x.php
+msgid "Nenhum resultado encontrado."
+msgstr "Nenhum resultado encontrado."
+
+#: bolao-x.php
+msgid "Qual resultado deseja publicar?"
+msgstr "Qual resultado deseja publicar?"
+
+#: bolao-x.php
+msgid "Pesquisar Concursos"
+msgstr "Pesquisar Concursos"
+
+#: bolao-x.php
+msgid "Pagamentos não confirmados"
+msgstr "Pagamentos não confirmados"
+
+#: bolao-x.php
+msgid "Pagamentos via Pix não confirmados"
+msgstr "Pagamentos via Pix não confirmados"
+
+#: bolao-x.php
+msgid "Nenhum pagamento pendente."
+msgstr "Nenhum pagamento pendente."
+
+#: bolao-x.php
+msgid "Marcar como pago"
+msgstr "Marcar como pago"
+
+#: bolao-x.php
+msgid "Pagamento marcado como pago."
+msgstr "Pagamento marcado como pago."
+
+#: bolao-x.php
+msgid "Editar Resultado"
+msgstr "Editar Resultado"
+
+#: bolao-x.php
+msgid "Resultado:"
+msgstr "Resultado:"
+
+#: bolao-x.php
+msgid "Concurso"
+msgstr "Concurso"
+
+#: bolao-x.php
+msgid "Resultado do Concurso %s"
+msgstr "Resultado do Concurso %s"
+
+#: bolao-x.php
+msgid "Mais Pontos: %s com %d ponto(s)"
+msgstr "Mais Pontos: %s com %d ponto(s)"
+
+#: bolao-x.php
+msgid "Menos Pontos: %s com %d ponto(s)"
+msgstr "Menos Pontos: %s com %d ponto(s)"
+
+#: bolao-x.php
+msgid "Contemplados"
+msgstr "Contemplados"
+
+#: bolao-x.php
+msgid "ÚLTIMOS RESULTADOS"
+msgstr "ÚLTIMOS RESULTADOS"
+
+#: bolao-x.php
+msgid "VER TODOS RESULTADOS"
+msgstr "VER TODOS RESULTADOS"
+
+#: bolao-x.php
+msgid "VENCEDORES COM MAIS PONTOS"
+msgstr "VENCEDORES COM MAIS PONTOS"
+
+#: bolao-x.php
+msgid "VENCEDORES COM MENOS PONTOS"
+msgstr "VENCEDORES COM MENOS PONTOS"
+
+#: bolao-x.php
+msgid "TODAS AS APOSTAS"
+msgstr "TODAS AS APOSTAS"
+
+#: bolao-x.php
+msgid "Nenhum vencedor."
+msgstr "Nenhum vencedor."
+
+#: bolao-x.php
+msgid "Filtrar por Concurso"
+msgstr "Filtrar por Concurso"
+
+#: bolao-x.php
+msgid "Ordenar por"
+msgstr "Ordenar por"
+
+#: bolao-x.php
+msgid "Pontuação"
+msgstr "Pontuação"
+
+#: bolao-x.php
+msgid "Data"
+msgstr "Data"
+
+#: bolao-x.php
+msgid "Exportar Relatório"
+msgstr "Exportar Relatório"
+
+#: bolao-x.php
+msgid "ESTATÍSTICAS"
+msgstr "ESTATÍSTICAS"
+
+#: bolao-x.php
+msgid "Total de Participantes: %d"
+msgstr "Total de Participantes: %d"
+
+#: bolao-x.php
+msgid "Média de Pontos: %.2f"
+msgstr "Média de Pontos: %.2f"
+
+#: bolao-x.php
+msgid "Taxa de Acerto: %s%%"
+msgstr "Taxa de Acerto: %s%%"
+
+#: bolao-x.php
+msgid "Nenhum concurso cadastrado."
+msgstr "Nenhum concurso cadastrado."
+
+#: bolao-x.php
+msgid "Telefone inválido."
+msgstr "Telefone inválido."
+
+#: bolao-x.php
+msgid "A senha precisa ter ao menos 6 caracteres."
+msgstr "A senha precisa ter ao menos 6 caracteres."

--- a/bolao-x/languages/bolao-x.pot
+++ b/bolao-x/languages/bolao-x.pot
@@ -1,0 +1,684 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Bolao X 2.8.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-23 22:34+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: bolao-x.php:113
+msgid "Apostas"
+msgstr ""
+
+#: bolao-x.php:114 bolao-x.php:450
+msgid "Aposta"
+msgstr ""
+
+msgid "Apostador"
+msgstr ""
+
+#: bolao-x.php:123
+msgid "Resultados"
+msgstr ""
+
+#: bolao-x.php:124
+msgid "Resultado"
+msgstr ""
+
+#: bolao-x.php:133 bolao-x.php:452 bolao-x.php:532
+msgid "Dezenas"
+msgstr ""
+
+#: bolao-x.php:138
+msgid "Ex: 05,12,23,34,45,56,67,78,89,90"
+msgstr ""
+
+#: bolao-x.php:146
+msgid ""
+"Dezenas da aposta inválidas. Use 10 números de 00 a 99 separados por vírgula."
+msgstr ""
+
+#: bolao-x.php:155 bolao-x.php:233
+msgid "Configurações"
+msgstr ""
+
+#: bolao-x.php:156
+msgid "Importar CSV"
+msgstr ""
+
+#: bolao-x.php:157
+msgid "Histórico"
+msgstr ""
+
+#: bolao-x.php:158 bolao-x.php:320
+msgid "Estatísticas"
+msgstr ""
+
+#: bolao-x.php:165
+msgid ""
+"Resultado semanal inválido. Informe 10 números de 00 a 99 separados por "
+"vírgula."
+msgstr ""
+
+#: bolao-x.php:189
+msgid "Resultado Semanal"
+msgstr ""
+
+#: bolao-x.php:192
+msgid "Ex: 05,19,28,36,44,59,66,71,86,96"
+msgstr ""
+
+#: bolao-x.php:193
+msgid "Salvar"
+msgstr ""
+
+#: bolao-x.php:196
+msgid "Conferência"
+msgstr ""
+
+#: bolao-x.php:200
+msgid "Exportar CSV"
+msgstr ""
+
+#: bolao-x.php:201
+msgid "Exportar Excel"
+msgstr ""
+
+#: bolao-x.php:202
+msgid "Exportar PDF"
+msgstr ""
+
+#: bolao-x.php:210
+msgid "Segunda"
+msgstr ""
+
+#: bolao-x.php:211
+msgid "Terça"
+msgstr ""
+
+#: bolao-x.php:212
+msgid "Quarta"
+msgstr ""
+
+#: bolao-x.php:213
+msgid "Quinta"
+msgstr ""
+
+#: bolao-x.php:214
+msgid "Sexta"
+msgstr ""
+
+#: bolao-x.php:215
+msgid "Sábado"
+msgstr ""
+
+#: bolao-x.php:216
+msgid "Domingo"
+msgstr ""
+
+#: bolao-x.php:229
+msgid "Configurações salvas."
+msgstr ""
+
+#: bolao-x.php:242
+msgid "Chave Pix"
+msgstr ""
+
+msgid "Chaves Pix"
+msgstr ""
+
+msgid "Chave ativa"
+msgstr ""
+
+msgid "Nome do Recebedor"
+msgstr ""
+
+msgid "Cidade"
+msgstr ""
+
+#: bolao-x.php:249
+msgid "Importar Apostas via CSV"
+msgstr ""
+
+#: bolao-x.php:276
+#, php-format
+msgid "Importadas %d apostas."
+msgstr ""
+
+#: bolao-x.php:281
+msgid "Importar"
+msgstr ""
+
+#: bolao-x.php:300
+msgid "Histórico de Resultados"
+msgstr ""
+
+#: bolao-x.php:302 bolao-x.php:549 bolao-x.php:561
+msgid "Nenhum resultado cadastrado."
+msgstr ""
+
+#: bolao-x.php:320 bolao-x.php:352 bolao-x.php:607
+msgid "Nenhuma aposta cadastrada."
+msgstr ""
+
+#: bolao-x.php:335
+msgid "Estatísticas de Frequência"
+msgstr ""
+
+#: bolao-x.php:336
+msgid "Dezena"
+msgstr ""
+
+#: bolao-x.php:336
+msgid "Ocorrências"
+msgstr ""
+
+#: bolao-x.php:447
+msgid "Relatorio de Apostas"
+msgstr ""
+
+#: bolao-x.php:451
+msgid "Acertos"
+msgstr ""
+
+#: bolao-x.php:478
+#, php-format
+msgid "Olá %s,"
+msgstr ""
+
+#: bolao-x.php:479
+#, php-format
+msgid "O resultado da semana foi: %s"
+msgstr ""
+
+#: bolao-x.php:480
+#, php-format
+msgid "Sua aposta: %s"
+msgstr ""
+
+#: bolao-x.php
+msgid "Sua aposta:"
+msgstr ""
+
+#: bolao-x.php:481
+#, php-format
+msgid "Acertos: %d"
+msgstr ""
+
+#: bolao-x.php:483
+#, php-format
+msgid "Parabéns! Você acertou %d dezenas."
+msgstr ""
+
+#: bolao-x.php:485
+msgid "Resultado do Bolão"
+msgstr ""
+
+#: bolao-x.php:497
+msgid "Apostas encerradas. Tente novamente no próximo concurso."
+msgstr ""
+
+#: bolao-x.php:506
+msgid ""
+"Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula."
+msgstr ""
+
+#: bolao-x.php:517
+msgid "Aposta registrada com sucesso!"
+msgstr ""
+
+#: bolao-x.php:523
+#, php-format
+msgid "Pague via Pix usando a chave: %s"
+msgstr ""
+
+#: bolao-x.php:608
+msgid "Como quer ser chamado?"
+msgstr ""
+
+#: bolao-x.php:609
+msgid "Escolha 10 dezenas"
+msgstr ""
+
+#: bolao-x.php:610
+msgid "APOSTE AGORA"
+msgstr ""
+
+#: bolao-x.php:540
+#, php-format
+msgid "Chave Pix: %s"
+msgstr ""
+
+msgid "TXID: %s"
+msgstr ""
+
+#: bolao-x.php:526
+msgid "Copiar"
+msgstr ""
+
+#: bolao-x.php:552
+msgid "Resultado da Semana:"
+msgstr ""
+
+#: bolao-x.php:875
+msgid "RESULTADO DA SEMANA"
+msgstr ""
+
+
+#: bolao-x.php:586
+msgid "Você ainda não cadastrou apostas."
+msgstr ""
+
+#: bolao-x.php:658
+#, php-format
+msgid "Total de apostas: %d"
+msgstr ""
+
+#: bolao-x.php:660
+msgid "Acertos:"
+msgstr ""
+
+#: bolao-x.php:661
+#, php-format
+msgid "10 dezenas: %d"
+msgstr ""
+
+#: bolao-x.php:662
+#, php-format
+msgid "9 dezenas: %d"
+msgstr ""
+
+#: bolao-x.php:663
+#, php-format
+msgid "8 dezenas: %d"
+msgstr ""
+
+#: bolao-x.php:666
+msgid "Nenhum resultado cadastrado ainda."
+msgstr ""
+
+#: bolao-x.php:524
+msgid "Pague com Pix"
+msgstr ""
+
+#: bolao-x.php:726
+msgid "Perdeu a senha?"
+msgstr ""
+
+#: bolao-x.php:742
+msgid "Nova senha"
+msgstr ""
+
+#: bolao-x.php:743
+msgid "Confirme a senha"
+msgstr ""
+
+#: bolao-x.php:744
+msgid "Alterar senha"
+msgstr ""
+
+#: bolao-x.php:736
+msgid "Senha alterada com sucesso."
+msgstr ""
+
+#: bolao-x.php:738
+msgid "As senhas não conferem."
+msgstr ""
+#: bolao-x.php:269
+
+#: bolao-x.php:771
+msgid "Você já está logado."
+msgstr ""
+
+#: bolao-x.php:782
+msgid "Senha incorreta."
+msgstr ""
+
+#: bolao-x.php:784
+msgid "Telefone não encontrado."
+msgstr ""
+
+#: bolao-x.php:790
+msgid "Preencha todos os campos."
+msgstr ""
+
+#: bolao-x.php:792
+msgid "Telefone já cadastrado."
+msgstr ""
+
+#: bolao-x.php:798
+msgid "Erro ao criar usuário."
+msgstr ""
+
+#: bolao-x.php:801
+msgid "Cadastro realizado com sucesso."
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum concurso ativo."
+msgstr ""
+
+#: bolao-x.php
+msgid "Apostas ainda não liberadas."
+msgstr ""
+
+#: bolao-x.php
+msgid "Adicionar mais um Jogo"
+msgstr ""
+
+#: bolao-x.php
+msgid "Valor da aposta: R$ %s"
+msgstr ""
+
+#: bolao-x.php
+msgid "Preço da aposta (R$)"
+msgstr ""
+
+#: bolao-x.php
+msgid "Logs de Pagamento"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum log encontrado."
+msgstr ""
+
+#: bolao-x.php
+msgid "Limpar logs"
+msgstr ""
+
+#: bolao-x.php
+msgid "Logs limpos."
+msgstr ""
+
+#: bolao-x.php:1082
+msgid "Você precisa entrar para acessar o painel."
+msgstr ""
+
+#: bolao-x.php:1085
+msgid "Perfil"
+msgstr ""
+
+#: bolao-x.php:1086
+msgid "Nova Aposta"
+msgstr ""
+
+#: bolao-x.php:1087
+msgid "Minhas Apostas"
+msgstr ""
+
+#: bolao-x.php:1088
+msgid "Resultados"
+msgstr ""
+
+#: bolao-x.php:1089
+msgid "Estatísticas"
+msgstr ""
+
+#: bolao-x.php:1090
+msgid "Histórico"
+msgstr ""
+
+#: bolao-x.php:1091
+msgid "Sair"
+msgstr ""
+
+#: bolao-x.php:808
+msgid "Telefone"
+msgstr ""
+
+#: bolao-x.php:809 bolao-x.php:816
+msgid "Senha"
+msgstr ""
+
+#: bolao-x.php:810
+msgid "Entrar"
+msgstr ""
+
+#: bolao-x.php:817
+msgid "Criar conta"
+msgstr ""
+
+#: bolao-x.php:820
+msgid "Acessar"
+msgstr ""
+
+#: bolao-x.php:820
+msgid "Cadastrar"
+msgstr ""
+
+#: bolao-x.php
+msgid "Login realizado com sucesso."
+msgstr ""
+
+#: bolao-x.php
+msgid "Cadastro realizado com sucesso."
+msgstr ""
+
+#: bolao-x.php
+msgid "Análises Gerais"
+msgstr ""
+
+#: bolao-x.php
+msgid "Exibicoes hoje: %d | Usuarios online: %d"
+msgstr ""
+
+#: bolao-x.php
+msgid "Visitas nos ultimos 15 dias"
+msgstr ""
+
+#: bolao-x.php
+msgid "Usuarios nos ultimos 15 dias"
+msgstr ""
+
+#: bolao-x.php
+msgid "Visitas por pais"
+msgstr ""
+
+#: bolao-x.php
+msgid "Plataformas usadas"
+msgstr ""
+
+#: bolao-x.php
+msgid "Navegadores usados"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pais mais popular"
+msgstr ""
+
+#: bolao-x.php
+msgid "Plataforma mais usada"
+msgstr ""
+
+#: bolao-x.php
+msgid "Navegadores mais usados"
+msgstr ""
+
+#: bolao-x.php
+msgid "USUÁRIOS ONLINE"
+msgstr ""
+
+#: bolao-x.php
+msgid "USUÁRIOS HOJE"
+msgstr ""
+
+#: bolao-x.php
+msgid "VISITAS NOS ÚLTIMOS 15 DIAS"
+msgstr ""
+
+#: bolao-x.php
+msgid "NAVEGADORES MAIS USADOS"
+msgstr ""
+
+#: bolao-x.php
+msgid "SISTEMAS OPERACIONAIS MAIS USADOS"
+msgstr ""
+\n#: bolao-x.php
+msgid "Apostador Fixo"
+msgstr ""
+\n#: bolao-x.php
+msgid "Manter para próximos concursos"
+msgstr ""
+
+#: bolao-x.php
+msgid "Tipo"
+msgstr ""
+
+#: bolao-x.php
+msgid "Fixas"
+msgstr ""
+
+#: bolao-x.php
+msgid "Rotativas"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nome do Apostador"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhuma aposta encontrada."
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum resultado encontrado."
+msgstr ""
+
+#: bolao-x.php
+msgid "Qual resultado deseja publicar?"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pesquisar Concursos"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pagamentos não confirmados"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pagamentos via Pix não confirmados"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum pagamento pendente."
+msgstr ""
+
+#: bolao-x.php
+msgid "Marcar como pago"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pagamento marcado como pago."
+msgstr ""
+
+#: bolao-x.php
+msgid "Editar Resultado"
+msgstr ""
+
+#: bolao-x.php
+msgid "Resultado:"
+msgstr ""
+
+#: bolao-x.php
+msgid "Concurso"
+msgstr ""
+
+#: bolao-x.php
+msgid "Resultado do Concurso %s"
+msgstr ""
+
+#: bolao-x.php
+msgid "Mais Pontos: %s com %d ponto(s)"
+msgstr ""
+
+#: bolao-x.php
+msgid "Menos Pontos: %s com %d ponto(s)"
+msgstr ""
+
+#: bolao-x.php
+msgid "Contemplados"
+msgstr ""
+
+#: bolao-x.php
+msgid "ÚLTIMOS RESULTADOS"
+msgstr ""
+
+#: bolao-x.php
+msgid "VER TODOS RESULTADOS"
+msgstr ""
+
+#: bolao-x.php
+msgid "VENCEDORES COM MAIS PONTOS"
+msgstr ""
+
+#: bolao-x.php
+msgid "VENCEDORES COM MENOS PONTOS"
+msgstr ""
+
+#: bolao-x.php
+msgid "TODAS AS APOSTAS"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum vencedor."
+msgstr ""
+
+#: bolao-x.php
+msgid "Filtrar por Concurso"
+msgstr ""
+
+#: bolao-x.php
+msgid "Ordenar por"
+msgstr ""
+
+#: bolao-x.php
+msgid "Pontuação"
+msgstr ""
+
+#: bolao-x.php
+msgid "Data"
+msgstr ""
+
+#: bolao-x.php
+msgid "Exportar Relatório"
+msgstr ""
+
+#: bolao-x.php
+msgid "ESTATÍSTICAS"
+msgstr ""
+
+#: bolao-x.php
+msgid "Total de Participantes: %d"
+msgstr ""
+
+#: bolao-x.php
+msgid "Média de Pontos: %.2f"
+msgstr ""
+
+#: bolao-x.php
+msgid "Taxa de Acerto: %s%%"
+msgstr ""
+
+#: bolao-x.php
+msgid "Nenhum concurso cadastrado."
+msgstr ""
+
+#: bolao-x.php
+msgid "Telefone inválido."
+msgstr ""
+
+#: bolao-x.php
+msgid "A senha precisa ter ao menos 6 caracteres."
+msgstr ""

--- a/bolao-x/lib/fpdf.php
+++ b/bolao-x/lib/fpdf.php
@@ -1,0 +1,1934 @@
+<?php
+/*******************************************************************************
+* FPDF                                                                         *
+*                                                                              *
+* Version: 1.86                                                                *
+* Date:    2023-06-25                                                          *
+* Author:  Olivier PLATHEY                                                     *
+*******************************************************************************/
+
+class FPDF
+{
+const VERSION = '1.86';
+protected $page;               // current page number
+protected $n;                  // current object number
+protected $offsets;            // array of object offsets
+protected $buffer;             // buffer holding in-memory PDF
+protected $pages;              // array containing pages
+protected $state;              // current document state
+protected $compress;           // compression flag
+protected $iconv;              // whether iconv is available
+protected $k;                  // scale factor (number of points in user unit)
+protected $DefOrientation;     // default orientation
+protected $CurOrientation;     // current orientation
+protected $StdPageSizes;       // standard page sizes
+protected $DefPageSize;        // default page size
+protected $CurPageSize;        // current page size
+protected $CurRotation;        // current page rotation
+protected $PageInfo;           // page-related data
+protected $wPt, $hPt;          // dimensions of current page in points
+protected $w, $h;              // dimensions of current page in user unit
+protected $lMargin;            // left margin
+protected $tMargin;            // top margin
+protected $rMargin;            // right margin
+protected $bMargin;            // page break margin
+protected $cMargin;            // cell margin
+protected $x, $y;              // current position in user unit
+protected $lasth;              // height of last printed cell
+protected $LineWidth;          // line width in user unit
+protected $fontpath;           // directory containing fonts
+protected $CoreFonts;          // array of core font names
+protected $fonts;              // array of used fonts
+protected $FontFiles;          // array of font files
+protected $encodings;          // array of encodings
+protected $cmaps;              // array of ToUnicode CMaps
+protected $FontFamily;         // current font family
+protected $FontStyle;          // current font style
+protected $underline;          // underlining flag
+protected $CurrentFont;        // current font info
+protected $FontSizePt;         // current font size in points
+protected $FontSize;           // current font size in user unit
+protected $DrawColor;          // commands for drawing color
+protected $FillColor;          // commands for filling color
+protected $TextColor;          // commands for text color
+protected $ColorFlag;          // indicates whether fill and text colors are different
+protected $WithAlpha;          // indicates whether alpha channel is used
+protected $ws;                 // word spacing
+protected $images;             // array of used images
+protected $PageLinks;          // array of links in pages
+protected $links;              // array of internal links
+protected $AutoPageBreak;      // automatic page breaking
+protected $PageBreakTrigger;   // threshold used to trigger page breaks
+protected $InHeader;           // flag set when processing header
+protected $InFooter;           // flag set when processing footer
+protected $AliasNbPages;       // alias for total number of pages
+protected $ZoomMode;           // zoom display mode
+protected $LayoutMode;         // layout display mode
+protected $metadata;           // document properties
+protected $CreationDate;       // document creation date
+protected $PDFVersion;         // PDF version number
+
+/*******************************************************************************
+*                               Public methods                                 *
+*******************************************************************************/
+
+function __construct($orientation='P', $unit='mm', $size='A4')
+{
+	// Initialization of properties
+	$this->state = 0;
+	$this->page = 0;
+	$this->n = 2;
+	$this->buffer = '';
+	$this->pages = array();
+	$this->PageInfo = array();
+	$this->fonts = array();
+	$this->FontFiles = array();
+	$this->encodings = array();
+	$this->cmaps = array();
+	$this->images = array();
+	$this->links = array();
+	$this->InHeader = false;
+	$this->InFooter = false;
+	$this->lasth = 0;
+	$this->FontFamily = '';
+	$this->FontStyle = '';
+	$this->FontSizePt = 12;
+	$this->underline = false;
+	$this->DrawColor = '0 G';
+	$this->FillColor = '0 g';
+	$this->TextColor = '0 g';
+	$this->ColorFlag = false;
+	$this->WithAlpha = false;
+	$this->ws = 0;
+	$this->iconv = function_exists('iconv');
+	// Font path
+	if(defined('FPDF_FONTPATH'))
+		$this->fontpath = FPDF_FONTPATH;
+	else
+		$this->fontpath = dirname(__FILE__).'/font/';
+	// Core fonts
+	$this->CoreFonts = array('courier', 'helvetica', 'times', 'symbol', 'zapfdingbats');
+	// Scale factor
+	if($unit=='pt')
+		$this->k = 1;
+	elseif($unit=='mm')
+		$this->k = 72/25.4;
+	elseif($unit=='cm')
+		$this->k = 72/2.54;
+	elseif($unit=='in')
+		$this->k = 72;
+	else
+		$this->Error('Incorrect unit: '.$unit);
+	// Page sizes
+	$this->StdPageSizes = array('a3'=>array(841.89,1190.55), 'a4'=>array(595.28,841.89), 'a5'=>array(420.94,595.28),
+		'letter'=>array(612,792), 'legal'=>array(612,1008));
+	$size = $this->_getpagesize($size);
+	$this->DefPageSize = $size;
+	$this->CurPageSize = $size;
+	// Page orientation
+	$orientation = strtolower($orientation);
+	if($orientation=='p' || $orientation=='portrait')
+	{
+		$this->DefOrientation = 'P';
+		$this->w = $size[0];
+		$this->h = $size[1];
+	}
+	elseif($orientation=='l' || $orientation=='landscape')
+	{
+		$this->DefOrientation = 'L';
+		$this->w = $size[1];
+		$this->h = $size[0];
+	}
+	else
+		$this->Error('Incorrect orientation: '.$orientation);
+	$this->CurOrientation = $this->DefOrientation;
+	$this->wPt = $this->w*$this->k;
+	$this->hPt = $this->h*$this->k;
+	// Page rotation
+	$this->CurRotation = 0;
+	// Page margins (1 cm)
+	$margin = 28.35/$this->k;
+	$this->SetMargins($margin,$margin);
+	// Interior cell margin (1 mm)
+	$this->cMargin = $margin/10;
+	// Line width (0.2 mm)
+	$this->LineWidth = .567/$this->k;
+	// Automatic page break
+	$this->SetAutoPageBreak(true,2*$margin);
+	// Default display mode
+	$this->SetDisplayMode('default');
+	// Enable compression
+	$this->SetCompression(true);
+	// Metadata
+	$this->metadata = array('Producer'=>'FPDF '.self::VERSION);
+	// Set default PDF version number
+	$this->PDFVersion = '1.3';
+}
+
+function SetMargins($left, $top, $right=null)
+{
+	// Set left, top and right margins
+	$this->lMargin = $left;
+	$this->tMargin = $top;
+	if($right===null)
+		$right = $left;
+	$this->rMargin = $right;
+}
+
+function SetLeftMargin($margin)
+{
+	// Set left margin
+	$this->lMargin = $margin;
+	if($this->page>0 && $this->x<$margin)
+		$this->x = $margin;
+}
+
+function SetTopMargin($margin)
+{
+	// Set top margin
+	$this->tMargin = $margin;
+}
+
+function SetRightMargin($margin)
+{
+	// Set right margin
+	$this->rMargin = $margin;
+}
+
+function SetAutoPageBreak($auto, $margin=0)
+{
+	// Set auto page break mode and triggering margin
+	$this->AutoPageBreak = $auto;
+	$this->bMargin = $margin;
+	$this->PageBreakTrigger = $this->h-$margin;
+}
+
+function SetDisplayMode($zoom, $layout='default')
+{
+	// Set display mode in viewer
+	if($zoom=='fullpage' || $zoom=='fullwidth' || $zoom=='real' || $zoom=='default' || !is_string($zoom))
+		$this->ZoomMode = $zoom;
+	else
+		$this->Error('Incorrect zoom display mode: '.$zoom);
+	if($layout=='single' || $layout=='continuous' || $layout=='two' || $layout=='default')
+		$this->LayoutMode = $layout;
+	else
+		$this->Error('Incorrect layout display mode: '.$layout);
+}
+
+function SetCompression($compress)
+{
+	// Set page compression
+	if(function_exists('gzcompress'))
+		$this->compress = $compress;
+	else
+		$this->compress = false;
+}
+
+function SetTitle($title, $isUTF8=false)
+{
+	// Title of document
+	$this->metadata['Title'] = $isUTF8 ? $title : $this->_UTF8encode($title);
+}
+
+function SetAuthor($author, $isUTF8=false)
+{
+	// Author of document
+	$this->metadata['Author'] = $isUTF8 ? $author : $this->_UTF8encode($author);
+}
+
+function SetSubject($subject, $isUTF8=false)
+{
+	// Subject of document
+	$this->metadata['Subject'] = $isUTF8 ? $subject : $this->_UTF8encode($subject);
+}
+
+function SetKeywords($keywords, $isUTF8=false)
+{
+	// Keywords of document
+	$this->metadata['Keywords'] = $isUTF8 ? $keywords : $this->_UTF8encode($keywords);
+}
+
+function SetCreator($creator, $isUTF8=false)
+{
+	// Creator of document
+	$this->metadata['Creator'] = $isUTF8 ? $creator : $this->_UTF8encode($creator);
+}
+
+function AliasNbPages($alias='{nb}')
+{
+	// Define an alias for total number of pages
+	$this->AliasNbPages = $alias;
+}
+
+function Error($msg)
+{
+	// Fatal error
+	throw new Exception('FPDF error: '.$msg);
+}
+
+function Close()
+{
+	// Terminate document
+	if($this->state==3)
+		return;
+	if($this->page==0)
+		$this->AddPage();
+	// Page footer
+	$this->InFooter = true;
+	$this->Footer();
+	$this->InFooter = false;
+	// Close page
+	$this->_endpage();
+	// Close document
+	$this->_enddoc();
+}
+
+function AddPage($orientation='', $size='', $rotation=0)
+{
+	// Start a new page
+	if($this->state==3)
+		$this->Error('The document is closed');
+	$family = $this->FontFamily;
+	$style = $this->FontStyle.($this->underline ? 'U' : '');
+	$fontsize = $this->FontSizePt;
+	$lw = $this->LineWidth;
+	$dc = $this->DrawColor;
+	$fc = $this->FillColor;
+	$tc = $this->TextColor;
+	$cf = $this->ColorFlag;
+	if($this->page>0)
+	{
+		// Page footer
+		$this->InFooter = true;
+		$this->Footer();
+		$this->InFooter = false;
+		// Close page
+		$this->_endpage();
+	}
+	// Start new page
+	$this->_beginpage($orientation,$size,$rotation);
+	// Set line cap style to square
+	$this->_out('2 J');
+	// Set line width
+	$this->LineWidth = $lw;
+	$this->_out(sprintf('%.2F w',$lw*$this->k));
+	// Set font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Set colors
+	$this->DrawColor = $dc;
+	if($dc!='0 G')
+		$this->_out($dc);
+	$this->FillColor = $fc;
+	if($fc!='0 g')
+		$this->_out($fc);
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+	// Page header
+	$this->InHeader = true;
+	$this->Header();
+	$this->InHeader = false;
+	// Restore line width
+	if($this->LineWidth!=$lw)
+	{
+		$this->LineWidth = $lw;
+		$this->_out(sprintf('%.2F w',$lw*$this->k));
+	}
+	// Restore font
+	if($family)
+		$this->SetFont($family,$style,$fontsize);
+	// Restore colors
+	if($this->DrawColor!=$dc)
+	{
+		$this->DrawColor = $dc;
+		$this->_out($dc);
+	}
+	if($this->FillColor!=$fc)
+	{
+		$this->FillColor = $fc;
+		$this->_out($fc);
+	}
+	$this->TextColor = $tc;
+	$this->ColorFlag = $cf;
+}
+
+function Header()
+{
+	// To be implemented in your own inherited class
+}
+
+function Footer()
+{
+	// To be implemented in your own inherited class
+}
+
+function PageNo()
+{
+	// Get current page number
+	return $this->page;
+}
+
+function SetDrawColor($r, $g=null, $b=null)
+{
+	// Set color for all stroking operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->DrawColor = sprintf('%.3F G',$r/255);
+	else
+		$this->DrawColor = sprintf('%.3F %.3F %.3F RG',$r/255,$g/255,$b/255);
+	if($this->page>0)
+		$this->_out($this->DrawColor);
+}
+
+function SetFillColor($r, $g=null, $b=null)
+{
+	// Set color for all filling operations
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->FillColor = sprintf('%.3F g',$r/255);
+	else
+		$this->FillColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+	if($this->page>0)
+		$this->_out($this->FillColor);
+}
+
+function SetTextColor($r, $g=null, $b=null)
+{
+	// Set color for text
+	if(($r==0 && $g==0 && $b==0) || $g===null)
+		$this->TextColor = sprintf('%.3F g',$r/255);
+	else
+		$this->TextColor = sprintf('%.3F %.3F %.3F rg',$r/255,$g/255,$b/255);
+	$this->ColorFlag = ($this->FillColor!=$this->TextColor);
+}
+
+function GetStringWidth($s)
+{
+	// Get width of a string in the current font
+	$cw = $this->CurrentFont['cw'];
+	$w = 0;
+	$s = (string)$s;
+	$l = strlen($s);
+	for($i=0;$i<$l;$i++)
+		$w += $cw[$s[$i]];
+	return $w*$this->FontSize/1000;
+}
+
+function SetLineWidth($width)
+{
+	// Set line width
+	$this->LineWidth = $width;
+	if($this->page>0)
+		$this->_out(sprintf('%.2F w',$width*$this->k));
+}
+
+function Line($x1, $y1, $x2, $y2)
+{
+	// Draw a line
+	$this->_out(sprintf('%.2F %.2F m %.2F %.2F l S',$x1*$this->k,($this->h-$y1)*$this->k,$x2*$this->k,($this->h-$y2)*$this->k));
+}
+
+function Rect($x, $y, $w, $h, $style='')
+{
+	// Draw a rectangle
+	if($style=='F')
+		$op = 'f';
+	elseif($style=='FD' || $style=='DF')
+		$op = 'B';
+	else
+		$op = 'S';
+	$this->_out(sprintf('%.2F %.2F %.2F %.2F re %s',$x*$this->k,($this->h-$y)*$this->k,$w*$this->k,-$h*$this->k,$op));
+}
+
+function AddFont($family, $style='', $file='', $dir='')
+{
+	// Add a TrueType, OpenType or Type1 font
+	$family = strtolower($family);
+	if($file=='')
+		$file = str_replace(' ','',$family).strtolower($style).'.php';
+	$style = strtoupper($style);
+	if($style=='IB')
+		$style = 'BI';
+	$fontkey = $family.$style;
+	if(isset($this->fonts[$fontkey]))
+		return;
+	if(strpos($file,'/')!==false || strpos($file,"\\")!==false)
+		$this->Error('Incorrect font definition file name: '.$file);
+	if($dir=='')
+		$dir = $this->fontpath;
+	if(substr($dir,-1)!='/' && substr($dir,-1)!='\\')
+		$dir .= '/';
+	$info = $this->_loadfont($dir.$file);
+	$info['i'] = count($this->fonts)+1;
+	if(!empty($info['file']))
+	{
+		// Embedded font
+		$info['file'] = $dir.$info['file'];
+		if($info['type']=='TrueType')
+			$this->FontFiles[$info['file']] = array('length1'=>$info['originalsize']);
+		else
+			$this->FontFiles[$info['file']] = array('length1'=>$info['size1'], 'length2'=>$info['size2']);
+	}
+	$this->fonts[$fontkey] = $info;
+}
+
+function SetFont($family, $style='', $size=0)
+{
+	// Select a font; size given in points
+	if($family=='')
+		$family = $this->FontFamily;
+	else
+		$family = strtolower($family);
+	$style = strtoupper($style);
+	if(strpos($style,'U')!==false)
+	{
+		$this->underline = true;
+		$style = str_replace('U','',$style);
+	}
+	else
+		$this->underline = false;
+	if($style=='IB')
+		$style = 'BI';
+	if($size==0)
+		$size = $this->FontSizePt;
+	// Test if font is already selected
+	if($this->FontFamily==$family && $this->FontStyle==$style && $this->FontSizePt==$size)
+		return;
+	// Test if font is already loaded
+	$fontkey = $family.$style;
+	if(!isset($this->fonts[$fontkey]))
+	{
+		// Test if one of the core fonts
+		if($family=='arial')
+			$family = 'helvetica';
+		if(in_array($family,$this->CoreFonts))
+		{
+			if($family=='symbol' || $family=='zapfdingbats')
+				$style = '';
+			$fontkey = $family.$style;
+			if(!isset($this->fonts[$fontkey]))
+				$this->AddFont($family,$style);
+		}
+		else
+			$this->Error('Undefined font: '.$family.' '.$style);
+	}
+	// Select it
+	$this->FontFamily = $family;
+	$this->FontStyle = $style;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	$this->CurrentFont = $this->fonts[$fontkey];
+	if($this->page>0)
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function SetFontSize($size)
+{
+	// Set font size in points
+	if($this->FontSizePt==$size)
+		return;
+	$this->FontSizePt = $size;
+	$this->FontSize = $size/$this->k;
+	if($this->page>0 && isset($this->CurrentFont))
+		$this->_out(sprintf('BT /F%d %.2F Tf ET',$this->CurrentFont['i'],$this->FontSizePt));
+}
+
+function AddLink()
+{
+	// Create a new internal link
+	$n = count($this->links)+1;
+	$this->links[$n] = array(0, 0);
+	return $n;
+}
+
+function SetLink($link, $y=0, $page=-1)
+{
+	// Set destination of internal link
+	if($y==-1)
+		$y = $this->y;
+	if($page==-1)
+		$page = $this->page;
+	$this->links[$link] = array($page, $y);
+}
+
+function Link($x, $y, $w, $h, $link)
+{
+	// Put a link on the page
+	$this->PageLinks[$this->page][] = array($x*$this->k, $this->hPt-$y*$this->k, $w*$this->k, $h*$this->k, $link);
+}
+
+function Text($x, $y, $txt)
+{
+	// Output a string
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$txt = (string)$txt;
+	$s = sprintf('BT %.2F %.2F Td (%s) Tj ET',$x*$this->k,($this->h-$y)*$this->k,$this->_escape($txt));
+	if($this->underline && $txt!=='')
+		$s .= ' '.$this->_dounderline($x,$y,$txt);
+	if($this->ColorFlag)
+		$s = 'q '.$this->TextColor.' '.$s.' Q';
+	$this->_out($s);
+}
+
+function AcceptPageBreak()
+{
+	// Accept automatic page break or not
+	return $this->AutoPageBreak;
+}
+
+function Cell($w, $h=0, $txt='', $border=0, $ln=0, $align='', $fill=false, $link='')
+{
+	// Output a cell
+	$k = $this->k;
+	if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+	{
+		// Automatic page break
+		$x = $this->x;
+		$ws = $this->ws;
+		if($ws>0)
+		{
+			$this->ws = 0;
+			$this->_out('0 Tw');
+		}
+		$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+		$this->x = $x;
+		if($ws>0)
+		{
+			$this->ws = $ws;
+			$this->_out(sprintf('%.3F Tw',$ws*$k));
+		}
+	}
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$s = '';
+	if($fill || $border==1)
+	{
+		if($fill)
+			$op = ($border==1) ? 'B' : 'f';
+		else
+			$op = 'S';
+		$s = sprintf('%.2F %.2F %.2F %.2F re %s ',$this->x*$k,($this->h-$this->y)*$k,$w*$k,-$h*$k,$op);
+	}
+	if(is_string($border))
+	{
+		$x = $this->x;
+		$y = $this->y;
+		if(strpos($border,'L')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,$x*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'T')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-$y)*$k);
+		if(strpos($border,'R')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',($x+$w)*$k,($this->h-$y)*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+		if(strpos($border,'B')!==false)
+			$s .= sprintf('%.2F %.2F m %.2F %.2F l S ',$x*$k,($this->h-($y+$h))*$k,($x+$w)*$k,($this->h-($y+$h))*$k);
+	}
+	$txt = (string)$txt;
+	if($txt!=='')
+	{
+		if(!isset($this->CurrentFont))
+			$this->Error('No font has been set');
+		if($align=='R')
+			$dx = $w-$this->cMargin-$this->GetStringWidth($txt);
+		elseif($align=='C')
+			$dx = ($w-$this->GetStringWidth($txt))/2;
+		else
+			$dx = $this->cMargin;
+		if($this->ColorFlag)
+			$s .= 'q '.$this->TextColor.' ';
+		$s .= sprintf('BT %.2F %.2F Td (%s) Tj ET',($this->x+$dx)*$k,($this->h-($this->y+.5*$h+.3*$this->FontSize))*$k,$this->_escape($txt));
+		if($this->underline)
+			$s .= ' '.$this->_dounderline($this->x+$dx,$this->y+.5*$h+.3*$this->FontSize,$txt);
+		if($this->ColorFlag)
+			$s .= ' Q';
+		if($link)
+			$this->Link($this->x+$dx,$this->y+.5*$h-.5*$this->FontSize,$this->GetStringWidth($txt),$this->FontSize,$link);
+	}
+	if($s)
+		$this->_out($s);
+	$this->lasth = $h;
+	if($ln>0)
+	{
+		// Go to next line
+		$this->y += $h;
+		if($ln==1)
+			$this->x = $this->lMargin;
+	}
+	else
+		$this->x += $w;
+}
+
+function MultiCell($w, $h, $txt, $border=0, $align='J', $fill=false)
+{
+	// Output text with automatic or explicit line breaks
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	if($w==0)
+		$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	if($nb>0 && $s[$nb-1]=="\n")
+		$nb--;
+	$b = 0;
+	if($border)
+	{
+		if($border==1)
+		{
+			$border = 'LTRB';
+			$b = 'LRT';
+			$b2 = 'LR';
+		}
+		else
+		{
+			$b2 = '';
+			if(strpos($border,'L')!==false)
+				$b2 .= 'L';
+			if(strpos($border,'R')!==false)
+				$b2 .= 'R';
+			$b = (strpos($border,'T')!==false) ? $b2.'T' : $b2;
+		}
+	}
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$ns = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			if($this->ws>0)
+			{
+				$this->ws = 0;
+				$this->_out('0 Tw');
+			}
+			$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+			continue;
+		}
+		if($c==' ')
+		{
+			$sep = $i;
+			$ls = $l;
+			$ns++;
+		}
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($i==$j)
+					$i++;
+				if($this->ws>0)
+				{
+					$this->ws = 0;
+					$this->_out('0 Tw');
+				}
+				$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+			}
+			else
+			{
+				if($align=='J')
+				{
+					$this->ws = ($ns>1) ? ($wmax-$ls)/1000*$this->FontSize/($ns-1) : 0;
+					$this->_out(sprintf('%.3F Tw',$this->ws*$this->k));
+				}
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),$b,2,$align,$fill);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			$ns = 0;
+			$nl++;
+			if($border && $nl==2)
+				$b = $b2;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($this->ws>0)
+	{
+		$this->ws = 0;
+		$this->_out('0 Tw');
+	}
+	if($border && strpos($border,'B')!==false)
+		$b .= 'B';
+	$this->Cell($w,$h,substr($s,$j,$i-$j),$b,2,$align,$fill);
+	$this->x = $this->lMargin;
+}
+
+function Write($h, $txt, $link='')
+{
+	// Output text in flowing mode
+	if(!isset($this->CurrentFont))
+		$this->Error('No font has been set');
+	$cw = $this->CurrentFont['cw'];
+	$w = $this->w-$this->rMargin-$this->x;
+	$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+	$s = str_replace("\r",'',(string)$txt);
+	$nb = strlen($s);
+	$sep = -1;
+	$i = 0;
+	$j = 0;
+	$l = 0;
+	$nl = 1;
+	while($i<$nb)
+	{
+		// Get next character
+		$c = $s[$i];
+		if($c=="\n")
+		{
+			// Explicit line break
+			$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			$i++;
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+			continue;
+		}
+		if($c==' ')
+			$sep = $i;
+		$l += $cw[$c];
+		if($l>$wmax)
+		{
+			// Automatic line break
+			if($sep==-1)
+			{
+				if($this->x>$this->lMargin)
+				{
+					// Move to next line
+					$this->x = $this->lMargin;
+					$this->y += $h;
+					$w = $this->w-$this->rMargin-$this->x;
+					$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+					$i++;
+					$nl++;
+					continue;
+				}
+				if($i==$j)
+					$i++;
+				$this->Cell($w,$h,substr($s,$j,$i-$j),0,2,'',false,$link);
+			}
+			else
+			{
+				$this->Cell($w,$h,substr($s,$j,$sep-$j),0,2,'',false,$link);
+				$i = $sep+1;
+			}
+			$sep = -1;
+			$j = $i;
+			$l = 0;
+			if($nl==1)
+			{
+				$this->x = $this->lMargin;
+				$w = $this->w-$this->rMargin-$this->x;
+				$wmax = ($w-2*$this->cMargin)*1000/$this->FontSize;
+			}
+			$nl++;
+		}
+		else
+			$i++;
+	}
+	// Last chunk
+	if($i!=$j)
+		$this->Cell($l/1000*$this->FontSize,$h,substr($s,$j),0,0,'',false,$link);
+}
+
+function Ln($h=null)
+{
+	// Line feed; default value is the last cell height
+	$this->x = $this->lMargin;
+	if($h===null)
+		$this->y += $this->lasth;
+	else
+		$this->y += $h;
+}
+
+function Image($file, $x=null, $y=null, $w=0, $h=0, $type='', $link='')
+{
+	// Put an image on the page
+	if($file=='')
+		$this->Error('Image file name is empty');
+	if(!isset($this->images[$file]))
+	{
+		// First use of this image, get info
+		if($type=='')
+		{
+			$pos = strrpos($file,'.');
+			if(!$pos)
+				$this->Error('Image file has no extension and no type was specified: '.$file);
+			$type = substr($file,$pos+1);
+		}
+		$type = strtolower($type);
+		if($type=='jpeg')
+			$type = 'jpg';
+		$mtd = '_parse'.$type;
+		if(!method_exists($this,$mtd))
+			$this->Error('Unsupported image type: '.$type);
+		$info = $this->$mtd($file);
+		$info['i'] = count($this->images)+1;
+		$this->images[$file] = $info;
+	}
+	else
+		$info = $this->images[$file];
+
+	// Automatic width and height calculation if needed
+	if($w==0 && $h==0)
+	{
+		// Put image at 96 dpi
+		$w = -96;
+		$h = -96;
+	}
+	if($w<0)
+		$w = -$info['w']*72/$w/$this->k;
+	if($h<0)
+		$h = -$info['h']*72/$h/$this->k;
+	if($w==0)
+		$w = $h*$info['w']/$info['h'];
+	if($h==0)
+		$h = $w*$info['h']/$info['w'];
+
+	// Flowing mode
+	if($y===null)
+	{
+		if($this->y+$h>$this->PageBreakTrigger && !$this->InHeader && !$this->InFooter && $this->AcceptPageBreak())
+		{
+			// Automatic page break
+			$x2 = $this->x;
+			$this->AddPage($this->CurOrientation,$this->CurPageSize,$this->CurRotation);
+			$this->x = $x2;
+		}
+		$y = $this->y;
+		$this->y += $h;
+	}
+
+	if($x===null)
+		$x = $this->x;
+	$this->_out(sprintf('q %.2F 0 0 %.2F %.2F %.2F cm /I%d Do Q',$w*$this->k,$h*$this->k,$x*$this->k,($this->h-($y+$h))*$this->k,$info['i']));
+	if($link)
+		$this->Link($x,$y,$w,$h,$link);
+}
+
+function GetPageWidth()
+{
+	// Get current page width
+	return $this->w;
+}
+
+function GetPageHeight()
+{
+	// Get current page height
+	return $this->h;
+}
+
+function GetX()
+{
+	// Get x position
+	return $this->x;
+}
+
+function SetX($x)
+{
+	// Set x position
+	if($x>=0)
+		$this->x = $x;
+	else
+		$this->x = $this->w+$x;
+}
+
+function GetY()
+{
+	// Get y position
+	return $this->y;
+}
+
+function SetY($y, $resetX=true)
+{
+	// Set y position and optionally reset x
+	if($y>=0)
+		$this->y = $y;
+	else
+		$this->y = $this->h+$y;
+	if($resetX)
+		$this->x = $this->lMargin;
+}
+
+function SetXY($x, $y)
+{
+	// Set x and y positions
+	$this->SetX($x);
+	$this->SetY($y,false);
+}
+
+function Output($dest='', $name='', $isUTF8=false)
+{
+	// Output PDF to some destination
+	$this->Close();
+	if(strlen($name)==1 && strlen($dest)!=1)
+	{
+		// Fix parameter order
+		$tmp = $dest;
+		$dest = $name;
+		$name = $tmp;
+	}
+	if($dest=='')
+		$dest = 'I';
+	if($name=='')
+		$name = 'doc.pdf';
+	switch(strtoupper($dest))
+	{
+		case 'I':
+			// Send to standard output
+			$this->_checkoutput();
+			if(PHP_SAPI!='cli')
+			{
+				// We send to a browser
+				header('Content-Type: application/pdf');
+				header('Content-Disposition: inline; '.$this->_httpencode('filename',$name,$isUTF8));
+				header('Cache-Control: private, max-age=0, must-revalidate');
+				header('Pragma: public');
+			}
+			echo $this->buffer;
+			break;
+		case 'D':
+			// Download file
+			$this->_checkoutput();
+			header('Content-Type: application/pdf');
+			header('Content-Disposition: attachment; '.$this->_httpencode('filename',$name,$isUTF8));
+			header('Cache-Control: private, max-age=0, must-revalidate');
+			header('Pragma: public');
+			echo $this->buffer;
+			break;
+		case 'F':
+			// Save to local file
+			if(!file_put_contents($name,$this->buffer))
+				$this->Error('Unable to create output file: '.$name);
+			break;
+		case 'S':
+			// Return as a string
+			return $this->buffer;
+		default:
+			$this->Error('Incorrect output destination: '.$dest);
+	}
+	return '';
+}
+
+/*******************************************************************************
+*                              Protected methods                               *
+*******************************************************************************/
+
+protected function _checkoutput()
+{
+	if(PHP_SAPI!='cli')
+	{
+		if(headers_sent($file,$line))
+			$this->Error("Some data has already been output, can't send PDF file (output started at $file:$line)");
+	}
+	if(ob_get_length())
+	{
+		// The output buffer is not empty
+		if(preg_match('/^(\xEF\xBB\xBF)?\s*$/',ob_get_contents()))
+		{
+			// It contains only a UTF-8 BOM and/or whitespace, let's clean it
+			ob_clean();
+		}
+		else
+			$this->Error("Some data has already been output, can't send PDF file");
+	}
+}
+
+protected function _getpagesize($size)
+{
+	if(is_string($size))
+	{
+		$size = strtolower($size);
+		if(!isset($this->StdPageSizes[$size]))
+			$this->Error('Unknown page size: '.$size);
+		$a = $this->StdPageSizes[$size];
+		return array($a[0]/$this->k, $a[1]/$this->k);
+	}
+	else
+	{
+		if($size[0]>$size[1])
+			return array($size[1], $size[0]);
+		else
+			return $size;
+	}
+}
+
+protected function _beginpage($orientation, $size, $rotation)
+{
+	$this->page++;
+	$this->pages[$this->page] = '';
+	$this->PageLinks[$this->page] = array();
+	$this->state = 2;
+	$this->x = $this->lMargin;
+	$this->y = $this->tMargin;
+	$this->FontFamily = '';
+	// Check page size and orientation
+	if($orientation=='')
+		$orientation = $this->DefOrientation;
+	else
+		$orientation = strtoupper($orientation[0]);
+	if($size=='')
+		$size = $this->DefPageSize;
+	else
+		$size = $this->_getpagesize($size);
+	if($orientation!=$this->CurOrientation || $size[0]!=$this->CurPageSize[0] || $size[1]!=$this->CurPageSize[1])
+	{
+		// New size or orientation
+		if($orientation=='P')
+		{
+			$this->w = $size[0];
+			$this->h = $size[1];
+		}
+		else
+		{
+			$this->w = $size[1];
+			$this->h = $size[0];
+		}
+		$this->wPt = $this->w*$this->k;
+		$this->hPt = $this->h*$this->k;
+		$this->PageBreakTrigger = $this->h-$this->bMargin;
+		$this->CurOrientation = $orientation;
+		$this->CurPageSize = $size;
+	}
+	if($orientation!=$this->DefOrientation || $size[0]!=$this->DefPageSize[0] || $size[1]!=$this->DefPageSize[1])
+		$this->PageInfo[$this->page]['size'] = array($this->wPt, $this->hPt);
+	if($rotation!=0)
+	{
+		if($rotation%90!=0)
+			$this->Error('Incorrect rotation value: '.$rotation);
+		$this->PageInfo[$this->page]['rotation'] = $rotation;
+	}
+	$this->CurRotation = $rotation;
+}
+
+protected function _endpage()
+{
+	$this->state = 1;
+}
+
+protected function _loadfont($path)
+{
+	// Load a font definition file
+	include($path);
+	if(!isset($name))
+		$this->Error('Could not include font definition file: '.$path);
+	if(isset($enc))
+		$enc = strtolower($enc);
+	if(!isset($subsetted))
+		$subsetted = false;
+	return get_defined_vars();
+}
+
+protected function _isascii($s)
+{
+	// Test if string is ASCII
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		if(ord($s[$i])>127)
+			return false;
+	}
+	return true;
+}
+
+protected function _httpencode($param, $value, $isUTF8)
+{
+	// Encode HTTP header field parameter
+	if($this->_isascii($value))
+		return $param.'="'.$value.'"';
+	if(!$isUTF8)
+		$value = $this->_UTF8encode($value);
+	return $param."*=UTF-8''".rawurlencode($value);
+}
+
+protected function _UTF8encode($s)
+{
+	// Convert ISO-8859-1 to UTF-8
+	if($this->iconv)
+		return iconv('ISO-8859-1','UTF-8',$s);
+	$res = '';
+	$nb = strlen($s);
+	for($i=0;$i<$nb;$i++)
+	{
+		$c = $s[$i];
+		$v = ord($c);
+		if($v>=128)
+		{
+			$res .= chr(0xC0 | ($v >> 6));
+			$res .= chr(0x80 | ($v & 0x3F));
+		}
+		else
+			$res .= $c;
+	}
+	return $res;
+}
+
+protected function _UTF8toUTF16($s)
+{
+	// Convert UTF-8 to UTF-16BE with BOM
+	$res = "\xFE\xFF";
+	if($this->iconv)
+		return $res.iconv('UTF-8','UTF-16BE',$s);
+	$nb = strlen($s);
+	$i = 0;
+	while($i<$nb)
+	{
+		$c1 = ord($s[$i++]);
+		if($c1>=224)
+		{
+			// 3-byte character
+			$c2 = ord($s[$i++]);
+			$c3 = ord($s[$i++]);
+			$res .= chr((($c1 & 0x0F)<<4) + (($c2 & 0x3C)>>2));
+			$res .= chr((($c2 & 0x03)<<6) + ($c3 & 0x3F));
+		}
+		elseif($c1>=192)
+		{
+			// 2-byte character
+			$c2 = ord($s[$i++]);
+			$res .= chr(($c1 & 0x1C)>>2);
+			$res .= chr((($c1 & 0x03)<<6) + ($c2 & 0x3F));
+		}
+		else
+		{
+			// Single-byte character
+			$res .= "\0".chr($c1);
+		}
+	}
+	return $res;
+}
+
+protected function _escape($s)
+{
+	// Escape special characters
+	if(strpos($s,'(')!==false || strpos($s,')')!==false || strpos($s,'\\')!==false || strpos($s,"\r")!==false)
+		return str_replace(array('\\','(',')',"\r"), array('\\\\','\\(','\\)','\\r'), $s);
+	else
+		return $s;
+}
+
+protected function _textstring($s)
+{
+	// Format a text string
+	if(!$this->_isascii($s))
+		$s = $this->_UTF8toUTF16($s);
+	return '('.$this->_escape($s).')';
+}
+
+protected function _dounderline($x, $y, $txt)
+{
+	// Underline text
+	$up = $this->CurrentFont['up'];
+	$ut = $this->CurrentFont['ut'];
+	$w = $this->GetStringWidth($txt)+$this->ws*substr_count($txt,' ');
+	return sprintf('%.2F %.2F %.2F %.2F re f',$x*$this->k,($this->h-($y-$up/1000*$this->FontSize))*$this->k,$w*$this->k,-$ut/1000*$this->FontSizePt);
+}
+
+protected function _parsejpg($file)
+{
+	// Extract info from a JPEG file
+	$a = getimagesize($file);
+	if(!$a)
+		$this->Error('Missing or incorrect image file: '.$file);
+	if($a[2]!=2)
+		$this->Error('Not a JPEG file: '.$file);
+	if(!isset($a['channels']) || $a['channels']==3)
+		$colspace = 'DeviceRGB';
+	elseif($a['channels']==4)
+		$colspace = 'DeviceCMYK';
+	else
+		$colspace = 'DeviceGray';
+	$bpc = isset($a['bits']) ? $a['bits'] : 8;
+	$data = file_get_contents($file);
+	return array('w'=>$a[0], 'h'=>$a[1], 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'DCTDecode', 'data'=>$data);
+}
+
+protected function _parsepng($file)
+{
+	// Extract info from a PNG file
+	$f = fopen($file,'rb');
+	if(!$f)
+		$this->Error('Can\'t open image file: '.$file);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _parsepngstream($f, $file)
+{
+	// Check signature
+	if($this->_readstream($f,8)!=chr(137).'PNG'.chr(13).chr(10).chr(26).chr(10))
+		$this->Error('Not a PNG file: '.$file);
+
+	// Read header chunk
+	$this->_readstream($f,4);
+	if($this->_readstream($f,4)!='IHDR')
+		$this->Error('Incorrect PNG file: '.$file);
+	$w = $this->_readint($f);
+	$h = $this->_readint($f);
+	$bpc = ord($this->_readstream($f,1));
+	if($bpc>8)
+		$this->Error('16-bit depth not supported: '.$file);
+	$ct = ord($this->_readstream($f,1));
+	if($ct==0 || $ct==4)
+		$colspace = 'DeviceGray';
+	elseif($ct==2 || $ct==6)
+		$colspace = 'DeviceRGB';
+	elseif($ct==3)
+		$colspace = 'Indexed';
+	else
+		$this->Error('Unknown color type: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown compression method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Unknown filter method: '.$file);
+	if(ord($this->_readstream($f,1))!=0)
+		$this->Error('Interlacing not supported: '.$file);
+	$this->_readstream($f,4);
+	$dp = '/Predictor 15 /Colors '.($colspace=='DeviceRGB' ? 3 : 1).' /BitsPerComponent '.$bpc.' /Columns '.$w;
+
+	// Scan chunks looking for palette, transparency and image data
+	$pal = '';
+	$trns = '';
+	$data = '';
+	do
+	{
+		$n = $this->_readint($f);
+		$type = $this->_readstream($f,4);
+		if($type=='PLTE')
+		{
+			// Read palette
+			$pal = $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='tRNS')
+		{
+			// Read transparency info
+			$t = $this->_readstream($f,$n);
+			if($ct==0)
+				$trns = array(ord(substr($t,1,1)));
+			elseif($ct==2)
+				$trns = array(ord(substr($t,1,1)), ord(substr($t,3,1)), ord(substr($t,5,1)));
+			else
+			{
+				$pos = strpos($t,chr(0));
+				if($pos!==false)
+					$trns = array($pos);
+			}
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IDAT')
+		{
+			// Read image data block
+			$data .= $this->_readstream($f,$n);
+			$this->_readstream($f,4);
+		}
+		elseif($type=='IEND')
+			break;
+		else
+			$this->_readstream($f,$n+4);
+	}
+	while($n);
+
+	if($colspace=='Indexed' && empty($pal))
+		$this->Error('Missing palette in '.$file);
+	$info = array('w'=>$w, 'h'=>$h, 'cs'=>$colspace, 'bpc'=>$bpc, 'f'=>'FlateDecode', 'dp'=>$dp, 'pal'=>$pal, 'trns'=>$trns);
+	if($ct>=4)
+	{
+		// Extract alpha channel
+		if(!function_exists('gzuncompress'))
+			$this->Error('Zlib not available, can\'t handle alpha channel: '.$file);
+		$data = gzuncompress($data);
+		$color = '';
+		$alpha = '';
+		if($ct==4)
+		{
+			// Gray image
+			$len = 2*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.)./s','$1',$line);
+				$alpha .= preg_replace('/.(.)/s','$1',$line);
+			}
+		}
+		else
+		{
+			// RGB image
+			$len = 4*$w;
+			for($i=0;$i<$h;$i++)
+			{
+				$pos = (1+$len)*$i;
+				$color .= $data[$pos];
+				$alpha .= $data[$pos];
+				$line = substr($data,$pos+1,$len);
+				$color .= preg_replace('/(.{3})./s','$1',$line);
+				$alpha .= preg_replace('/.{3}(.)/s','$1',$line);
+			}
+		}
+		unset($data);
+		$data = gzcompress($color);
+		$info['smask'] = gzcompress($alpha);
+		$this->WithAlpha = true;
+		if($this->PDFVersion<'1.4')
+			$this->PDFVersion = '1.4';
+	}
+	$info['data'] = $data;
+	return $info;
+}
+
+protected function _readstream($f, $n)
+{
+	// Read n bytes from stream
+	$res = '';
+	while($n>0 && !feof($f))
+	{
+		$s = fread($f,$n);
+		if($s===false)
+			$this->Error('Error while reading stream');
+		$n -= strlen($s);
+		$res .= $s;
+	}
+	if($n>0)
+		$this->Error('Unexpected end of stream');
+	return $res;
+}
+
+protected function _readint($f)
+{
+	// Read a 4-byte integer from stream
+	$a = unpack('Ni',$this->_readstream($f,4));
+	return $a['i'];
+}
+
+protected function _parsegif($file)
+{
+	// Extract info from a GIF file (via PNG conversion)
+	if(!function_exists('imagepng'))
+		$this->Error('GD extension is required for GIF support');
+	if(!function_exists('imagecreatefromgif'))
+		$this->Error('GD has no GIF read support');
+	$im = imagecreatefromgif($file);
+	if(!$im)
+		$this->Error('Missing or incorrect image file: '.$file);
+	imageinterlace($im,0);
+	ob_start();
+	imagepng($im);
+	$data = ob_get_clean();
+	imagedestroy($im);
+	$f = fopen('php://temp','rb+');
+	if(!$f)
+		$this->Error('Unable to create memory stream');
+	fwrite($f,$data);
+	rewind($f);
+	$info = $this->_parsepngstream($f,$file);
+	fclose($f);
+	return $info;
+}
+
+protected function _out($s)
+{
+	// Add a line to the current page
+	if($this->state==2)
+		$this->pages[$this->page] .= $s."\n";
+	elseif($this->state==0)
+		$this->Error('No page has been added yet');
+	elseif($this->state==1)
+		$this->Error('Invalid call');
+	elseif($this->state==3)
+		$this->Error('The document is closed');
+}
+
+protected function _put($s)
+{
+	// Add a line to the document
+	$this->buffer .= $s."\n";
+}
+
+protected function _getoffset()
+{
+	return strlen($this->buffer);
+}
+
+protected function _newobj($n=null)
+{
+	// Begin a new object
+	if($n===null)
+		$n = ++$this->n;
+	$this->offsets[$n] = $this->_getoffset();
+	$this->_put($n.' 0 obj');
+}
+
+protected function _putstream($data)
+{
+	$this->_put('stream');
+	$this->_put($data);
+	$this->_put('endstream');
+}
+
+protected function _putstreamobject($data)
+{
+	if($this->compress)
+	{
+		$entries = '/Filter /FlateDecode ';
+		$data = gzcompress($data);
+	}
+	else
+		$entries = '';
+	$entries .= '/Length '.strlen($data);
+	$this->_newobj();
+	$this->_put('<<'.$entries.'>>');
+	$this->_putstream($data);
+	$this->_put('endobj');
+}
+
+protected function _putlinks($n)
+{
+	foreach($this->PageLinks[$n] as $pl)
+	{
+		$this->_newobj();
+		$rect = sprintf('%.2F %.2F %.2F %.2F',$pl[0],$pl[1],$pl[0]+$pl[2],$pl[1]-$pl[3]);
+		$s = '<</Type /Annot /Subtype /Link /Rect ['.$rect.'] /Border [0 0 0] ';
+		if(is_string($pl[4]))
+			$s .= '/A <</S /URI /URI '.$this->_textstring($pl[4]).'>>>>';
+		else
+		{
+			$l = $this->links[$pl[4]];
+			if(isset($this->PageInfo[$l[0]]['size']))
+				$h = $this->PageInfo[$l[0]]['size'][1];
+			else
+				$h = ($this->DefOrientation=='P') ? $this->DefPageSize[1]*$this->k : $this->DefPageSize[0]*$this->k;
+			$s .= sprintf('/Dest [%d 0 R /XYZ 0 %.2F null]>>',$this->PageInfo[$l[0]]['n'],$h-$l[1]*$this->k);
+		}
+		$this->_put($s);
+		$this->_put('endobj');
+	}
+}
+
+protected function _putpage($n)
+{
+	$this->_newobj();
+	$this->_put('<</Type /Page');
+	$this->_put('/Parent 1 0 R');
+	if(isset($this->PageInfo[$n]['size']))
+		$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$this->PageInfo[$n]['size'][0],$this->PageInfo[$n]['size'][1]));
+	if(isset($this->PageInfo[$n]['rotation']))
+		$this->_put('/Rotate '.$this->PageInfo[$n]['rotation']);
+	$this->_put('/Resources 2 0 R');
+	if(!empty($this->PageLinks[$n]))
+	{
+		$s = '/Annots [';
+		foreach($this->PageLinks[$n] as $pl)
+			$s .= $pl[5].' 0 R ';
+		$s .= ']';
+		$this->_put($s);
+	}
+	if($this->WithAlpha)
+		$this->_put('/Group <</Type /Group /S /Transparency /CS /DeviceRGB>>');
+	$this->_put('/Contents '.($this->n+1).' 0 R>>');
+	$this->_put('endobj');
+	// Page content
+	if(!empty($this->AliasNbPages))
+		$this->pages[$n] = str_replace($this->AliasNbPages,$this->page,$this->pages[$n]);
+	$this->_putstreamobject($this->pages[$n]);
+	// Link annotations
+	$this->_putlinks($n);
+}
+
+protected function _putpages()
+{
+	$nb = $this->page;
+	$n = $this->n;
+	for($i=1;$i<=$nb;$i++)
+	{
+		$this->PageInfo[$i]['n'] = ++$n;
+		$n++;
+		foreach($this->PageLinks[$i] as &$pl)
+			$pl[5] = ++$n;
+		unset($pl);
+	}
+	for($i=1;$i<=$nb;$i++)
+		$this->_putpage($i);
+	// Pages root
+	$this->_newobj(1);
+	$this->_put('<</Type /Pages');
+	$kids = '/Kids [';
+	for($i=1;$i<=$nb;$i++)
+		$kids .= $this->PageInfo[$i]['n'].' 0 R ';
+	$kids .= ']';
+	$this->_put($kids);
+	$this->_put('/Count '.$nb);
+	if($this->DefOrientation=='P')
+	{
+		$w = $this->DefPageSize[0];
+		$h = $this->DefPageSize[1];
+	}
+	else
+	{
+		$w = $this->DefPageSize[1];
+		$h = $this->DefPageSize[0];
+	}
+	$this->_put(sprintf('/MediaBox [0 0 %.2F %.2F]',$w*$this->k,$h*$this->k));
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putfonts()
+{
+	foreach($this->FontFiles as $file=>$info)
+	{
+		// Font file embedding
+		$this->_newobj();
+		$this->FontFiles[$file]['n'] = $this->n;
+		$font = file_get_contents($file);
+		if(!$font)
+			$this->Error('Font file not found: '.$file);
+		$compressed = (substr($file,-2)=='.z');
+		if(!$compressed && isset($info['length2']))
+			$font = substr($font,6,$info['length1']).substr($font,6+$info['length1']+6,$info['length2']);
+		$this->_put('<</Length '.strlen($font));
+		if($compressed)
+			$this->_put('/Filter /FlateDecode');
+		$this->_put('/Length1 '.$info['length1']);
+		if(isset($info['length2']))
+			$this->_put('/Length2 '.$info['length2'].' /Length3 0');
+		$this->_put('>>');
+		$this->_putstream($font);
+		$this->_put('endobj');
+	}
+	foreach($this->fonts as $k=>$font)
+	{
+		// Encoding
+		if(isset($font['diff']))
+		{
+			if(!isset($this->encodings[$font['enc']]))
+			{
+				$this->_newobj();
+				$this->_put('<</Type /Encoding /BaseEncoding /WinAnsiEncoding /Differences ['.$font['diff'].']>>');
+				$this->_put('endobj');
+				$this->encodings[$font['enc']] = $this->n;
+			}
+		}
+		// ToUnicode CMap
+		if(isset($font['uv']))
+		{
+			if(isset($font['enc']))
+				$cmapkey = $font['enc'];
+			else
+				$cmapkey = $font['name'];
+			if(!isset($this->cmaps[$cmapkey]))
+			{
+				$cmap = $this->_tounicodecmap($font['uv']);
+				$this->_putstreamobject($cmap);
+				$this->cmaps[$cmapkey] = $this->n;
+			}
+		}
+		// Font object
+		$this->fonts[$k]['n'] = $this->n+1;
+		$type = $font['type'];
+		$name = $font['name'];
+		if($font['subsetted'])
+			$name = 'AAAAAA+'.$name;
+		if($type=='Core')
+		{
+			// Core font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /Type1');
+			if($name!='Symbol' && $name!='ZapfDingbats')
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+		}
+		elseif($type=='Type1' || $type=='TrueType')
+		{
+			// Additional Type1 or TrueType/OpenType font
+			$this->_newobj();
+			$this->_put('<</Type /Font');
+			$this->_put('/BaseFont /'.$name);
+			$this->_put('/Subtype /'.$type);
+			$this->_put('/FirstChar 32 /LastChar 255');
+			$this->_put('/Widths '.($this->n+1).' 0 R');
+			$this->_put('/FontDescriptor '.($this->n+2).' 0 R');
+			if(isset($font['diff']))
+				$this->_put('/Encoding '.$this->encodings[$font['enc']].' 0 R');
+			else
+				$this->_put('/Encoding /WinAnsiEncoding');
+			if(isset($font['uv']))
+				$this->_put('/ToUnicode '.$this->cmaps[$cmapkey].' 0 R');
+			$this->_put('>>');
+			$this->_put('endobj');
+			// Widths
+			$this->_newobj();
+			$cw = $font['cw'];
+			$s = '[';
+			for($i=32;$i<=255;$i++)
+				$s .= $cw[chr($i)].' ';
+			$this->_put($s.']');
+			$this->_put('endobj');
+			// Descriptor
+			$this->_newobj();
+			$s = '<</Type /FontDescriptor /FontName /'.$name;
+			foreach($font['desc'] as $k=>$v)
+				$s .= ' /'.$k.' '.$v;
+			if(!empty($font['file']))
+				$s .= ' /FontFile'.($type=='Type1' ? '' : '2').' '.$this->FontFiles[$font['file']]['n'].' 0 R';
+			$this->_put($s.'>>');
+			$this->_put('endobj');
+		}
+		else
+		{
+			// Allow for additional types
+			$mtd = '_put'.strtolower($type);
+			if(!method_exists($this,$mtd))
+				$this->Error('Unsupported font type: '.$type);
+			$this->$mtd($font);
+		}
+	}
+}
+
+protected function _tounicodecmap($uv)
+{
+	$ranges = '';
+	$nbr = 0;
+	$chars = '';
+	$nbc = 0;
+	foreach($uv as $c=>$v)
+	{
+		if(is_array($v))
+		{
+			$ranges .= sprintf("<%02X> <%02X> <%04X>\n",$c,$c+$v[1]-1,$v[0]);
+			$nbr++;
+		}
+		else
+		{
+			$chars .= sprintf("<%02X> <%04X>\n",$c,$v);
+			$nbc++;
+		}
+	}
+	$s = "/CIDInit /ProcSet findresource begin\n";
+	$s .= "12 dict begin\n";
+	$s .= "begincmap\n";
+	$s .= "/CIDSystemInfo\n";
+	$s .= "<</Registry (Adobe)\n";
+	$s .= "/Ordering (UCS)\n";
+	$s .= "/Supplement 0\n";
+	$s .= ">> def\n";
+	$s .= "/CMapName /Adobe-Identity-UCS def\n";
+	$s .= "/CMapType 2 def\n";
+	$s .= "1 begincodespacerange\n";
+	$s .= "<00> <FF>\n";
+	$s .= "endcodespacerange\n";
+	if($nbr>0)
+	{
+		$s .= "$nbr beginbfrange\n";
+		$s .= $ranges;
+		$s .= "endbfrange\n";
+	}
+	if($nbc>0)
+	{
+		$s .= "$nbc beginbfchar\n";
+		$s .= $chars;
+		$s .= "endbfchar\n";
+	}
+	$s .= "endcmap\n";
+	$s .= "CMapName currentdict /CMap defineresource pop\n";
+	$s .= "end\n";
+	$s .= "end";
+	return $s;
+}
+
+protected function _putimages()
+{
+	foreach(array_keys($this->images) as $file)
+	{
+		$this->_putimage($this->images[$file]);
+		unset($this->images[$file]['data']);
+		unset($this->images[$file]['smask']);
+	}
+}
+
+protected function _putimage(&$info)
+{
+	$this->_newobj();
+	$info['n'] = $this->n;
+	$this->_put('<</Type /XObject');
+	$this->_put('/Subtype /Image');
+	$this->_put('/Width '.$info['w']);
+	$this->_put('/Height '.$info['h']);
+	if($info['cs']=='Indexed')
+		$this->_put('/ColorSpace [/Indexed /DeviceRGB '.(strlen($info['pal'])/3-1).' '.($this->n+1).' 0 R]');
+	else
+	{
+		$this->_put('/ColorSpace /'.$info['cs']);
+		if($info['cs']=='DeviceCMYK')
+			$this->_put('/Decode [1 0 1 0 1 0 1 0]');
+	}
+	$this->_put('/BitsPerComponent '.$info['bpc']);
+	if(isset($info['f']))
+		$this->_put('/Filter /'.$info['f']);
+	if(isset($info['dp']))
+		$this->_put('/DecodeParms <<'.$info['dp'].'>>');
+	if(isset($info['trns']) && is_array($info['trns']))
+	{
+		$trns = '';
+		for($i=0;$i<count($info['trns']);$i++)
+			$trns .= $info['trns'][$i].' '.$info['trns'][$i].' ';
+		$this->_put('/Mask ['.$trns.']');
+	}
+	if(isset($info['smask']))
+		$this->_put('/SMask '.($this->n+1).' 0 R');
+	$this->_put('/Length '.strlen($info['data']).'>>');
+	$this->_putstream($info['data']);
+	$this->_put('endobj');
+	// Soft mask
+	if(isset($info['smask']))
+	{
+		$dp = '/Predictor 15 /Colors 1 /BitsPerComponent 8 /Columns '.$info['w'];
+		$smask = array('w'=>$info['w'], 'h'=>$info['h'], 'cs'=>'DeviceGray', 'bpc'=>8, 'f'=>$info['f'], 'dp'=>$dp, 'data'=>$info['smask']);
+		$this->_putimage($smask);
+	}
+	// Palette
+	if($info['cs']=='Indexed')
+		$this->_putstreamobject($info['pal']);
+}
+
+protected function _putxobjectdict()
+{
+	foreach($this->images as $image)
+		$this->_put('/I'.$image['i'].' '.$image['n'].' 0 R');
+}
+
+protected function _putresourcedict()
+{
+	$this->_put('/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]');
+	$this->_put('/Font <<');
+	foreach($this->fonts as $font)
+		$this->_put('/F'.$font['i'].' '.$font['n'].' 0 R');
+	$this->_put('>>');
+	$this->_put('/XObject <<');
+	$this->_putxobjectdict();
+	$this->_put('>>');
+}
+
+protected function _putresources()
+{
+	$this->_putfonts();
+	$this->_putimages();
+	// Resource dictionary
+	$this->_newobj(2);
+	$this->_put('<<');
+	$this->_putresourcedict();
+	$this->_put('>>');
+	$this->_put('endobj');
+}
+
+protected function _putinfo()
+{
+	$date = @date('YmdHisO',$this->CreationDate);
+	$this->metadata['CreationDate'] = 'D:'.substr($date,0,-2)."'".substr($date,-2)."'";
+	foreach($this->metadata as $key=>$value)
+		$this->_put('/'.$key.' '.$this->_textstring($value));
+}
+
+protected function _putcatalog()
+{
+	$n = $this->PageInfo[1]['n'];
+	$this->_put('/Type /Catalog');
+	$this->_put('/Pages 1 0 R');
+	if($this->ZoomMode=='fullpage')
+		$this->_put('/OpenAction ['.$n.' 0 R /Fit]');
+	elseif($this->ZoomMode=='fullwidth')
+		$this->_put('/OpenAction ['.$n.' 0 R /FitH null]');
+	elseif($this->ZoomMode=='real')
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null 1]');
+	elseif(!is_string($this->ZoomMode))
+		$this->_put('/OpenAction ['.$n.' 0 R /XYZ null null '.sprintf('%.2F',$this->ZoomMode/100).']');
+	if($this->LayoutMode=='single')
+		$this->_put('/PageLayout /SinglePage');
+	elseif($this->LayoutMode=='continuous')
+		$this->_put('/PageLayout /OneColumn');
+	elseif($this->LayoutMode=='two')
+		$this->_put('/PageLayout /TwoColumnLeft');
+}
+
+protected function _putheader()
+{
+	$this->_put('%PDF-'.$this->PDFVersion);
+}
+
+protected function _puttrailer()
+{
+	$this->_put('/Size '.($this->n+1));
+	$this->_put('/Root '.$this->n.' 0 R');
+	$this->_put('/Info '.($this->n-1).' 0 R');
+}
+
+protected function _enddoc()
+{
+	$this->CreationDate = time();
+	$this->_putheader();
+	$this->_putpages();
+	$this->_putresources();
+	// Info
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putinfo();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Catalog
+	$this->_newobj();
+	$this->_put('<<');
+	$this->_putcatalog();
+	$this->_put('>>');
+	$this->_put('endobj');
+	// Cross-ref
+	$offset = $this->_getoffset();
+	$this->_put('xref');
+	$this->_put('0 '.($this->n+1));
+	$this->_put('0000000000 65535 f ');
+	for($i=1;$i<=$this->n;$i++)
+		$this->_put(sprintf('%010d 00000 n ',$this->offsets[$i]));
+	// Trailer
+	$this->_put('trailer');
+	$this->_put('<<');
+	$this->_puttrailer();
+	$this->_put('>>');
+	$this->_put('startxref');
+	$this->_put($offset);
+	$this->_put('%%EOF');
+	$this->state = 3;
+}
+}
+?>

--- a/bolao-x/lib/pix.php
+++ b/bolao-x/lib/pix.php
@@ -1,0 +1,52 @@
+<?php
+class Bolaox_Pix {
+    public static function emv($id, $val){
+        return $id . sprintf('%02d', strlen($val)) . $val;
+    }
+    public static function crc16($payload){
+        $crc = 0xFFFF;
+        for($i=0;$i<strlen($payload);$i++){
+            $crc ^= ord($payload[$i]) << 8;
+            for($b=0;$b<8;$b++){
+                if($crc & 0x8000){
+                    $crc = ($crc << 1) ^ 0x1021;
+                } else {
+                    $crc <<= 1;
+                }
+                $crc &= 0xFFFF;
+            }
+        }
+        return sprintf('%04X',$crc);
+    }
+    public static function payload($key,$merchant='BOLAO X',$city='BRASILIA',$txid='***',$amount=''){
+        $payload  = self::emv('00','01');
+        $payload .= self::emv('26', self::emv('00','BR.GOV.BCB.PIX').self::emv('01',$key));
+        $payload .= self::emv('52','0000');
+        $payload .= self::emv('53','986');
+        if($amount !== ''){
+            $payload .= self::emv('54',number_format($amount,2,'.',''));
+        }
+        $payload .= self::emv('58','BR');
+        $payload .= self::emv('59',$merchant);
+        $payload .= self::emv('60',$city);
+        $payload .= self::emv('62', self::emv('05',$txid));
+        $to_crc = $payload.'6304';
+        $crc = self::crc16($to_crc.'0000');
+        return $to_crc.$crc;
+    }
+    public static function qr_base64($payload){
+        if(!function_exists('imagepng')){return '';}
+        require_once __DIR__.'/qrcode.php';
+        $qr = QRCode::getMinimumQRCode($payload, QR_ERROR_CORRECT_LEVEL_M);
+        $img = $qr->createImage(10,4);
+        if(!$img){return '';}
+        $size = imagesx($img);
+        $scaled = imagescale($img,$size*2,$size*2);
+        imagedestroy($img);
+        ob_start();
+        imagepng($scaled);
+        $data = ob_get_clean();
+        imagedestroy($scaled);
+        return 'data:image/png;base64,'.base64_encode($data);
+    }
+}

--- a/bolao-x/lib/qrcode.php
+++ b/bolao-x/lib/qrcode.php
@@ -1,0 +1,1745 @@
+<?php
+
+//---------------------------------------------------------------
+// QRCode for PHP5
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//   http://www.opensource.org/licenses/mit-license.php
+//
+// The word "QR Code" is registered trademark of
+// DENSO WAVE INCORPORATED
+//   http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+//---------------------------------------------------------------
+// QRCode
+//---------------------------------------------------------------
+
+define("QR_PAD0", 0xEC);
+define("QR_PAD1", 0x11);
+
+class QRCode {
+
+    var $typeNumber;
+
+    var $modules;
+
+    var $moduleCount;
+
+    var $errorCorrectLevel;
+
+    var $qrDataList;
+
+    function __construct() {
+        $this->typeNumber = 1;
+        $this->errorCorrectLevel = QR_ERROR_CORRECT_LEVEL_H;
+        $this->qrDataList = array();
+    }
+
+    function getTypeNumber() {
+        return $this->typeNumber;
+    }
+
+    function setTypeNumber($typeNumber) {
+        $this->typeNumber = $typeNumber;
+    }
+
+    function getErrorCorrectLevel() {
+        return $this->errorCorrectLevel;
+    }
+
+    function setErrorCorrectLevel($errorCorrectLevel) {
+        $this->errorCorrectLevel = $errorCorrectLevel;
+    }
+
+    function addData($data, $mode = 0) {
+
+        if ($mode == 0) {
+            $mode = QRUtil::getMode($data);
+        }
+
+        switch($mode) {
+
+        case QR_MODE_NUMBER :
+            $this->addDataImpl(new QRNumber($data) );
+            break;
+
+        case QR_MODE_ALPHA_NUM :
+            $this->addDataImpl(new QRAlphaNum($data) );
+            break;
+
+        case QR_MODE_8BIT_BYTE :
+            $this->addDataImpl(new QR8BitByte($data) );
+            break;
+
+        case QR_MODE_KANJI :
+            $this->addDataImpl(new QRKanji($data) );
+            break;
+
+        default :
+            trigger_error("mode:$mode", E_USER_ERROR);
+        }
+    }
+
+    function clearData() {
+        $this->qrDataList = array();
+    }
+
+    function addDataImpl($qrData) {
+        $this->qrDataList[] = $qrData;
+    }
+
+    function getDataCount() {
+        return count($this->qrDataList);
+    }
+
+    function getData($index) {
+        return $this->qrDataList[$index];
+    }
+
+    function isDark($row, $col) {
+        if ($this->modules[$row][$col] !== null) {
+            return $this->modules[$row][$col];
+        } else {
+            return false;
+        }
+    }
+
+    function getModuleCount() {
+        return $this->moduleCount;
+    }
+
+    // used for converting fg/bg colors (e.g. #0000ff = 0x0000FF)
+    // added 2015.07.27 ~ DoktorJ
+    function hex2rgb($hex = 0x0) {
+        return array(
+            'r' => floor($hex / 65536),
+            'g' => floor($hex / 256) % 256,
+            'b' => $hex % 256
+        );
+    }
+
+    function make() {
+        $this->makeImpl(false, $this->getBestMaskPattern() );
+    }
+
+    function getBestMaskPattern() {
+
+        $minLostPoint = 0;
+        $pattern = 0;
+
+        for ($i = 0; $i < 8; $i++) {
+
+            $this->makeImpl(true, $i);
+
+            $lostPoint = QRUtil::getLostPoint($this);
+
+            if ($i == 0 || $minLostPoint > $lostPoint) {
+                $minLostPoint = $lostPoint;
+                $pattern = $i;
+            }
+        }
+
+        return $pattern;
+    }
+
+    function createNullArray($length) {
+        $nullArray = array();
+        for ($i = 0; $i < $length; $i++) {
+            $nullArray[] = null;
+        }
+        return $nullArray;
+    }
+
+    function makeImpl($test, $maskPattern) {
+
+        $this->moduleCount = $this->typeNumber * 4 + 17;
+
+        $this->modules = array();
+        for ($i = 0; $i < $this->moduleCount; $i++) {
+            $this->modules[] = QRCode::createNullArray($this->moduleCount);
+        }
+
+        $this->setupPositionProbePattern(0, 0);
+        $this->setupPositionProbePattern($this->moduleCount - 7, 0);
+        $this->setupPositionProbePattern(0, $this->moduleCount - 7);
+
+        $this->setupPositionAdjustPattern();
+        $this->setupTimingPattern();
+
+        $this->setupTypeInfo($test, $maskPattern);
+
+        if ($this->typeNumber >= 7) {
+            $this->setupTypeNumber($test);
+        }
+
+        $dataArray = $this->qrDataList;
+
+        $data = QRCode::createData($this->typeNumber, $this->errorCorrectLevel, $dataArray);
+
+        $this->mapData($data, $maskPattern);
+    }
+
+    function mapData(&$data, $maskPattern) {
+
+        $inc = -1;
+        $row = $this->moduleCount - 1;
+        $bitIndex = 7;
+        $byteIndex = 0;
+
+        for ($col = $this->moduleCount - 1; $col > 0; $col -= 2) {
+
+            if ($col == 6) $col--;
+
+            while (true) {
+
+                for ($c = 0; $c < 2; $c++) {
+
+                    if ($this->modules[$row][$col - $c] === null) {
+
+                        $dark = false;
+
+                        if ($byteIndex < count($data) ) {
+                            $dark = ( ( ($data[$byteIndex] >> $bitIndex) & 1) == 1);
+                        }
+
+                        if (QRUtil::getMask($maskPattern, $row, $col - $c)) {
+                            $dark = !$dark;
+                        }
+
+                        $this->modules[$row][$col - $c] = $dark;
+                        $bitIndex--;
+
+                        if ($bitIndex == -1) {
+                            $byteIndex++;
+                            $bitIndex = 7;
+                        }
+                    }
+                }
+
+                $row += $inc;
+
+                if ($row < 0 || $this->moduleCount <= $row) {
+                    $row -= $inc;
+                    $inc = -$inc;
+                    break;
+                }
+            }
+        }
+    }
+
+    function setupPositionAdjustPattern() {
+
+        $pos = QRUtil::getPatternPosition($this->typeNumber);
+
+        for ($i = 0; $i < count($pos); $i++) {
+
+            for ($j = 0; $j < count($pos); $j++) {
+
+                $row = $pos[$i];
+                $col = $pos[$j];
+
+                if ($this->modules[$row][$col] !== null) {
+                    continue;
+                }
+
+                for ($r = -2; $r <= 2; $r++) {
+
+                    for ($c = -2; $c <= 2; $c++) {
+                        $this->modules[$row + $r][$col + $c] =
+                            $r == -2 || $r == 2 || $c == -2 || $c == 2 || ($r == 0 && $c == 0);
+                    }
+                }
+            }
+        }
+    }
+
+    function setupPositionProbePattern($row, $col) {
+
+        for ($r = -1; $r <= 7; $r++) {
+
+            for ($c = -1; $c <= 7; $c++) {
+
+                if ($row + $r <= -1 || $this->moduleCount <= $row + $r
+                        || $col + $c <= -1 || $this->moduleCount <= $col + $c) {
+                    continue;
+                }
+
+                $this->modules[$row + $r][$col + $c] =
+                       (0 <= $r && $r <= 6 && ($c == 0 || $c == 6) )
+                    || (0 <= $c && $c <= 6 && ($r == 0 || $r == 6) )
+                    || (2 <= $r && $r <= 4 &&  2 <= $c && $c <= 4);
+            }
+        }
+    }
+
+    function setupTimingPattern() {
+
+        for ($i = 8; $i < $this->moduleCount - 8; $i++) {
+
+            if ($this->modules[$i][6] !== null || $this->modules[6][$i] !== null) {
+                continue;
+            }
+
+            $this->modules[$i][6] = ($i % 2 == 0);
+            $this->modules[6][$i] = ($i % 2 == 0);
+        }
+    }
+
+    function setupTypeNumber($test) {
+
+        $bits = QRUtil::getBCHTypeNumber($this->typeNumber);
+
+        for ($i = 0; $i < 18; $i++) {
+            $mod = (!$test && ( ($bits >> $i) & 1) == 1);
+            $this->modules[(int)floor($i / 3)][$i % 3 + $this->moduleCount - 8 - 3] = $mod;
+            $this->modules[$i % 3 + $this->moduleCount - 8 - 3][floor($i / 3)] = $mod;
+        }
+    }
+
+    function setupTypeInfo($test, $maskPattern) {
+
+        $data = ($this->errorCorrectLevel << 3) | $maskPattern;
+        $bits = QRUtil::getBCHTypeInfo($data);
+
+        for ($i = 0; $i < 15; $i++) {
+
+            $mod = (!$test && ( ($bits >> $i) & 1) == 1);
+
+            if ($i < 6) {
+                $this->modules[$i][8] = $mod;
+            } else if ($i < 8) {
+                $this->modules[$i + 1][8] = $mod;
+            } else {
+                $this->modules[$this->moduleCount - 15 + $i][8] = $mod;
+            }
+
+            if ($i < 8) {
+                $this->modules[8][$this->moduleCount - $i - 1] = $mod;
+            } else if ($i < 9) {
+                $this->modules[8][15 - $i - 1 + 1] = $mod;
+            } else {
+                $this->modules[8][15 - $i - 1] = $mod;
+            }
+        }
+
+        $this->modules[$this->moduleCount - 8][8] = !$test;
+    }
+
+    function createData($typeNumber, $errorCorrectLevel, $dataArray) {
+
+        $rsBlocks = QRRSBlock::getRSBlocks($typeNumber, $errorCorrectLevel);
+
+        $buffer = new QRBitBuffer();
+
+        for ($i = 0; $i < count($dataArray); $i++) {
+            /** @var \QRData $data */
+            $data = $dataArray[$i];
+            $buffer->put($data->getMode(), 4);
+            $buffer->put($data->getLength(), $data->getLengthInBits($typeNumber) );
+            $data->write($buffer);
+        }
+
+        $totalDataCount = 0;
+        for ($i = 0; $i < count($rsBlocks); $i++) {
+            $totalDataCount += $rsBlocks[$i]->getDataCount();
+        }
+
+        if ($buffer->getLengthInBits() > $totalDataCount * 8) {
+            throw new Exception(
+                'code length overflow: ' .
+                $buffer->getLengthInBits() . '>' .
+                ($totalDataCount * 8)
+            );
+        }
+
+        // end code.
+        if ($buffer->getLengthInBits() + 4 <= $totalDataCount * 8) {
+            $buffer->put(0, 4);
+        }
+
+        // padding
+        while ($buffer->getLengthInBits() % 8 != 0) {
+            $buffer->putBit(false);
+        }
+
+        // padding
+        while (true) {
+
+            if ($buffer->getLengthInBits() >= $totalDataCount * 8) {
+                break;
+            }
+            $buffer->put(QR_PAD0, 8);
+
+            if ($buffer->getLengthInBits() >= $totalDataCount * 8) {
+                break;
+            }
+            $buffer->put(QR_PAD1, 8);
+        }
+
+        return QRCode::createBytes($buffer, $rsBlocks);
+    }
+
+    /**
+     * @param \QRBitBuffer $buffer
+     * @param \QRRSBlock[] $rsBlocks
+     *
+     * @return array
+     */
+    function createBytes(&$buffer, &$rsBlocks) {
+
+        $offset = 0;
+
+        $maxDcCount = 0;
+        $maxEcCount = 0;
+
+        $dcdata = QRCode::createNullArray(count($rsBlocks) );
+        $ecdata = QRCode::createNullArray(count($rsBlocks) );
+
+        $rsBlockCount = count($rsBlocks);
+        for ($r = 0; $r < $rsBlockCount; $r++) {
+
+            $dcCount = $rsBlocks[$r]->getDataCount();
+            $ecCount = $rsBlocks[$r]->getTotalCount() - $dcCount;
+
+            $maxDcCount = max($maxDcCount, $dcCount);
+            $maxEcCount = max($maxEcCount, $ecCount);
+
+            $dcdata[$r] = QRCode::createNullArray($dcCount);
+            $dcDataCount = count($dcdata[$r]);
+            for ($i = 0; $i < $dcDataCount; $i++) {
+                $bdata = $buffer->getBuffer();
+                $dcdata[$r][$i] = 0xff & $bdata[$i + $offset];
+            }
+            $offset += $dcCount;
+
+            $rsPoly = QRUtil::getErrorCorrectPolynomial($ecCount);
+            $rawPoly = new QRPolynomial($dcdata[$r], $rsPoly->getLength() - 1);
+
+            $modPoly = $rawPoly->mod($rsPoly);
+            $ecdata[$r] = QRCode::createNullArray($rsPoly->getLength() - 1);
+
+            $ecDataCount = count($ecdata[$r]);
+            for ($i = 0; $i < $ecDataCount; $i++) {
+                $modIndex = $i + $modPoly->getLength() - count($ecdata[$r]);
+                $ecdata[$r][$i] = ($modIndex >= 0)? $modPoly->get($modIndex) : 0;
+            }
+        }
+
+        $totalCodeCount = 0;
+        for ($i = 0; $i < $rsBlockCount; $i++) {
+            $totalCodeCount += $rsBlocks[$i]->getTotalCount();
+        }
+
+        $data = QRCode::createNullArray($totalCodeCount);
+
+        $index = 0;
+
+        for ($i = 0; $i < $maxDcCount; $i++) {
+            for ($r = 0; $r < $rsBlockCount; $r++) {
+                if ($i < count($dcdata[$r]) ) {
+                    $data[$index++] = $dcdata[$r][$i];
+                }
+            }
+        }
+
+        for ($i = 0; $i < $maxEcCount; $i++) {
+            for ($r = 0; $r < $rsBlockCount; $r++) {
+                if ($i < count($ecdata[$r]) ) {
+                    $data[$index++] = $ecdata[$r][$i];
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    static function getMinimumQRCode($data, $errorCorrectLevel) {
+
+        $mode = QRUtil::getMode($data);
+
+        for ($typeNumber = 1; $typeNumber <= 40; $typeNumber++) {
+            try {
+                $qr = new QRCode();
+                $qr->setTypeNumber($typeNumber);
+                $qr->setErrorCorrectLevel($errorCorrectLevel);
+                $qr->addData($data, $mode);
+                $qr->make();
+                return $qr;
+            } catch (Exception $e) {
+                // try next type number
+            }
+        }
+
+        throw new Exception('failed to generate QR code');
+    }
+
+    // added $fg (foreground), $bg (background), and $bgtrans (use transparent bg) parameters
+    // also added some simple error checking on parameters
+    // updated 2015.07.27 ~ DoktorJ
+    function createImage($size = 2, $margin = 2, $fg = 0x000000, $bg = 0xFFFFFF, $bgtrans = false) {
+
+        // size/margin EC
+        if (!is_numeric($size)) $size = 2;
+        if (!is_numeric($margin)) $margin = 2;
+        if ($size < 1) $size = 1;
+        if ($margin < 0) $margin = 0;
+
+        $image_size = $this->getModuleCount() * $size + $margin * 2;
+
+        $image = imagecreatetruecolor($image_size, $image_size);
+
+        // fg/bg EC
+        if ($fg < 0 || $fg > 0xFFFFFF) $fg = 0x0;
+        if ($bg < 0 || $bg > 0xFFFFFF) $bg = 0xFFFFFF;
+
+        // convert hexadecimal RGB to arrays for imagecolorallocate
+        $fgrgb = $this->hex2rgb($fg);
+        $bgrgb = $this->hex2rgb($bg);
+
+        // replace $black and $white with $fgc and $bgc
+        $fgc = imagecolorallocate($image, $fgrgb['r'], $fgrgb['g'], $fgrgb['b']);
+        $bgc = imagecolorallocate($image, $bgrgb['r'], $bgrgb['g'], $bgrgb['b']);
+        if ($bgtrans) imagecolortransparent($image, $bgc);
+
+        // update $white to $bgc
+        imagefilledrectangle($image, 0, 0, $image_size, $image_size, $bgc);
+
+        for ($r = 0; $r < $this->getModuleCount(); $r++) {
+            for ($c = 0; $c < $this->getModuleCount(); $c++) {
+                if ($this->isDark($r, $c) ) {
+
+                    // update $black to $fgc
+                    imagefilledrectangle($image,
+                        $margin + $c * $size,
+                        $margin + $r * $size,
+                        $margin + ($c + 1) * $size - 1,
+                        $margin + ($r + 1) * $size - 1,
+                        $fgc);
+                }
+            }
+        }
+
+        return $image;
+    }
+
+    function printHTML($size = "2px") {
+
+        $style = "border-style:none;border-collapse:collapse;margin:0px;padding:0px;";
+
+        print("<table style='$style'>");
+
+        for ($r = 0; $r < $this->getModuleCount(); $r++) {
+
+            print("<tr style='$style'>");
+
+            for ($c = 0; $c < $this->getModuleCount(); $c++) {
+                $color = $this->isDark($r, $c)? "#000000" : "#ffffff";
+                print("<td style='$style;width:$size;height:$size;background-color:$color'></td>");
+            }
+
+            print("</tr>");
+        }
+
+        print("</table>");
+    }
+
+    public function printSVG($size = 2)
+    {
+        $width = $this->getModuleCount() * $size;
+        $height = $width;
+        print('<svg width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '" xmlns="http://www.w3.org/2000/svg">');
+
+        for ($r = 0; $r < $this->getModuleCount(); $r++) {
+            for ($c = 0; $c < $this->getModuleCount(); $c++) {
+                $color = $this->isDark($r, $c) ? "#000000" : "#ffffff";
+                print('<rect x="' . ($c * $size) . '" y="' . ($r * $size) . '" width="' . $size . '" height="' . $size . '" fill="' . $color . '" shape-rendering="crispEdges"/>');
+            }
+        }
+
+        print("</svg>");
+    }
+}
+
+//---------------------------------------------------------------
+// QRUtil
+//---------------------------------------------------------------
+
+define("QR_G15", (1 << 10) | (1 << 8) | (1 << 5)
+    | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0) );
+
+define("QR_G18", (1 << 12) | (1 << 11) | (1 << 10)
+    | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0) );
+
+define("QR_G15_MASK", (1 << 14) | (1 << 12) | (1 << 10)
+    | (1 << 4) | (1 << 1) );
+
+class QRUtil {
+
+    static $QR_MAX_LENGTH = array(
+        array( array(41,  25,  17,  10),  array(34,  20,  14,  8),   array(27,  16,  11,  7),  array(17,  10,  7,   4) ),
+        array( array(77,  47,  32,  20),  array(63,  38,  26,  16),  array(48,  29,  20,  12), array(34,  20,  14,  8) ),
+        array( array(127, 77,  53,  32),  array(101, 61,  42,  26),  array(77,  47,  32,  20), array(58,  35,  24,  15) ),
+        array( array(187, 114, 78,  48),  array(149, 90,  62,  38),  array(111, 67,  46,  28), array(82,  50,  34,  21) ),
+        array( array(255, 154, 106, 65),  array(202, 122, 84,  52),  array(144, 87,  60,  37), array(106, 64,  44,  27) ),
+        array( array(322, 195, 134, 82),  array(255, 154, 106, 65),  array(178, 108, 74,  45), array(139, 84,  58,  36) ),
+        array( array(370, 224, 154, 95),  array(293, 178, 122, 75),  array(207, 125, 86,  53), array(154, 93,  64,  39) ),
+        array( array(461, 279, 192, 118), array(365, 221, 152, 93),  array(259, 157, 108, 66), array(202, 122, 84,  52) ),
+        array( array(552, 335, 230, 141), array(432, 262, 180, 111), array(312, 189, 130, 80), array(235, 143, 98,  60) ),
+        array( array(652, 395, 271, 167), array(513, 311, 213, 131), array(364, 221, 151, 93), array(288, 174, 119, 74) )
+    );
+
+    static $QR_PATTERN_POSITION_TABLE = array(
+        array(),
+        array(6, 18),
+        array(6, 22),
+        array(6, 26),
+        array(6, 30),
+        array(6, 34),
+        array(6, 22, 38),
+        array(6, 24, 42),
+        array(6, 26, 46),
+        array(6, 28, 50),
+        array(6, 30, 54),
+        array(6, 32, 58),
+        array(6, 34, 62),
+        array(6, 26, 46, 66),
+        array(6, 26, 48, 70),
+        array(6, 26, 50, 74),
+        array(6, 30, 54, 78),
+        array(6, 30, 56, 82),
+        array(6, 30, 58, 86),
+        array(6, 34, 62, 90),
+        array(6, 28, 50, 72, 94),
+        array(6, 26, 50, 74, 98),
+        array(6, 30, 54, 78, 102),
+        array(6, 28, 54, 80, 106),
+        array(6, 32, 58, 84, 110),
+        array(6, 30, 58, 86, 114),
+        array(6, 34, 62, 90, 118),
+        array(6, 26, 50, 74, 98, 122),
+        array(6, 30, 54, 78, 102, 126),
+        array(6, 26, 52, 78, 104, 130),
+        array(6, 30, 56, 82, 108, 134),
+        array(6, 34, 60, 86, 112, 138),
+        array(6, 30, 58, 86, 114, 142),
+        array(6, 34, 62, 90, 118, 146),
+        array(6, 30, 54, 78, 102, 126, 150),
+        array(6, 24, 50, 76, 102, 128, 154),
+        array(6, 28, 54, 80, 106, 132, 158),
+        array(6, 32, 58, 84, 110, 136, 162),
+        array(6, 26, 54, 82, 110, 138, 166),
+        array(6, 30, 58, 86, 114, 142, 170)
+    );
+
+    static function getPatternPosition($typeNumber) {
+        $index = $typeNumber - 1;
+        if (!isset(self::$QR_PATTERN_POSITION_TABLE[$index])) {
+            // Avoid undefined index warnings by falling back to the last entry
+            $index = count(self::$QR_PATTERN_POSITION_TABLE) - 1;
+        }
+        return self::$QR_PATTERN_POSITION_TABLE[$index];
+    }
+
+    static function getMaxLength($typeNumber, $mode, $errorCorrectLevel) {
+
+        $t = $typeNumber - 1;
+        $e = 0;
+        $m = 0;
+
+        switch($errorCorrectLevel) {
+        case QR_ERROR_CORRECT_LEVEL_L : $e = 0; break;
+        case QR_ERROR_CORRECT_LEVEL_M : $e = 1; break;
+        case QR_ERROR_CORRECT_LEVEL_Q : $e = 2; break;
+        case QR_ERROR_CORRECT_LEVEL_H : $e = 3; break;
+        default :
+            trigger_error("e:$errorCorrectLevel", E_USER_ERROR);
+        }
+
+        switch($mode) {
+        case QR_MODE_NUMBER    : $m = 0; break;
+        case QR_MODE_ALPHA_NUM : $m = 1; break;
+        case QR_MODE_8BIT_BYTE : $m = 2; break;
+        case QR_MODE_KANJI     : $m = 3; break;
+        default :
+            trigger_error("m:$mode", E_USER_ERROR);
+        }
+
+        if (!isset(self::$QR_MAX_LENGTH[$t][$e][$m])) {
+            $t = min($t, count(self::$QR_MAX_LENGTH) - 1);
+            $e = isset(self::$QR_MAX_LENGTH[$t][$e]) ? $e : 0;
+            $m = isset(self::$QR_MAX_LENGTH[$t][$e][$m]) ? $m : 0;
+        }
+        return self::$QR_MAX_LENGTH[$t][$e][$m];
+    }
+
+    static function getErrorCorrectPolynomial($errorCorrectLength) {
+
+        $a = new QRPolynomial(array(1) );
+
+        for ($i = 0; $i < $errorCorrectLength; $i++) {
+            $a = $a->multiply(new QRPolynomial(array(1, QRMath::gexp($i) ) ) );
+        }
+
+        return $a;
+    }
+
+    static function getMask($maskPattern, $i, $j) {
+
+        switch ($maskPattern) {
+
+        case QR_MASK_PATTERN000 : return ($i + $j) % 2 == 0;
+        case QR_MASK_PATTERN001 : return $i % 2 == 0;
+        case QR_MASK_PATTERN010 : return $j % 3 == 0;
+        case QR_MASK_PATTERN011 : return ($i + $j) % 3 == 0;
+        case QR_MASK_PATTERN100 : return (floor($i / 2) + floor($j / 3) ) % 2 == 0;
+        case QR_MASK_PATTERN101 : return ($i * $j) % 2 + ($i * $j) % 3 == 0;
+        case QR_MASK_PATTERN110 : return ( ($i * $j) % 2 + ($i * $j) % 3) % 2 == 0;
+        case QR_MASK_PATTERN111 : return ( ($i * $j) % 3 + ($i + $j) % 2) % 2 == 0;
+
+        default :
+            trigger_error("mask:$maskPattern", E_USER_ERROR);
+        }
+    }
+
+    /**
+     * @param \QRCode $qrCode
+     *
+     * @return float|int
+     */
+    static function getLostPoint($qrCode) {
+
+        $moduleCount = $qrCode->getModuleCount();
+
+        $lostPoint = 0;
+
+
+        // LEVEL1
+
+        for ($row = 0; $row < $moduleCount; $row++) {
+
+            for ($col = 0; $col < $moduleCount; $col++) {
+
+                $sameCount = 0;
+                $dark = $qrCode->isDark($row, $col);
+
+                for ($r = -1; $r <= 1; $r++) {
+
+                    if ($row + $r < 0 || $moduleCount <= $row + $r) {
+                        continue;
+                    }
+
+                    for ($c = -1; $c <= 1; $c++) {
+
+                        if (($col + $c < 0 || $moduleCount <= $col + $c) || ($r == 0 && $c == 0)) {
+                            continue;
+                        }
+
+                        if ($dark == $qrCode->isDark($row + $r, $col + $c) ) {
+                            $sameCount++;
+                        }
+                    }
+                }
+
+                if ($sameCount > 5) {
+                    $lostPoint += (3 + $sameCount - 5);
+                }
+            }
+        }
+
+        // LEVEL2
+
+        for ($row = 0; $row < $moduleCount - 1; $row++) {
+            for ($col = 0; $col < $moduleCount - 1; $col++) {
+                $count = 0;
+                if ($qrCode->isDark($row,     $col    ) ) $count++;
+                if ($qrCode->isDark($row + 1, $col    ) ) $count++;
+                if ($qrCode->isDark($row,     $col + 1) ) $count++;
+                if ($qrCode->isDark($row + 1, $col + 1) ) $count++;
+                if ($count == 0 || $count == 4) {
+                    $lostPoint += 3;
+                }
+            }
+        }
+
+        // LEVEL3
+
+        for ($row = 0; $row < $moduleCount; $row++) {
+            for ($col = 0; $col < $moduleCount - 6; $col++) {
+                if ($qrCode->isDark($row, $col)
+                        && !$qrCode->isDark($row, $col + 1)
+                        &&  $qrCode->isDark($row, $col + 2)
+                        &&  $qrCode->isDark($row, $col + 3)
+                        &&  $qrCode->isDark($row, $col + 4)
+                        && !$qrCode->isDark($row, $col + 5)
+                        &&  $qrCode->isDark($row, $col + 6) ) {
+                    $lostPoint += 40;
+                }
+            }
+        }
+
+        for ($col = 0; $col < $moduleCount; $col++) {
+            for ($row = 0; $row < $moduleCount - 6; $row++) {
+                if ($qrCode->isDark($row, $col)
+                        && !$qrCode->isDark($row + 1, $col)
+                        &&  $qrCode->isDark($row + 2, $col)
+                        &&  $qrCode->isDark($row + 3, $col)
+                        &&  $qrCode->isDark($row + 4, $col)
+                        && !$qrCode->isDark($row + 5, $col)
+                        &&  $qrCode->isDark($row + 6, $col) ) {
+                    $lostPoint += 40;
+                }
+            }
+        }
+
+        // LEVEL4
+
+        $darkCount = 0;
+
+        for ($col = 0; $col < $moduleCount; $col++) {
+            for ($row = 0; $row < $moduleCount; $row++) {
+                if ($qrCode->isDark($row, $col) ) {
+                    $darkCount++;
+                }
+            }
+        }
+
+        $ratio = abs(100 * $darkCount / $moduleCount / $moduleCount - 50) / 5;
+        $lostPoint += $ratio * 10;
+
+        return $lostPoint;
+    }
+
+    static function getMode($s) {
+        if (QRUtil::isAlphaNum($s) ) {
+            if (QRUtil::isNumber($s) ) {
+                return QR_MODE_NUMBER;
+            }
+            return QR_MODE_ALPHA_NUM;
+        } else if (QRUtil::isKanji($s) ) {
+            return QR_MODE_KANJI;
+        } else {
+            return QR_MODE_8BIT_BYTE;
+        }
+    }
+
+    static function isNumber($s) {
+        for ($i = 0; $i < strlen($s); $i++) {
+            $c = ord($s[$i]);
+            if (!(QRUtil::toCharCode('0') <= $c && $c <= QRUtil::toCharCode('9') ) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static function isAlphaNum($s) {
+        for ($i = 0; $i < strlen($s); $i++) {
+            $c = ord($s[$i]);
+            if (!(QRUtil::toCharCode('0') <= $c && $c <= QRUtil::toCharCode('9') )
+                && !(QRUtil::toCharCode('A') <= $c && $c <= QRUtil::toCharCode('Z') )
+                    && strpos(" $%*+-./:", $s[$i]) === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static function isKanji($s) {
+
+        $data = $s;
+
+        $i = 0;
+
+        while ($i + 1 < strlen($data) ) {
+
+            $c = ( (0xff & ord($data[$i]) ) << 8) | (0xff & ord($data[$i + 1]) );
+
+            if (!(0x8140 <= $c && $c <= 0x9FFC) && !(0xE040 <= $c && $c <= 0xEBBF) ) {
+                return false;
+            }
+
+            $i += 2;
+        }
+
+        if ($i < strlen($data) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    static function toCharCode($s) {
+        return ord($s[0]);
+    }
+
+    static function getBCHTypeInfo($data) {
+        $d = $data << 10;
+        while (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G15) >= 0) {
+            $d ^= (QR_G15 << (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G15) ) );
+        }
+        return ( ($data << 10) | $d) ^ QR_G15_MASK;
+    }
+
+    static function getBCHTypeNumber($data) {
+        $d = $data << 12;
+        while (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G18) >= 0) {
+            $d ^= (QR_G18 << (QRUtil::getBCHDigit($d) - QRUtil::getBCHDigit(QR_G18) ) );
+        }
+        return ($data << 12) | $d;
+    }
+
+    static function getBCHDigit($data) {
+
+        $digit = 0;
+
+        while ($data != 0) {
+            $digit++;
+            $data >>= 1;
+        }
+
+        return $digit;
+    }
+}
+
+//---------------------------------------------------------------
+// QRRSBlock
+//---------------------------------------------------------------
+
+class QRRSBlock {
+
+    var $totalCount;
+    var $dataCount;
+
+    static $QR_RS_BLOCK_TABLE = array(
+
+        // L
+        // M
+        // Q
+        // H
+
+        // 1
+        array(1, 26, 19),
+        array(1, 26, 16),
+        array(1, 26, 13),
+        array(1, 26, 9),
+
+        // 2
+        array(1, 44, 34),
+        array(1, 44, 28),
+        array(1, 44, 22),
+        array(1, 44, 16),
+
+        // 3
+        array(1, 70, 55),
+        array(1, 70, 44),
+        array(2, 35, 17),
+        array(2, 35, 13),
+
+        // 4
+        array(1, 100, 80),
+        array(2, 50, 32),
+        array(2, 50, 24),
+        array(4, 25, 9),
+
+        // 5
+        array(1, 134, 108),
+        array(2, 67, 43),
+        array(2, 33, 15, 2, 34, 16),
+        array(2, 33, 11, 2, 34, 12),
+
+        // 6
+        array(2, 86, 68),
+        array(4, 43, 27),
+        array(4, 43, 19),
+        array(4, 43, 15),
+
+        // 7
+        array(2, 98, 78),
+        array(4, 49, 31),
+        array(2, 32, 14, 4, 33, 15),
+        array(4, 39, 13, 1, 40, 14),
+
+        // 8
+        array(2, 121, 97),
+        array(2, 60, 38, 2, 61, 39),
+        array(4, 40, 18, 2, 41, 19),
+        array(4, 40, 14, 2, 41, 15),
+
+        // 9
+        array(2, 146, 116),
+        array(3, 58, 36, 2, 59, 37),
+        array(4, 36, 16, 4, 37, 17),
+        array(4, 36, 12, 4, 37, 13),
+
+        // 10
+        array(2, 86, 68, 2, 87, 69),
+        array(4, 69, 43, 1, 70, 44),
+        array(6, 43, 19, 2, 44, 20),
+        array(6, 43, 15, 2, 44, 16),
+
+        // 11
+        array(4, 101, 81),
+        array(1, 80, 50, 4, 81, 51),
+        array(4, 50, 22, 4, 51, 23),
+        array(3, 36, 12, 8, 37, 13),
+
+        // 12
+        array(2, 116, 92, 2, 117, 93),
+        array(6, 58, 36, 2, 59, 37),
+        array(4, 46, 20, 6, 47, 21),
+        array(7, 42, 14, 4, 43, 15),
+
+        // 13
+        array(4, 133, 107),
+        array(8, 59, 37, 1, 60, 38),
+        array(8, 44, 20, 4, 45, 21),
+        array(12, 33, 11, 4, 34, 12),
+
+        // 14
+        array(3, 145, 115, 1, 146, 116),
+        array(4, 64, 40, 5, 65, 41),
+        array(11, 36, 16, 5, 37, 17),
+        array(11, 36, 12, 5, 37, 13),
+
+        // 15
+        array(5, 109, 87, 1, 110, 88),
+        array(5, 65, 41, 5, 66, 42),
+        array(5, 54, 24, 7, 55, 25),
+        array(11, 36, 12, 7, 37, 13),
+
+        // 16
+        array(5, 122, 98, 1, 123, 99),
+        array(7, 73, 45, 3, 74, 46),
+        array(15, 43, 19, 2, 44, 20),
+        array(3, 45, 15, 13, 46, 16),
+
+        // 17
+        array(1, 135, 107, 5, 136, 108),
+        array(10, 74, 46, 1, 75, 47),
+        array(1, 50, 22, 15, 51, 23),
+        array(2, 42, 14, 17, 43, 15),
+
+        // 18
+        array(5, 150, 120, 1, 151, 121),
+        array(9, 69, 43, 4, 70, 44),
+        array(17, 50, 22, 1, 51, 23),
+        array(2, 42, 14, 19, 43, 15),
+
+        // 19
+        array(3, 141, 113, 4, 142, 114),
+        array(3, 70, 44, 11, 71, 45),
+        array(17, 47, 21, 4, 48, 22),
+        array(9, 39, 13, 16, 40, 14),
+
+        // 20
+        array(3, 135, 107, 5, 136, 108),
+        array(3, 67, 41, 13, 68, 42),
+        array(15, 54, 24, 5, 55, 25),
+        array(15, 43, 15, 10, 44, 16),
+
+        // 21
+        array(4, 144, 116, 4, 145, 117),
+        array(17, 68, 42),
+        array(17, 50, 22, 6, 51, 23),
+        array(19, 46, 16, 6, 47, 17),
+
+        // 22
+        array(2, 139, 111, 7, 140, 112),
+        array(17, 74, 46),
+        array(7, 54, 24, 16, 55, 25),
+        array(34, 37, 13),
+
+        // 23
+        array(4, 151, 121, 5, 152, 122),
+        array(4, 75, 47, 14, 76, 48),
+        array(11, 54, 24, 14, 55, 25),
+        array(16, 45, 15, 14, 46, 16),
+
+        // 24
+        array(6, 147, 117, 4, 148, 118),
+        array(6, 73, 45, 14, 74, 46),
+        array(11, 54, 24, 16, 55, 25),
+        array(30, 46, 16, 2, 47, 17),
+
+        // 25
+        array(8, 132, 106, 4, 133, 107),
+        array(8, 75, 47, 13, 76, 48),
+        array(7, 54, 24, 22, 55, 25),
+        array(22, 45, 15, 13, 46, 16),
+
+        // 26
+        array(10, 142, 114, 2, 143, 115),
+        array(19, 74, 46, 4, 75, 47),
+        array(28, 50, 22, 6, 51, 23),
+        array(33, 46, 16, 4, 47, 17),
+
+        // 27
+        array(8, 152, 122, 4, 153, 123),
+        array(22, 73, 45, 3, 74, 46),
+        array(8, 53, 23, 26, 54, 24),
+        array(12, 45, 15, 28, 46, 16),
+
+        // 28
+        array(3, 147, 117, 10, 148, 118),
+        array(3, 73, 45, 23, 74, 46),
+        array(4, 54, 24, 31, 55, 25),
+        array(11, 45, 15, 31, 46, 16),
+
+        // 29
+        array(7, 146, 116, 7, 147, 117),
+        array(21, 73, 45, 7, 74, 46),
+        array(1, 53, 23, 37, 54, 24),
+        array(19, 45, 15, 26, 46, 16),
+
+        // 30
+        array(5, 145, 115, 10, 146, 116),
+        array(19, 75, 47, 10, 76, 48),
+        array(15, 54, 24, 25, 55, 25),
+        array(23, 45, 15, 25, 46, 16),
+
+        // 31
+        array(13, 145, 115, 3, 146, 116),
+        array(2, 74, 46, 29, 75, 47),
+        array(42, 54, 24, 1, 55, 25),
+        array(23, 45, 15, 28, 46, 16),
+
+        // 32
+        array(17, 145, 115),
+        array(10, 74, 46, 23, 75, 47),
+        array(10, 54, 24, 35, 55, 25),
+        array(19, 45, 15, 35, 46, 16),
+
+        // 33
+        array(17, 145, 115, 1, 146, 116),
+        array(14, 74, 46, 21, 75, 47),
+        array(29, 54, 24, 19, 55, 25),
+        array(11, 45, 15, 46, 46, 16),
+
+        // 34
+        array(13, 145, 115, 6, 146, 116),
+        array(14, 74, 46, 23, 75, 47),
+        array(44, 54, 24, 7, 55, 25),
+        array(59, 46, 16, 1, 47, 17),
+
+        // 35
+        array(12, 151, 121, 7, 152, 122),
+        array(12, 75, 47, 26, 76, 48),
+        array(39, 54, 24, 14, 55, 25),
+        array(22, 45, 15, 41, 46, 16),
+
+        // 36
+        array(6, 151, 121, 14, 152, 122),
+        array(6, 75, 47, 34, 76, 48),
+        array(46, 54, 24, 10, 55, 25),
+        array(2, 45, 15, 64, 46, 16),
+
+        // 37
+        array(17, 152, 122, 4, 153, 123),
+        array(29, 74, 46, 14, 75, 47),
+        array(49, 54, 24, 10, 55, 25),
+        array(24, 45, 15, 46, 46, 16),
+
+        // 38
+        array(4, 152, 122, 18, 153, 123),
+        array(13, 74, 46, 32, 75, 47),
+        array(48, 54, 24, 14, 55, 25),
+        array(42, 45, 15, 32, 46, 16),
+
+        // 39
+        array(20, 147, 117, 4, 148, 118),
+        array(40, 75, 47, 7, 76, 48),
+        array(43, 54, 24, 22, 55, 25),
+        array(10, 45, 15, 67, 46, 16),
+
+        // 40
+        array(19, 148, 118, 6, 149, 119),
+        array(18, 75, 47, 31, 76, 48),
+        array(34, 54, 24, 34, 55, 25),
+        array(20, 45, 15, 61, 46, 16)
+
+    );
+
+    function __construct($totalCount, $dataCount) {
+        $this->totalCount = $totalCount;
+        $this->dataCount  = $dataCount;
+    }
+
+    function getDataCount() {
+        return $this->dataCount;
+    }
+
+    function getTotalCount() {
+        return $this->totalCount;
+    }
+
+    static function getRSBlocks($typeNumber, $errorCorrectLevel) {
+
+        $rsBlock = QRRSBlock::getRsBlockTable($typeNumber, $errorCorrectLevel);
+        $length = count($rsBlock) / 3;
+
+        $list = array();
+
+        for ($i = 0; $i < $length; $i++) {
+
+            $count = $rsBlock[$i * 3 + 0];
+            $totalCount = $rsBlock[$i * 3 + 1];
+            $dataCount  = $rsBlock[$i * 3 + 2];
+
+            for ($j = 0; $j < $count; $j++) {
+                $list[] = new QRRSBlock($totalCount, $dataCount);
+            }
+        }
+
+        return $list;
+    }
+
+    static function getRsBlockTable($typeNumber, $errorCorrectLevel) {
+
+        $base = ($typeNumber - 1) * 4;
+        if ($base < 0 || $base + 3 >= count(self::$QR_RS_BLOCK_TABLE)) {
+            $base = (count(self::$QR_RS_BLOCK_TABLE) - 4);
+        }
+
+        switch($errorCorrectLevel) {
+        case QR_ERROR_CORRECT_LEVEL_L :
+            return self::$QR_RS_BLOCK_TABLE[$base + 0];
+        case QR_ERROR_CORRECT_LEVEL_M :
+            return self::$QR_RS_BLOCK_TABLE[$base + 1];
+        case QR_ERROR_CORRECT_LEVEL_Q :
+            return self::$QR_RS_BLOCK_TABLE[$base + 2];
+        case QR_ERROR_CORRECT_LEVEL_H :
+            return self::$QR_RS_BLOCK_TABLE[$base + 3];
+        default :
+            trigger_error("tn:$typeNumber/ecl:$errorCorrectLevel", E_USER_ERROR);
+        }
+    }
+}
+
+//---------------------------------------------------------------
+// QRNumber
+//---------------------------------------------------------------
+
+class QRNumber extends QRData {
+
+    function __construct($data) {
+        parent::__construct(QR_MODE_NUMBER, $data);
+    }
+
+    function write(&$buffer) {
+
+        $data = $this->getData();
+
+        $i = 0;
+
+        while ($i + 2 < strlen($data) ) {
+            $num = QRNumber::parseInt(substr($data, $i, 3) );
+            $buffer->put($num, 10);
+            $i += 3;
+        }
+
+        if ($i < strlen($data) ) {
+
+            if (strlen($data) - $i == 1) {
+                $num = QRNumber::parseInt(substr($data, $i, $i + 1) );
+                $buffer->put($num, 4);
+            } else if (strlen($data) - $i == 2) {
+                $num = QRNumber::parseInt(substr($data, $i, $i + 2) );
+                $buffer->put($num, 7);
+            }
+        }
+    }
+
+    static function parseInt($s) {
+
+        $num = 0;
+        for ($i = 0; $i < strlen($s); $i++) {
+            $num = $num * 10 + QRNumber::parseIntAt(ord($s[$i]) );
+        }
+        return $num;
+    }
+
+    static function parseIntAt($c) {
+
+        if (QRUtil::toCharCode('0') <= $c && $c <= QRUtil::toCharCode('9') ) {
+            return $c - QRUtil::toCharCode('0');
+        }
+
+        trigger_error("illegal char : $c", E_USER_ERROR);
+    }
+}
+
+//---------------------------------------------------------------
+// QRKanji
+//---------------------------------------------------------------
+
+class QRKanji extends QRData {
+
+    function __construct($data) {
+        parent::__construct(QR_MODE_KANJI, $data);
+    }
+
+    function write(&$buffer) {
+
+        $data = $this->getData();
+
+        $i = 0;
+
+        while ($i + 1 < strlen($data) ) {
+
+            $c = ( (0xff & ord($data[$i]) ) << 8) | (0xff & ord($data[$i + 1]) );
+
+            if (0x8140 <= $c && $c <= 0x9FFC) {
+                $c -= 0x8140;
+            } else if (0xE040 <= $c && $c <= 0xEBBF) {
+                $c -= 0xC140;
+            } else {
+                trigger_error("illegal char at " . ($i + 1) . "/$c", E_USER_ERROR);
+            }
+
+            $c = ( ($c >> 8) & 0xff) * 0xC0 + ($c & 0xff);
+
+            $buffer->put($c, 13);
+
+            $i += 2;
+        }
+
+        if ($i < strlen($data) ) {
+            trigger_error("illegal char at " . ($i + 1), E_USER_ERROR);
+        }
+    }
+
+    function getLength() {
+        return floor(strlen($this->getData() ) / 2);
+    }
+}
+
+//---------------------------------------------------------------
+// QRAlphaNum
+//---------------------------------------------------------------
+
+class QRAlphaNum extends QRData {
+
+    function __construct($data) {
+        parent::__construct(QR_MODE_ALPHA_NUM, $data);
+    }
+
+    function write(&$buffer) {
+
+        $i = 0;
+        $c = $this->getData();
+
+        while ($i + 1 < strlen($c) ) {
+            $buffer->put(QRAlphaNum::getCode(ord($c[$i]) ) * 45
+                + QRAlphaNum::getCode(ord($c[$i + 1]) ), 11);
+            $i += 2;
+        }
+
+        if ($i < strlen($c) ) {
+            $buffer->put(QRAlphaNum::getCode(ord($c[$i])), 6);
+        }
+    }
+
+    static function getCode($c) {
+
+        if (QRUtil::toCharCode('0') <= $c
+                && $c <= QRUtil::toCharCode('9') ) {
+            return $c - QRUtil::toCharCode('0');
+        } else if (QRUtil::toCharCode('A') <= $c
+                && $c <= QRUtil::toCharCode('Z') ) {
+            return $c - QRUtil::toCharCode('A') + 10;
+        } else {
+            switch ($c) {
+            case QRUtil::toCharCode(' ') : return 36;
+            case QRUtil::toCharCode('$') : return 37;
+            case QRUtil::toCharCode('%') : return 38;
+            case QRUtil::toCharCode('*') : return 39;
+            case QRUtil::toCharCode('+') : return 40;
+            case QRUtil::toCharCode('-') : return 41;
+            case QRUtil::toCharCode('.') : return 42;
+            case QRUtil::toCharCode('/') : return 43;
+            case QRUtil::toCharCode(':') : return 44;
+            default :
+                trigger_error("illegal char : $c", E_USER_ERROR);
+            }
+        }
+
+    }
+}
+
+//---------------------------------------------------------------
+// QR8BitByte
+//---------------------------------------------------------------
+
+class QR8BitByte extends QRData {
+
+    function __construct($data) {
+        parent::__construct(QR_MODE_8BIT_BYTE, $data);
+    }
+
+    function write(&$buffer) {
+
+        $data = $this->getData();
+        for ($i = 0; $i < strlen($data); $i++) {
+            $buffer->put(ord($data[$i]), 8);
+        }
+    }
+
+}
+
+//---------------------------------------------------------------
+// QRData
+//---------------------------------------------------------------
+
+abstract class QRData {
+
+    var $mode;
+
+    var $data;
+
+    function __construct($mode, $data) {
+        $this->mode = $mode;
+        $this->data = $data;
+    }
+
+    function getMode() {
+        return $this->mode;
+    }
+
+    function getData() {
+        return $this->data;
+    }
+
+    /**
+     * @return int
+     */
+    function getLength() {
+        return strlen($this->getData() );
+    }
+
+    /**
+     * @param \QRBitBuffer $buffer
+     */
+    abstract function write(&$buffer);
+
+    function getLengthInBits($type) {
+
+        if (1 <= $type && $type < 10) {
+
+            // 1 - 9
+
+            switch($this->mode) {
+            case QR_MODE_NUMBER     : return 10;
+            case QR_MODE_ALPHA_NUM     : return 9;
+            case QR_MODE_8BIT_BYTE    : return 8;
+            case QR_MODE_KANJI      : return 8;
+            default :
+                trigger_error("mode:$this->mode", E_USER_ERROR);
+            }
+
+        } else if ($type < 27) {
+
+            // 10 - 26
+
+            switch($this->mode) {
+            case QR_MODE_NUMBER     : return 12;
+            case QR_MODE_ALPHA_NUM     : return 11;
+            case QR_MODE_8BIT_BYTE    : return 16;
+            case QR_MODE_KANJI      : return 10;
+            default :
+                trigger_error("mode:$this->mode", E_USER_ERROR);
+            }
+
+        } else if ($type < 41) {
+
+            // 27 - 40
+
+            switch($this->mode) {
+            case QR_MODE_NUMBER     : return 14;
+            case QR_MODE_ALPHA_NUM    : return 13;
+            case QR_MODE_8BIT_BYTE    : return 16;
+            case QR_MODE_KANJI      : return 12;
+            default :
+                trigger_error("mode:$this->mode", E_USER_ERROR);
+            }
+
+        } else {
+            trigger_error("mode:$this->mode", E_USER_ERROR);
+        }
+    }
+
+}
+
+//---------------------------------------------------------------
+// QRMath
+//---------------------------------------------------------------
+
+class QRMath {
+
+    static $QR_MATH_EXP_TABLE = null;
+    static $QR_MATH_LOG_TABLE = null;
+
+    static function init() {
+
+        self::$QR_MATH_EXP_TABLE = QRMath::createNumArray(256);
+
+        for ($i = 0; $i < 8; $i++) {
+            self::$QR_MATH_EXP_TABLE[$i] = 1 << $i;
+        }
+
+        for ($i = 8; $i < 256; $i++) {
+            self::$QR_MATH_EXP_TABLE[$i] = self::$QR_MATH_EXP_TABLE[$i - 4]
+                ^ self::$QR_MATH_EXP_TABLE[$i - 5]
+                ^ self::$QR_MATH_EXP_TABLE[$i - 6]
+                ^ self::$QR_MATH_EXP_TABLE[$i - 8];
+        }
+
+        self::$QR_MATH_LOG_TABLE = QRMath::createNumArray(256);
+
+        for ($i = 0; $i < 255; $i++) {
+            self::$QR_MATH_LOG_TABLE[self::$QR_MATH_EXP_TABLE[$i] ] = $i;
+        }
+    }
+
+    static function createNumArray($length) {
+        $num_array = array();
+        for ($i = 0; $i < $length; $i++) {
+            $num_array[] = 0;
+        }
+        return $num_array;
+    }
+
+    static function glog($n) {
+
+        if ($n < 1) {
+            trigger_error("log($n)", E_USER_ERROR);
+        }
+
+        return self::$QR_MATH_LOG_TABLE[$n];
+    }
+
+    static function gexp($n) {
+
+        while ($n < 0) {
+            $n += 255;
+        }
+
+        while ($n >= 256) {
+            $n -= 255;
+        }
+
+        return self::$QR_MATH_EXP_TABLE[$n];
+    }
+}
+
+// init static table
+QRMath::init();
+
+//---------------------------------------------------------------
+// QRPolynomial
+//---------------------------------------------------------------
+
+class QRPolynomial {
+
+    var $num;
+
+    function __construct($num, $shift = 0) {
+
+        $offset = 0;
+
+        while ($offset < count($num) && $num[$offset] == 0) {
+            $offset++;
+        }
+
+        $this->num = QRMath::createNumArray(count($num) - $offset + $shift);
+        for ($i = 0; $i < count($num) - $offset; $i++) {
+            $this->num[$i] = $num[$i + $offset];
+        }
+    }
+
+    function get($index) {
+        return $this->num[$index];
+    }
+
+    function getLength() {
+        return count($this->num);
+    }
+
+    // PHP5
+    function __toString() {
+        return $this->toString();
+    }
+
+    function toString() {
+
+        $buffer = "";
+
+        for ($i = 0; $i < $this->getLength(); $i++) {
+            if ($i > 0) {
+                $buffer .= ",";
+            }
+            $buffer .= $this->get($i);
+        }
+
+        return $buffer;
+    }
+
+    function toLogString() {
+
+        $buffer = "";
+
+        for ($i = 0; $i < $this->getLength(); $i++) {
+            if ($i > 0) {
+                $buffer .= ",";
+            }
+            $buffer .= QRMath::glog($this->get($i) );
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * @param \QRPolynomial $e
+     *
+     * @return \QRPolynomial
+     */
+    function multiply($e) {
+
+        $num = QRMath::createNumArray($this->getLength() + $e->getLength() - 1);
+
+        for ($i = 0; $i < $this->getLength(); $i++) {
+            $vi = QRMath::glog($this->get($i) );
+
+            for ($j = 0; $j < $e->getLength(); $j++) {
+                $num[$i + $j] ^= QRMath::gexp($vi + QRMath::glog($e->get($j) ) );
+            }
+        }
+
+        return new QRPolynomial($num);
+    }
+
+    /**
+     * @param \QRPolynomial $e
+     *
+     * @return $this|\QRPolynomial
+     */
+    function mod($e) {
+
+        if ($this->getLength() - $e->getLength() < 0) {
+            return $this;
+        }
+
+        $ratio = QRMath::glog($this->get(0) ) - QRMath::glog($e->get(0) );
+
+        $num = QRMath::createNumArray($this->getLength() );
+        for ($i = 0; $i < $this->getLength(); $i++) {
+            $num[$i] = $this->get($i);
+        }
+
+        for ($i = 0; $i < $e->getLength(); $i++) {
+            $num[$i] ^= QRMath::gexp(QRMath::glog($e->get($i) ) + $ratio);
+        }
+
+        $newPolynomial = new QRPolynomial($num);
+        return $newPolynomial->mod($e);
+    }
+}
+
+//---------------------------------------------------------------
+// Mode
+//---------------------------------------------------------------
+
+define("QR_MODE_NUMBER", 1 << 0);
+define("QR_MODE_ALPHA_NUM", 1 << 1);
+define("QR_MODE_8BIT_BYTE", 1 << 2);
+define("QR_MODE_KANJI", 1 << 3);
+
+//---------------------------------------------------------------
+// MaskPattern
+//---------------------------------------------------------------
+
+define("QR_MASK_PATTERN000", 0);
+define("QR_MASK_PATTERN001", 1);
+define("QR_MASK_PATTERN010", 2);
+define("QR_MASK_PATTERN011", 3);
+define("QR_MASK_PATTERN100", 4);
+define("QR_MASK_PATTERN101", 5);
+define("QR_MASK_PATTERN110", 6);
+define("QR_MASK_PATTERN111", 7);
+
+//---------------------------------------------------------------
+// ErrorCorrectLevel
+
+// 7%.
+define("QR_ERROR_CORRECT_LEVEL_L", 1);
+// 15%.
+define("QR_ERROR_CORRECT_LEVEL_M", 0);
+// 25%.
+define("QR_ERROR_CORRECT_LEVEL_Q", 3);
+// 30%.
+define("QR_ERROR_CORRECT_LEVEL_H", 2);
+
+
+//---------------------------------------------------------------
+// QRBitBuffer
+//---------------------------------------------------------------
+
+class QRBitBuffer {
+
+    var $buffer;
+    var $length;
+
+    function __construct() {
+        $this->buffer = array();
+        $this->length = 0;
+    }
+
+    function getBuffer() {
+        return $this->buffer;
+    }
+
+    function getLengthInBits() {
+        return $this->length;
+    }
+
+    function __toString() {
+        $buffer = "";
+        for ($i = 0; $i < $this->getLengthInBits(); $i++) {
+            $buffer .= $this->get($i)? '1' : '0';
+        }
+        return $buffer;
+    }
+
+    function get($index) {
+        $bufIndex = (int)floor($index / 8);
+        return ( ($this->buffer[$bufIndex] >> (7 - $index % 8) ) & 1) == 1;
+    }
+
+    function put($num, $length) {
+
+        for ($i = 0; $i < $length; $i++) {
+            $this->putBit( ( ($num >> ($length - $i - 1) ) & 1) == 1);
+        }
+    }
+
+    function putBit($bit) {
+
+        $bufIndex = (int)floor($this->length / 8);
+        if (count($this->buffer) <= $bufIndex) {
+            $this->buffer[] = 0;
+        }
+
+        if ($bit) {
+            $this->buffer[$bufIndex] |= (0x80 >> ($this->length % 8) );
+        }
+
+        $this->length++;
+    }
+}
+
+?>

--- a/bolao-x/readme.txt
+++ b/bolao-x/readme.txt
@@ -1,0 +1,166 @@
+=== Bolao X ===
+Contributors: bolaox
+Tags: lottery, bolao, mercadopago, csv, pdf, excel
+Requires at least: 6.0
+Tested up to: 6.5
+Stable tag: 2.8.19
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Sistema completo para gerenciamento de bolão semanal. Permite cadastro de apostas, conferência automática, exportação de resultados e pagamento via Mercado Pago.
+
+== Description ==
+Plugin para gerenciamento de bolão com cadastro de apostas e conferência automática. Permite exportar resultados em CSV, Excel e PDF e gera um link de pagamento do Mercado Pago.
+* Shortcode [bolao_x_login] para login e cadastro usando telefone e senha
+* Após login ou cadastro o usuário é enviado ao formulário de apostas
+* Shortcode [bolao_x_dashboard] mostra painel do apostador com ícones e atalhos
+* Estatísticas com gráfico de barras
+* Interface 2025 com efeito de vidro, botões em gradiente e layout responsivo estilo aplicativo
+* Áreas dos shortcodes com visual claro e animações de entrada
+* Shortcodes exibidos em contêiner “app” para visual mais moderno
+* Escolha das dezenas em grade clicável
+* Widget de resumo no painel e envio de e-mails automáticos com barras de progresso
+* Premiação por "Menos Pontos" com acúmulo em caso de empate
+* Pagamento via Pix usando o e-mail do usuário logado
+* Credenciais de produção e teste (Public Key e Access Token) com modo ativo
+* Valor da aposta configurável e logs de pagamento acessíveis no admin
+* Validador de credenciais do Mercado Pago e logs gerais no painel
+* Chave Pix configurável para exibição no modal de pagamento
+* Pagamentos Pix usam X-Idempotency-Key único e logs são truncados para melhor
+  leitura
+* As chamadas usam a constante `MP_API_URL` que aponta para `https://api.mercadopago.com`
+* Botão "Pagar com Pix" mostra o QR Code em um modal e permite copiar o código pelo botão "Copie o Código" antes de apostar
+* O QR Code é exibido usando a imagem base64 retornada pelo Mercado Pago
+* Todos os dados são removidos na desinstalação
+* Pronto para tradução com arquivos `.pot` e `.po` em `/languages`
+* Tradução brasileira disponível com o arquivo-fonte `bolao-x-pt_BR.po`. O `.mo` gerado deve permanecer fora do repositório
+
+== Installation ==
+1. Envie a pasta `bolao-x` para o diretório `wp-content/plugins`.
+2. Ative o plugin no menu Plugins do WordPress.
+3. Acesse o menu Bolao X para configurar e começar a usar.
+
+== Usage ==
+1. No menu **Bolao X**, abra a tela **Configurações**.
+2. Informe as credenciais do Mercado Pago para produção e teste (Public Key e Access Token).
+3. Escolha o modo ativo (Teste ou Produção) e defina o valor da aposta em reais.
+4. Opcionalmente, informe a chave Pix que será exibida ao gerar o QR Code.
+5. Valide as credenciais pelo botão disponível e salve as alterações.
+
+== Development ==
+Instale o PHP CLI e extensões necessárias executando `../scripts/install-deps.sh`.
+Depois execute `scripts/test.sh` para validar o plugin.
+
+== Changelog ==
+= 2.8.19 =
+* Redireciona automaticamente para /login-cadastro ao acessar "Minhas Apostas" ou "Cadastro" sem estar logado
+= 2.8.18 =
+* Aprimora login e cadastro com validações e sessão de 1h
+= 2.8.17 =
+* Corrige exibição das apostas do usuário após login
+= 2.8.16 =
+* Aprimora visual do carrinho de apostas e esconde botão Pix quando vazio
+= 2.8.15 =
+* Ajusta página de Contemplados com filtro por concurso e opção de exportar relatório
+= 2.8.14 =
+* Corrige página em branco após login usando redirecionamento dinâmico
+= 2.8.13 =
+* Corrige o redirecionamento após login para a página solicitada
+= 2.8.2 =
+* Configuração do valor da aposta e página de logs do Mercado Pago
+= 2.8.1 =
+* Barras de porcentagem com animação gradiente
+= 2.8.0 =
+* Pagamentos integrados ao Mercado Pago com seleção de conta ativa
+
+= 2.7.1 =
+* Webhook de confirmação automática de pagamentos Pix via token no código
+= 2.7.0 =
+* Primeiro suporte a pagamento via Pix com QR Code
+= 3.12.1 =
+* Correção de avisos de índice indefinido ao gerar o QR Code
+
+= 3.12.0 =
+= 3.11.9 =
+* Removido o suporte à confirmação automática de pagamentos via webhook
+= 3.11.8 =
+* Confirmação de aposta com números em círculos e sem exibir o TXID
+= 3.11.7 =
+* Ícones do painel do apostador alinhados verticalmente e novo ícone para resultados
+= 3.11.6 =
+* Novo shortcode `[bolao_x_dashboard]` com painel do apostador e ícones premium
+= 3.11.5 =
+* Resultados anteriores mostram data e dezenas em círculos destacados
+= 3.11.4 =
+* Resultados, repetidos e apostadores alinhados à esquerda
+= 3.11.3 =
+* Texto "RESULTADO DA SEMANA" exibido em maiúsculas
+* Barra de porcentagem com fundo verde para melhor leitura
+= 3.11.2 =
+* Título "Resultado da Semana" usa o mesmo estilo de "NÚMEROS REPETIDOS"
+* Card especial para a premiação "Menos Pontos"
+= 3.11.0 =
+* Quadro de dezenas marcando os números sorteados
+* Área de "NÚMEROS REPETIDOS" exibindo os mais escolhidos
+* Listagem de apostas com números em círculos e destaque nos acertos
+= 3.8.3 =
+* QR Code inclui TXID único ligado à aposta e webhook reconhece por TXID
+= 3.8.2 =
+* Webhook Pix agora usa assinatura HMAC configurada no admin
+= 3.8.1 =
+* Token do webhook movido para constante no código
+= 3.8.0 =
+* Integracao Pix reescrita do zero com payload e QR code validos
+= 3.7.7 =
+* Pagamentos Pix reprogramados para evitar erros de leitura do QR Code
+= 3.7.6 =
+* Correção no cálculo do CRC do QR Code Pix
+= 3.7.5 =
+* QR Code Pix gerado com payload padrao e imagem maior para melhor leitura
+= 3.7.4 =
+* Mensagens de "Login realizado com sucesso." e "Cadastro realizado com sucesso." redirecionam automaticamente para /participe
+= 3.7.3 =
+* Redireciona para a página do formulário após login ou cadastro
+= 3.7.2 =
+* Shortcode [bolao_x_login] com tela de login e cadastro via telefone
+= 3.7.1 =
+* Grade de dezenas ampliada com círculos maiores e animações
+= 3.7.0 =
+* Webhook para confirmação automática de pagamentos
+* Token configurável e chave Pix editável
+= 3.6.3 =
+* Campo "Como quer ser chamado?" no formulário de aposta
+* Área do apostador com login animado e troca de senha
+= 3.6.2 =
+* Premiação "Menos Pontos" com acúmulo em caso de empate
+= 3.6.1 =
+* Largura ampliada do layout mantendo responsividade
+= 3.6.0 =
+* Visual mais claro sem áreas escuras
+* Animações de entrada e seleção aprimoradas nos shortcodes
+= 3.5.0 =
+* Contêiner app adiciona visual de aplicativo e responsividade extra
+= 3.4.0 =
+* Layout responsivo para dispositivos móveis
+= 3.3.0 =
+* Perfil do participante com atualização de dados
+* Status do pagamento visível em [bolao_x_my_bets]
+* Contagem regressiva até o horário limite
+= 3.2.4 =
+* Texto "Pague com Pix" acima do QR Code no formulário
+= 3.2.3 =
+* Campo "Nome Completo" agora usa input em largura total
+= 3.2.2 =
+* Ajuste de rótulos: "Nome Completo" e "Escolha 10 dezenas"
+* Botão "APOSTE AGORA" em largura total
+= 3.2.0 =
+* Grade de dezenas clicável para facilitar a seleção.
+= 3.1.0 =
+* Visual atualizado com efeito de vidro e botões em gradiente.
+= 3.0.0 =
+* Todas as mensagens internas preparadas para tradução.
+= 2.9.0 =
+* Suporte a internacionalização com carregamento de text domain.
+= 2.8.0 =
+* Gráficos de barra nas estatísticas.
+

--- a/bolao-x/uninstall.php
+++ b/bolao-x/uninstall.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit();
+}
+
+$types = array( 'bolaox_aposta', 'bolaox_result' );
+$posts = get_posts( array(
+    'post_type'   => $types,
+    'numberposts' => -1,
+    'post_status' => 'any',
+) );
+foreach ( $posts as $post ) {
+    wp_delete_post( $post->ID, true );
+}
+
+delete_option( 'bolaox_result' );
+delete_option( 'bolaox_cutoffs' );
+delete_option( 'bolaox_mp_prod_public' );
+delete_option( 'bolaox_mp_prod_token' );
+delete_option( 'bolaox_mp_test_public' );
+delete_option( 'bolaox_mp_test_token' );
+delete_option( 'bolaox_mp_mode' );
+delete_option( 'bolaox_price' );
+delete_option( 'bolaox_pix_key' );
+
+$upload = wp_upload_dir();
+$dir    = trailingslashit( $upload['basedir'] ) . 'bolao-x';
+if ( file_exists( $dir . '/mp-error.log' ) ) {
+    unlink( $dir . '/mp-error.log' );
+}
+if ( file_exists( $dir . '/general.log' ) ) {
+    unlink( $dir . '/general.log' );
+}
+if ( is_dir( $dir ) ) {
+    rmdir( $dir );
+}
+


### PR DESCRIPTION
## Summary
- update plugin to version 2.8.19
- redirect to /login-cadastro when accessing profile or bets without a session
- document the new behaviour in the changelog

## Testing
- `php -l bolao-x/bolao-x.php`
- `node --check bolao-x/assets/js/bolao-x.js`


------
https://chatgpt.com/codex/tasks/task_e_68767ef3fe68832ba005ffa7f92fadfe