### PR TITLE
Handle 6-player teams

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,69 @@
+<?php
+$default_players = [
+    "Dheniell", "Dario", "Papel", "Wallace", "Matheus", "Kloh",
+    "Bebeto", "Custela", "Diego", "Matheus MP", "Gabriel", "Bolo",
+    "Geisel", "Caputo", "Fred", "Darlan", "Baiano"
+];
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sorteio de Times</title>
+<link rel="stylesheet" href="style.css">
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+<div class="container">
+    <h1>Sistema de Sorteio de Jogadores</h1>
+    <table id="tabela-jogadores">
+        <thead>
+            <tr>
+                <th>Nº</th>
+                <th>Nome do Jogador</th>
+                <th>Posição</th>
+                <th>Pedra</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach($default_players as $i => $nome): ?>
+            <tr>
+                <td><?php echo $i+1; ?></td>
+                <td><input type="text" value="<?php echo htmlspecialchars($nome); ?>" class="nome-input" aria-label="Nome do Jogador"></td>
+                <td>
+                    <select class="posicao-select" aria-label="Posição">
+                        <option value="">--</option>
+                        <option>Goleiro</option>
+                        <option>Fixo</option>
+                        <option>Lateral Direito</option>
+                        <option>Lateral Esquerdo</option>
+                        <option>Meia</option>
+                        <option>Pivô</option>
+                    </select>
+                </td>
+                <td>
+                    <select class="pedra-select" aria-label="Pedra">
+                        <option value="">--</option>
+                        <option value="1">Pedra 1</option>
+                        <option value="2">Pedra 2</option>
+                        <option value="3">Pedra 3</option>
+                    </select>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="botoes">
+        <button id="sortear">Sortear Times</button>
+        <button id="resetar">Resetar Tabela</button>
+        <button id="carregar">Carregar Semana Anterior</button>
+        <button id="salvar">Salvar Times</button>
+        <button id="resetar-times">Resetar Times Sorteados</button>
+        <button id="baixar-pdf">Baixar PDF</button>
+    </div>
+    <div id="resultado" class="times"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,168 @@
+const TEAM_SIZES = [6,6,5];
+const EXPECTED_PLAYERS = TEAM_SIZES.reduce((a, b) => a + b, 0);
+
+function getPlayers() {
+    const rows = document.querySelectorAll('#tabela-jogadores tbody tr');
+    const players = [];
+    rows.forEach(row => {
+        const name = row.querySelector('.nome-input').value.trim();
+        const position = row.querySelector('.posicao-select').value;
+        const stone = row.querySelector('.pedra-select').value;
+        players.push({name, position, stone});
+    });
+    return players;
+}
+function validate(players) {
+    if (players.length !== EXPECTED_PLAYERS) {
+        alert(`É necessário ter ${EXPECTED_PLAYERS} jogadores, mas foram informados ${players.length}.`);
+        return false;
+    }
+    const goleiros = players.filter(p=>p.position==='Goleiro');
+    if (goleiros.length !== 2) {
+        alert('Devem haver exatamente 2 goleiros.');
+        return false;
+    }
+    for (const p of players) {
+        if(!p.name || !p.position || !p.stone) {
+            alert('Todos os campos devem estar preenchidos.');
+            return false;
+        }
+    }
+    return true;
+}
+function sortearTimes(players) {
+    const teams = [[],[],[]];
+    const reserves = [];
+    const positions = {
+        'Goleiro': [],
+        'Fixo': [],
+        'Lateral Direito': [],
+        'Lateral Esquerdo': [],
+        'Meia': [],
+        'Pivô': []
+    };
+    players.forEach(p=>positions[p.position].push(p));
+    for (const key in positions) {
+        positions[key].sort((a,b)=>a.stone-b.stone);
+    }
+    // Goleiros para time 0 e 1
+    for(let i=0;i<2;i++){
+        if(positions['Goleiro'][i]) teams[i].push(positions['Goleiro'][i]);
+    }
+    // Distribuir outras posições
+    const cycleAssign = (posArr)=>{
+        let t = 0;
+        posArr.forEach(p=>{
+            let attempts = 0;
+            while(attempts < 3 && teams[t].length >= TEAM_SIZES[t]){
+                t = (t + 1) % 3;
+                attempts++;
+            }
+            if(teams[t].length < TEAM_SIZES[t]){
+                teams[t].push(p);
+                t = (t + 1) % 3;
+            }else{
+                reserves.push(p);
+            }
+        });
+    };
+    cycleAssign(positions['Fixo']);
+    cycleAssign(positions['Lateral Direito']);
+    cycleAssign(positions['Lateral Esquerdo']);
+    cycleAssign([...positions['Meia'], ...positions['Pivô']]);
+    // Preencher faltantes
+    const rest = [];
+    for(const key in positions){
+        positions[key].forEach(p=>{
+            if(!teams.some(t=>t.includes(p)) && !reserves.includes(p)) rest.push(p);
+        });
+    }
+    rest.forEach(p=>{
+        const idxInfo = teams
+            .map((team,i)=>({i,len:team.length,cap:TEAM_SIZES[i]}))
+            .filter(o=>o.len < o.cap)
+            .sort((a,b)=>a.len - b.len)[0];
+        if(idxInfo){
+            teams[idxInfo.i].push(p);
+        } else {
+            reserves.push(p);
+        }
+    });
+    return {teams,reserves};
+}
+function renderTeams(data){
+    const container=document.getElementById('resultado');
+    container.innerHTML='';
+    data.teams.forEach((team,i)=>{
+        const div=document.createElement('div');
+        div.className='time';
+        div.innerHTML=`<h3>Time ${i+1}</h3>`+team.map(p=>`<div>${p.name} - ${p.position} - Pedra ${p.stone}</div>`).join('');
+        container.appendChild(div);
+    });
+    if(data.reserves.length){
+        const r=document.createElement('div');
+        r.className='reservas';
+        r.innerHTML='<h3>Reservas</h3>'+data.reserves.map(p=>`<div>${p.name}</div>`).join('');
+        container.appendChild(r);
+    }
+}
+
+document.getElementById('sortear').addEventListener('click',()=>{
+    const players = getPlayers();
+    if(!validate(players)) return;
+    const result = sortearTimes(players);
+    renderTeams(result);
+});
+
+document.getElementById('resetar').addEventListener('click',()=>{
+    location.reload();
+});
+
+document.getElementById('resetar-times').addEventListener('click',()=>{
+    document.getElementById('resultado').innerHTML='';
+});
+
+document.getElementById('salvar').addEventListener('click',()=>{
+    const players = getPlayers();
+    localStorage.setItem('jogadores', JSON.stringify(players));
+    alert('Times salvos localmente.');
+});
+
+function carregarSalvos(){
+    const saved = localStorage.getItem('jogadores');
+    if(saved){
+        const players = JSON.parse(saved);
+        const rows = document.querySelectorAll('#tabela-jogadores tbody tr');
+        players.forEach((p,i)=>{
+            if(rows[i]){
+                rows[i].querySelector('.nome-input').value = p.name;
+                rows[i].querySelector('.posicao-select').value = p.position;
+                rows[i].querySelector('.pedra-select').value = p.stone;
+            }
+        });
+    } else {
+        alert('Nenhuma lista salva encontrada.');
+    }
+}
+
+window.addEventListener('load',()=>{
+    carregarSalvos();
+});
+
+document.getElementById('carregar').addEventListener('click',()=>{
+    carregarSalvos();
+});
+
+document.getElementById('baixar-pdf').addEventListener('click',()=>{
+    const printContents = document.getElementById('resultado').innerHTML;
+    const newWin = window.open('', '', 'width=900,height=700');
+    newWin.document.write('<html><head><title>Times</title>');
+    newWin.document.write('<link rel="stylesheet" href="style.css">');
+    newWin.document.write('</head><body>');
+    newWin.document.write(printContents);
+    newWin.document.write('</body></html>');
+    newWin.document.close();
+    newWin.print();
+    newWin.close();
+});
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,62 @@
+body {
+    font-family: 'Outfit', sans-serif;
+    background: #f5f6fa;
+    margin: 0;
+    padding: 20px;
+}
+.container {
+    max-width: 960px;
+    margin: auto;
+}
+#tabela-jogadores {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+#tabela-jogadores th, #tabela-jogadores td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: center;
+}
+#tabela-jogadores th {
+    background: #e5e5f7;
+}
+.botoes button {
+    margin: 5px;
+    padding: 10px 20px;
+    border: none;
+    background: #845ef7;
+    color: #fff;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.3s;
+}
+.botoes button:hover {
+    background: #6f4bd8;
+}
+.pedra1 { background: #d3f9d8; }
+.pedra2 { background: #fff3bf; }
+.pedra3 { background: #ffa8a8; }
+.times {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+.time {
+    background: #fff;
+    padding: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    width: 30%;
+    min-width: 250px;
+}
+.time h3 {
+    margin-top: 0;
+    background:#e5e5f7;
+    padding:5px;
+    border-radius:4px;
+    text-align:center;
+}
+.reservas {
+    margin-top:20px;
+}


### PR DESCRIPTION
## Summary
- keep 17-player default list
- validate exactly 17 players and distribute according to new capacities
- change team limits to `[6,6,5]` so the third team has no goalkeeper
- show player count mismatch in validation message

## Testing
- `php -l index.php`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6887ff158978832bbba99eeba0ba53f2