### PR TITLE
Fix header search overlay toggle

### DIFF
--- a/realhomes/realhomes/assets/js/search-overlay.js
+++ b/realhomes/realhomes/assets/js/search-overlay.js
@@ -1,0 +1,24 @@
+document.addEventListener('click', function (e) {
+    if (e.target.closest('.rh-search-toggle')) {
+        var overlay = document.getElementById('rh-search-overlay');
+        if (overlay) {
+            overlay.classList.add('is-active');
+        }
+    }
+
+    if (e.target.closest('.rh-search-close')) {
+        var overlayClose = document.getElementById('rh-search-overlay');
+        if (overlayClose) {
+            overlayClose.classList.remove('is-active');
+        }
+    }
+});
+
+document.addEventListener('keyup', function (e) {
+    if (e.key === 'Escape') {
+        var overlayEsc = document.getElementById('rh-search-overlay');
+        if (overlayEsc) {
+            overlayEsc.classList.remove('is-active');
+        }
+    }
+});

--- a/realhomes/realhomes/assets/modern/partials/header/submit-property.php
+++ b/realhomes/realhomes/assets/modern/partials/header/submit-property.php
@@ -1,0 +1,32 @@
+<?php
+$show_submit_button = get_option( 'inspiry_show_submit_on_login', 'false' );
+$submit_url         = '';
+$login_required     = 'inspiry_submit_login_required';
+
+if ( is_user_logged_in() || inspiry_guest_submission_enabled() ) {
+	$login_required = '';
+}
+
+if ( realhomes_get_dashboard_page_url() && realhomes_dashboard_module_enabled( 'inspiry_submit_property_module_display' ) ) {
+	$submit_url = realhomes_get_dashboard_page_url( 'properties&submodule=submit-property' );
+}
+
+if ( ! empty( $submit_url ) && ( 'hide' !== $show_submit_button ) ) {
+
+	if ( inspiry_no_membership_disable_stuff() ) {
+
+		$theme_submit_button_text = get_option( 'theme_submit_button_text' );
+		if ( empty( $theme_submit_button_text ) ) {
+			$theme_submit_button_text = esc_html__( 'Submit', RH_TEXT_DOMAIN );
+		}
+
+$submit_link_format = '<div class="rh_menu__user_submit"><a class="rh-btn rh-btn-primary %s" href="%s">%s</a><button aria-label="Buscar" class="Header-module--link--3rH8w Header-module--searchLink--ku0tv rh-search-toggle"><svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="Header-module--iconSearchDesktop--29aB_"><path fill-rule="evenodd" clip-rule="evenodd" d="M17 10.5a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0zm-1.562 5.645a7.5 7.5 0 11.707-.707l5.209 5.208-.708.708-5.208-5.209z" fill="currentColor"></path></svg></button></div>';
+		if ( 'true' === $show_submit_button ) {
+			if ( realhomes_get_current_user_role_option( 'property_submit' ) || inspiry_guest_submission_enabled() ) {
+				printf( $submit_link_format, esc_attr( $login_required ), esc_url( $submit_url ), esc_html( $theme_submit_button_text ) );
+			}
+		} else {
+			printf( $submit_link_format, esc_attr( $login_required ), esc_url( $submit_url ), esc_html( $theme_submit_button_text ) );
+		}
+	}
+}

--- a/realhomes/realhomes/assets/modern/scripts/js/custom.js
+++ b/realhomes/realhomes/assets/modern/scripts/js/custom.js
@@ -1,0 +1,1421 @@
+( function ( $ ) {
+    "use strict";
+
+    /**
+     *  Sticky footer related code.
+     */
+    function footerStick() {
+        $( '.rh_wrap_stick_footer' ).css( 'padding-bottom', $( '.rh_sticky_wrapper_footer' ).outerHeight() + 'px' )
+    }
+
+    $( document ).ready( function () {
+
+        // Sticky Headers
+        reahomesStickyHeader( '.rh_mod_sticky_header,.rhea_long_screen_header_temp', 1139, '>' );
+        reahomesStickyHeader( '.rh-mobile-sticky-header', 1139, '<' );
+
+        // footerStick - Run on document ready.
+        footerStick();
+        $( window ).on( 'load resize', function () {
+            footerStick();
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Navigation menu.
+        /*-----------------------------------------------------------------------------------*/
+        $( '.rh_menu ul.rh_menu__main > li' ).on( {
+            mouseenter : function () {
+                var menu_link = $( this ).children( 'a' );
+                $( menu_link ).addClass( 'rh_menu--hover' );
+            },
+            mouseleave : function () {
+                var menu_link = $( this ).children( 'a' );
+                $( menu_link ).removeClass( 'rh_menu--hover' );
+            }
+        } );
+
+        // Responsive Menu.
+        // First level
+        $( '.rh_menu__hamburger' ).on( 'click', function () {
+            $( 'ul.rh_menu__responsive' ).toggleClass( 'rh_menu__responsive_show' );
+        } );
+
+        var sub_menu_parent = $( '.rh_menu__responsive ul.sub-menu' ).parent();
+        sub_menu_parent.prepend( '<i class="fas fa-caret-down rh_menu__indicator"></i>' );
+
+        // Second Level
+        $( 'ul.rh_menu__responsive > li .rh_menu__indicator' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            $( this ).parent().children( 'ul.sub-menu' ).slideToggle();
+            $( this ).toggleClass( 'rh_menu__indicator_up' );
+        } );
+
+        function moveUserMenuRes() {
+            var largeUserMenu        = $( '.rh_user_menu_wrapper_large' ).find( '.rh_menu__user_profile' );
+            var smallUserMenu        = $( '.rh_user_menu_wrapper_responsive' ).find( '.rh_menu__user_profile' );
+            var largeUserMenuWrapper = $( '.rh_user_menu_wrapper_large' );
+            var smallUserMenuWrapper = $( '.rh_user_menu_wrapper_responsive' );
+            if ( $( window ).width() < 1140 ) {
+                largeUserMenu.appendTo( smallUserMenuWrapper );
+            } else {
+                smallUserMenu.appendTo( largeUserMenuWrapper );
+            }
+        }
+
+        moveUserMenuRes();
+        $( window ).on( 'resize', function () {
+            moveUserMenuRes();
+        } );
+
+        // header variation standard
+        $( '.rh_menu__hamburger_standard' ).on( 'click', function () {
+            $( this ).siblings( '.menu-container-standard-responsive' ).toggleClass( 'rh_menu__responsive_show' );
+            // $('ul.rh_menu__responsive_plain').toggleClass('rh_menu__responsive_show');
+        } );
+
+        var sub_menu_parent_plain = $( '.rh_menu__responsive_plain ul.sub-menu' ).parent();
+        sub_menu_parent_plain.prepend( '<i class="fas fa-caret-down rh_menu__indicator"></i>' );
+
+        $( 'ul.rh_menu__responsive_plain > li .rh_menu__indicator' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            $( this ).parent().children( 'ul.sub-menu' ).slideToggle();
+            $( this ).toggleClass( 'rh_menu__indicator_up' );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /*	Scroll to Top
+        /*-----------------------------------------------------------------------------------*/
+        $( function () {
+            var scroll_anchor = $( '#scroll-top' );
+
+            $( window ).on( 'scroll', function () {
+                // if ($(window).width() > 980) {
+                if ( $( this ).scrollTop() > 250 ) {
+                    scroll_anchor.addClass( 'show' );
+                    return;
+                }
+                // }
+                scroll_anchor.removeClass( 'show' );
+            } );
+
+            scroll_anchor.on( 'click', function ( event ) {
+                event.preventDefault();
+                $( 'html, body' ).animate( { scrollTop : 0 }, 'slow' );
+            } );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Hover Fix For Listings
+        /*-----------------------------------------------------------------------------------*/
+
+        var mobileHover = function ( thumbFigure ) {
+            $( thumbFigure ).each( function () {
+                $( this ).on( 'touchstart', function () {
+                    return true;
+                } );
+                $( this ).parents( 'body' ).on( 'touchstart', function () {
+                    return true;
+                } );
+            } );
+
+        };
+
+        mobileHover( '.rh_prop_card__thumbnail' );
+        mobileHover( '.rh_list_card__thumbnail' );
+
+        // $('.rh_prop_card__thumbnail').attr("onclick","return true");
+
+        /*-----------------------------------------------------------------------------------*/
+        /*	Login Menu Open/Close
+        /*-----------------------------------------------------------------------------------*/
+        function logInMenu() {
+
+            $( ".rh_menu__user_profile" ).on( ' mouseover', function () {
+                if ( $( window ).width() > 1023 || $( this ).find( '.add-favorites-without-login' ).length ) {
+                    if ( ! $( this ).hasClass( 'open-login' ) ) {
+                        $( this ).addClass( 'open-login' );
+                    }
+                }
+            } );
+
+            $( ".rh_menu__user_profile" ).on( 'mouseout', function () {
+                if ( $( window ).width() > 1023 || $( this ).find( '.add-favorites-without-login' ).length ) {
+                    if ( $( this ).hasClass( 'open-login' ) ) {
+                        $( this ).removeClass( 'open-login' );
+                    }
+                }
+            } );
+
+            $( "body" ).on( 'click', '.rh_menu__user_profile', function () {
+                if ( $( window ).width() < 1024 ) {
+                    $( this ).toggleClass( 'open-login' );
+
+                    $( '.rh_modal' ).on( 'click', function ( e ) {
+                        e.stopPropagation();
+                    } );
+                }
+            } );
+        }
+
+        logInMenu();
+
+        /*-----------------------------------------------------------------------------------*/
+        /*	Auto Focus on login
+        /*-----------------------------------------------------------------------------------*/
+        $( function () {
+            $( '.rh_menu__user_profile' ).on( 'mouseover', function () {
+                if ( $( this ).find( '#username' ).hasClass( 'focus-class' ) ) {
+                    var userFocus   = $( '.focus-class' );
+                    var fieldVal    = userFocus.val();
+                    var fieldLength = fieldVal.length;
+                    if ( fieldLength === 0 ) {
+                        $( userFocus ).focus();
+                    }
+                }
+            } );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Flex Slider
+        /*-----------------------------------------------------------------------------------*/
+        if ( jQuery().flexslider ) {
+
+            // Flex Slider for Homepage.
+            $( '#rh_slider__home .flexslider' ).flexslider( {
+                animation          : "fade",
+                slideshowSpeed     : 7000,
+                animationSpeed     : 1500,
+                slideshow          : true,
+                directionNav       : true,
+                controlNav         : false,
+                keyboardNav        : true,
+                customDirectionNav : $( ".rh_flexslider__nav_main a" ),
+                start              : function ( slider ) {
+                    slider.removeClass( 'loading' );
+                    slider.removeClass( 'rh_home_load_height' );
+                }
+            } );
+
+            // Flex Slider for Property Single Videos.
+            const singlePropertyVideosSlider      = $( '.rh_wrapper_property_videos_slider' ),
+                  singlePropertyVideosSliderItems = singlePropertyVideosSlider.find( '.slides li' );
+            if ( ( singlePropertyVideosSliderItems.length > 1 ) ) {
+                singlePropertyVideosSlider.flexslider( {
+                    animation    : "slide",
+                    slideshow    : false,
+                    directionNav : true,
+                    controlNav   : false,
+                    start        : function ( slider ) {
+                        slider.resize();
+                        $( '.flexslider .clone' ).children().removeAttr( "data-fancybox" );
+                    },
+                } );
+            } else {
+                singlePropertyVideosSliderItems.css( 'display', 'block' );
+            }
+
+            // Featured Properties slider for Homepage.
+            $( '#rh_section__featured_slider .flexslider' ).flexslider( {
+                animation          : "fade",
+                slideshowSpeed     : 7000,
+                animationSpeed     : 1500,
+                slideshow          : false,
+                directionNav       : true,
+                controlNav         : false,
+                keyboardNav        : true,
+                customDirectionNav : $( ".rh_flexslider__nav a" ),
+                start              : function ( slider ) {
+                    slider.removeClass( 'loading' );
+                    $( '.flexslider .clone' ).children().removeAttr( "data-fancybox" );
+                }
+            } );
+
+
+            // Flex Slider for Detail Page
+            var $sliderItemCurrent = $( ".slider-item-current" );
+            $( '#property-detail-flexslider .flexslider' ).flexslider( {
+                animation    : "fade",
+                slideshow    : false,
+                directionNav : true,
+                controlNav   : false,
+                start        : function ( slider ) {
+                    slider.resize();
+                    slider.removeClass( 'rh_property_load_height' );
+                    $( '.flexslider .clone' ).children().removeAttr( "data-fancybox" );
+                },
+                after        : function ( slider ) {
+                    $sliderItemCurrent.text( slider.currentSlide + 1 );
+
+                },
+
+            } );
+
+            /* Property detail page slider variation two */
+            $( '#property-detail-slider-carousel-nav' ).flexslider( {
+                animation     : "slide",
+                controlNav    : false,
+                animationLoop : false,
+                directionNav  : true,
+                prevText      : "",
+                nextText      : "",
+                slideshow     : false,
+                itemWidth     : 130,
+                itemMargin    : 5,
+                minItems      : 8,
+                maxItems      : 8,
+                asNavFor      : '#property-detail-slider-two'
+            } );
+            $( '#property-detail-slider-two' ).flexslider( {
+                animation     : "fade",
+                controlNav    : false,
+                animationLoop : false,
+                slideshow     : false,
+                directionNav  : true,
+                // smoothHeight: true,
+                prevText : "",
+                nextText : "",
+                sync     : "#property-detail-slider-carousel-nav",
+                start    : function ( slider ) {
+                    slider.removeClass( 'rh_property_load_height' );
+                    $( '.flexslider .clone' ).children().removeAttr( "data-fancybox" );
+                    $( '.thumb-on-bottom .property-head-wrapper' ).css( 'bottom', $( '#property-detail-slider-carousel-nav' ).outerHeight() );
+                },
+
+            } );
+
+            $( window ).on( 'resize', function () {
+                $( '.thumb-on-bottom .property-head-wrapper' ).css( 'bottom', $( '#property-detail-slider-carousel-nav' ).outerHeight() );
+            } );
+
+
+            // Flex Slider for Child Properties on property detail page.
+            $( '#rh_property__child_slider .flexslider' ).flexslider( {
+                animation    : "slide",
+                slideshow    : false,
+                directionNav : true,
+                controlNav   : false,
+                start        : function ( slider ) {
+                    slider.resize();
+                }
+            } );
+
+            // Remove Flex Slider Navigation for Smaller Screens Like IPhone Portrait
+            $( '.slider-wrapper, .listing-slider' ).on( {
+                mouseenter : function () {
+                    var mobile = $( 'body' ).hasClass( 'probably-mobile' );
+                    if ( ! mobile ) {
+                        $( '.flex-direction-nav' ).stop( true, true ).fadeIn( 'slow' );
+                    }
+                },
+                mouseleave : function () {
+                    $( '.flex-direction-nav' ).stop( true, true ).fadeOut( 'slow' );
+                }
+            } );
+
+            // Flex Slider Gallery Post
+            $( '.listing-slider' ).each( function () {
+                $( this ).flexslider( {
+                    animation  : "slide",
+                    slideshow  : false,
+                    controlNav : false,
+                    // directionNav: false,
+                    // customDirectionNav: $(".rh_flexslider__nav_main_gallery .nav-mod"),
+                    customDirectionNav : $( this ).next( '.rh_flexslider__nav_main_gallery' ).find( '.nav-mod' ),
+                    start              : function ( slider ) {
+                        $( '.listing-slider' ).find( '.clone' ).children().removeAttr( "data-fancybox" );
+                    },
+                } );
+            } );
+
+        }
+
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Slick Carousel
+        /*-----------------------------------------------------------------------------------*/
+        if ( jQuery().slick ) {
+
+            $( '.inspiry_property_carousel_style' ).on( 'init', function ( event, slick, direction ) {
+                $( event.currentTarget ).removeClass( 'rh_property_car_height' );
+            } );
+            $( '.inspiry_property_carousel_style:not(.images_2)' ).slick( {
+                infinite       : false,
+                dots           : false,
+                slidesToScroll : 1,
+                vertical       : false,
+                mobileFirst    : true,
+                responsive     : [
+                    {
+                        breakpoint : 1024,
+                        settings   : {
+                            slidesToShow: 3,
+                        }
+                    },
+                    {
+                        breakpoint : 767,
+                        settings   : {
+                            slidesToShow: 2,
+                        }
+                    },
+                    {
+                        breakpoint : 0,
+                        settings   : {
+                            slidesToShow : 2,
+                            vertical: true,
+                        }
+                    }
+                ]
+            } );
+
+            $( '.inspiry_property_carousel_style.images_2' ).slick( {
+                infinite       : false,
+                dots           : false,
+                slidesToScroll : 1,
+                vertical       : false,
+                slidesToShow   : 2,
+                responsive     : [
+                    {
+                        breakpoint : 767,
+                        settings   : {
+                            vertical: true,
+                        }
+                    }
+                ]
+            } );
+
+
+            $( '.property-detail-slider-three' ).slick( {
+                infinite       : false,
+                slidesToShow   : 1,
+                slidesToScroll : 1,
+                arrows         : true,
+                dots           : false,
+                fade           : true,
+                adaptiveHeight : true,
+                asNavFor       : '.property-detail-carousel-three'
+            } );
+            $( '.property-detail-carousel-three' ).slick( {
+                infinite       : false,
+                slidesToScroll : 3,
+                asNavFor       : '.property-detail-slider-three',
+                dots           : false,
+                arrows         : true,
+                centerMode     : false,
+                focusOnSelect  : true,
+                mobileFirst    : true,
+                nextArrow      : '<i class="fas fa-angle-right"></i>',
+                prevArrow      : '<i class="fas fa-angle-left"></i>',
+                responsive     : [
+                    {
+                        breakpoint : 1400,
+                        settings   : {
+                            slidesToShow: 9,
+                        }
+                    },
+                    {
+                        breakpoint : 1200,
+                        settings   : {
+                            slidesToShow: 8,
+                        }
+                    },
+                    {
+                        breakpoint : 1024,
+                        settings   : {
+                            slidesToShow: 7,
+                        }
+                    },
+                    {
+                        breakpoint : 767,
+                        settings   : {
+                            slidesToShow: 6,
+                        }
+                    }
+                ]
+            } );
+
+
+        }
+
+        var sfoiB1 = $( '.rh_open_sfoi_advance' ).outerWidth();
+        var sfoiB2 = $( '.rh_sfoi_search_btn' ).outerWidth();
+
+        if ( sfoiB1 > sfoiB2 ) {
+            $( '.rh_sfoi_search_btn' ).css( 'min-width', sfoiB1 + "px" );
+            $( '.rh_mod_sfoi_wrapper_inner .rh_prop_search__option:nth-of-type(1)' ).css( 'min-width', sfoiB1 + "px" );
+        } else {
+            $( '.rh_open_sfoi_advance' ).css( 'min-width', sfoiB2 + "px" );
+            $( '.rh_mod_sfoi_wrapper_inner .rh_prop_search__option:nth-of-type(1)' ).css( 'min-width', sfoiB2 + "px" );
+
+        }
+
+        $( '.rh_mod_sfoi_advanced_expander' ).on( 'click', function () {
+            $( this ).toggleClass( 'rh_sfoi_is_open' );
+            const topFields = $(".rh_top_sfoi_fields");
+
+            if ( $( this ).hasClass( 'rh_sfoi_is_open' ) ) {
+                topFields.addClass("sfoi-fields-expanded");
+                $( '.rh_mod_sfoi_advance_fields_wrapper' ).stop().slideDown( 500 );
+            } else {
+                $( '.rh_mod_sfoi_advance_fields_wrapper' ).stop().slideUp( 500, function() {
+                    topFields.removeClass("sfoi-fields-expanded");
+                } );
+            }
+        } );
+
+        $( '.rh_sfoi_features .more-option-trigger a' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            $( this ).toggleClass( 'rh_sfoi_feature_open' );
+            if ( $( this ).hasClass( 'rh_sfoi_feature_open' ) ) {
+                $( '.more-options-wrapper' ).stop().slideDown( 500 );
+            } else {
+                $( '.more-options-wrapper' ).stop().slideUp( 500 );
+            }
+        } );
+
+
+        function moveFormToHeader() {
+            var screenWidth = $( window ).width();
+            if ( screenWidth <= 1139 ) {
+                $( '.inspiry_mod_header_variation_three .rh_prop_search_form_header' ).detach().prependTo( ".rh_prop_search" );
+                $( '.inspiry_mod_header_variation_three .rh_prop_search' ).show();
+            } else if ( screenWidth >= 1139 ) {
+                $( '.inspiry_mod_header_variation_three .rh_prop_search_form_header' ).detach().prependTo( ".rh_prop_search_in_header" );
+                $( '.inspiry_mod_header_variation_three .rh_prop_search' ).hide();
+            }
+        }
+
+        moveFormToHeader();
+
+        var isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test( navigator.userAgent ) ? true : false;
+
+        if ( ! isMobile ) {
+            $( window ).on( 'resize', moveFormToHeader );
+        }
+
+
+        function slideElementDisplay() {
+            var getDataTopBar        = $( '#rh_fields_search__wrapper' ).data( 'top-bar' );
+            var slideElementsDisplay = $( '.rh_prop_search__form .rh_prop_search__fields .rh_prop_search__option' );
+
+            var setDataTopBar = 0;
+            if ( window.matchMedia( '(max-width: 767px)' ).matches ) {
+                if ( getDataTopBar == 3 ) {
+                    setDataTopBar = 4;
+                } else {
+                    setDataTopBar = getDataTopBar;
+                }
+            } else if ( window.matchMedia( '(min-width: 768px)' ).matches ) {
+                setDataTopBar = getDataTopBar;
+
+            }
+
+            var slideElements = $( '.rh_prop_search__form .rh_prop_search__fields .rh_prop_search__option:not(.hide-fields):nth-of-type(n+' + ( setDataTopBar + 1 ) + ')' );
+
+            if ( ! slideElements.hasClass( 'show' ) ) {
+                // slideElements.css('max-width','25%');
+                slideElements.addClass( 'show' ).slideDown( 100 ).animate(
+                    { opacity : 1 },
+                    {queue: false, duration: 300}
+                );
+
+            } else {
+                slideElements.removeClass( 'show' ).slideUp( 100 ).animate(
+                    { opacity : 0 },
+                    {queue: false, duration: 100}
+                );
+            }
+        }
+
+        $( '.rh_prop_search__buttons .rh_prop_search__advance_btn' ).on( 'click', function ( e ) {
+
+            e.preventDefault();
+
+            // Toggle search icon.
+            $( this ).find( '#rh_icon__search' ).toggle( '400' );
+
+            // Open advance search fields.
+            $( '#rh_prop_search__dropdown' ).toggleClass( 'rh_prop_search__ddActive' );
+
+
+            var thisParent = $( this ).parents( '.rh_prop_search_init' );
+
+            if ( ! ( thisParent ).hasClass( 'rh_open_form' ) ) {
+                thisParent.addClass( 'rh_open_form' );
+                $( '.rh_form_fat_collapsed_fields_wrapper' ).stop().slideDown( 400 );
+            } else {
+                thisParent.removeClass( 'rh_open_form' );
+                // thisParent.find('.more-options-wrapper-mode').slideUp(200);
+                // thisParent.find('.open_more_features').removeClass('featured-open');
+                $( '.rh_form_fat_collapsed_fields_wrapper' ).stop().slideUp( 400 )
+            }
+
+            // slideElementDisplay();
+
+        } );
+
+        $( '.rh_prop_search__buttons_smart .rh_prop_search__advance_btn' ).on( 'click', function ( e ) {
+            e.preventDefault();
+
+            $( this ).find( '#rh_icon__search' ).toggle( '400' );
+
+            $( this ).toggleClass( 'rh_smart_form_open' );
+
+            if ( $( this ).hasClass( 'rh_smart_form_open' ) ) {
+                $( '.rh_form_smart_collapsed_fields_wrapper' ).stop().slideDown( 400 );
+            } else (
+                    $( '.rh_form_smart_collapsed_fields_wrapper' ).stop().slideUp( 400 )
+                )
+
+        } );
+
+        function topBarFieldsHeight() {
+            if ( $( '.advance-search-form' ).hasClass( 'rh_prop_search__form' ) ) {
+                var getDataTopBar    = $( '#rh_fields_search__wrapper' ).data( 'top-bar' );
+                var topElementsReset = $( '.rh_prop_search__form .rh_prop_search__fields .rh_prop_search__option' );
+
+                var showDataTopBar = 0;
+                if ( window.matchMedia( '(max-width: 767px)' ).matches ) {
+                    if ( getDataTopBar == '3' ) {
+                        showDataTopBar = 4;
+                        topElementsReset.removeClass( 'default-show' );
+                    } else {
+                        showDataTopBar = getDataTopBar;
+                    }
+                } else if ( window.matchMedia( '(min-width: 768px)' ).matches ) {
+                    showDataTopBar = getDataTopBar;
+                    topElementsReset.removeClass( 'default-show' );
+                }
+                var topElements = $( '.rh_prop_search__form .rh_prop_search__fields .rh_prop_search__option:not(.hide-fields):nth-of-type(-n+' + showDataTopBar + ')' );
+                topElements.addClass( 'default-show' );
+                if ( window.matchMedia( '(min-width: 768px)' ).matches ) {
+                    topElements.css({'max-width': (100 / showDataTopBar) + '%', 'width': 100 + '%'});
+                }
+                if ( window.matchMedia( '(max-width: 767px)' ).matches ) {
+                    if ( getDataTopBar == 1 ) {
+                        topElements.css({'max-width': 'none', 'width': '100%'});
+                    } else {
+                        topElements.css({'max-width': 'none', 'width': (100 / 2) + '%'});
+                    }
+                }
+            }
+        }
+
+        $( '.rh_prop_search__selectwrap' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            var search_select = $( this ).find( '.ajax-location-field' );
+            // var search_select = $(this).find('.rh_select2, .ajax-location-field');
+
+            if (e.target.classList[0] === 'select2-selection' || e.target.classList[0] === 'select2-selection__rendered') return;
+
+
+            // search_select.select2("open");
+        } );
+
+        $( '.inspiry_select_picker_trigger,.ajax-location-field' ).each( function () {
+            // $('.rh_select2, .ajax-location-field').each(function () {
+
+            var thisParent = $( this ).parents( '.rh_prop_search__select' );
+
+            var thisCurrentValue = $( this ).children( "option:selected" ).val();
+
+
+            if ( thisCurrentValue !== 'any' && typeof thisCurrentValue !== 'undefined' ) {
+                thisParent.addClass( 'rh_sfoi_field_selected' );
+            } else {
+                thisParent.removeClass( 'rh_sfoi_field_selected' );
+            }
+
+            $( this ).on( 'change', function () {
+                var thisAnyValue = this.value;
+
+
+                if ( thisAnyValue !== 'any' && thisAnyValue.length !== 0 ) {
+
+                    thisParent.addClass( 'rh_sfoi_field_selected' );
+                } else {
+                    thisParent.removeClass( 'rh_sfoi_field_selected' );
+                }
+            } );
+        } );
+
+        $( '.rh_mod_text_field' ).each( function () {
+            var thisParent    = $( this ).not( '.rvr_check_in,.rvr_check_out' );
+            var thisTextField = $( this ).find( 'input' );
+
+            thisTextField.on( "focus", function () {
+                thisParent.addClass( 'rh_mod_text_field_focused' );
+            } );
+
+            thisTextField.on( "blur", function () {
+
+                setTimeout( function () {
+                    if ( ! $( thisTextField ).val() ) {
+                        thisParent.removeClass( 'rh_mod_text_field_focused' );
+                    } else {
+                        thisParent.addClass( 'rh_mod_text_field_focused' );
+                    }
+                }, 100 );
+
+            } );
+        } );
+
+
+        //Open Search Form More Features fields
+        $( '.open_more_features' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            $( this ).toggleClass( 'featured-open' );
+            $( '.more-options-wrapper-mode' ).slideToggle( 200 );
+
+        } );
+
+        $( '.advance-search-form ' ).each( function () {
+            var getDataTopBar = $( this ).find( '.rh_prop_search_data' ).data( 'top-bar' );
+
+            var advanceSearch = $( this ).find( '.rh_search_top_field_common .rh_prop_search__option' );
+
+            var prePendTo = $( this ).find( '.rh_search_fields_prepend_to' );
+
+            var j = 0;
+
+            var i = 0;
+
+            advanceSearch.each( function () {
+                if ( i < getDataTopBar ) {
+                    if ( $( this ).hasClass( 'hide-fields' ) ) {
+                        j = 2;
+                    }
+                }
+                i++;
+            } );
+
+            var advanceElements = getDataTopBar + j + 1;
+
+            if ( advanceElements > 0 ) {
+                var advanceFieldsSmart = $( this ).find( '.rh_search_top_field_common .rh_prop_search__option:nth-of-type(n+' + advanceElements + ')' );
+
+                advanceFieldsSmart.detach().prependTo( prePendTo );
+
+            }
+        } );
+
+
+        var rhSFOIModFields = function () {
+            $( '.rh_sfoi_advance_search_form' ).each( function () {
+                var getDataTopBar = $( this ).find( '.rh_top_sfoi_fields' ).data( 'sfoi-top' );
+
+                var advanceSearch = $( this ).find( '.rh_top_sfoi_fields .rh_prop_search__option' );
+
+                var prePendTo = $( this ).find( '.rh_mod_sfoi_advance_fields' );
+
+                var j = 0;
+
+                var i = 0;
+
+                advanceSearch.each( function () {
+                    if ( i < getDataTopBar ) {
+                        if ( $( this ).hasClass( 'hide-fields' ) ) {
+                            j = 2;
+                        }
+                    }
+                    i++;
+                } );
+
+
+                var advanceElements = getDataTopBar + j + 1;
+
+
+                if ( advanceElements > 0 ) {
+                    var advanceFieldsSmart = $( this ).find( '.rh_top_sfoi_fields .rh_prop_search__option:nth-of-type(n+' + advanceElements + ')' );
+
+                    advanceFieldsSmart.detach().prependTo( prePendTo );
+
+                }
+            } );
+        };
+
+        var removeFadedFields = function () {
+            $( '.rh_mod_sfoi_content' ).removeClass( 'rh_sfoi_faded' );
+        };
+
+        var disableSfoiAdvance = function () {
+            if ( ! $.trim( $( '.rh_mod_sfoi_advance_fields' ).html() ).length ) {
+                $( '.rh_top_sfoi_fields' ).addClass( 'rh_sfoi_hide_advance_fields' );
+            }
+        };
+
+        var SfoiCallbacks = $.Callbacks();
+
+        SfoiCallbacks.add( rhSFOIModFields );
+        SfoiCallbacks.fire( rhSFOIModFields );
+
+        SfoiCallbacks.add( disableSfoiAdvance );
+        SfoiCallbacks.fire( disableSfoiAdvance );
+
+        SfoiCallbacks.add( removeFadedFields );
+        SfoiCallbacks.fire( removeFadedFields );
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Properties Sorting
+        /*-----------------------------------------------------------------------------------*/
+        function insertParam( key, value ) {
+            key   = encodeURI( key );
+            value = encodeURI( value );
+
+            var kvp = document.location.search.substr( 1 ).split( '&' );
+
+            var i = kvp.length;
+            var x;
+            while ( i-- ) {
+                x = kvp[i].split( '=' );
+
+                if ( x[0] == key ) {
+                    x[1]   = value;
+                    kvp[i] = x.join( '=' );
+                    break;
+                }
+            }
+
+            if ( i < 0 ) {
+                kvp[kvp.length] = [key, value].join( '=' );
+            }
+
+            //this will reload the page, it's likely better to store this until finished
+            document.location.search = kvp.join( '&' );
+        }
+
+        $( '#sort-properties' ).on( 'change', function () {
+            var key   = 'sortby';
+            var value = $( this ).val();
+            insertParam( key, value );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Properties Listing Map Height Fix
+        /*-----------------------------------------------------------------------------------*/
+        var fixMapHeight = function () {
+            var height      = ( $( '.rh_page__map_properties' ) ) ? $( '.rh_page__map_properties' ).outerHeight() : false;
+            var screenWidth = $( document ).width();
+            if ( height && ( 1024 < screenWidth ) ) {
+                $( '.rh_page__listing_map' ).css( { 'height' : height } );
+            }
+        };
+
+        /*----------------------------------------------------------------------------------*/
+        /* Contact Form AJAX validation and submission
+        /* Validation Plugin : http://bassistance.de/jquery-plugins/jquery-plugin-validation/
+        /* Form Ajax Plugin : http://www.malsup.com/jquery/form/
+        /*---------------------------------------------------------------------------------- */
+        if ( jQuery().validate && jQuery().ajaxSubmit ) {
+
+            var submitButton     = $( '#submit-button' ),
+                ajaxLoader       = $( '#ajax-loader' ),
+                messageContainer = $( '#message-container' ),
+                errorContainer   = $( "#error-container" );
+
+            var formOptions = {
+                beforeSubmit : function () {
+                    submitButton.attr( 'disabled', 'disabled' );
+                    ajaxLoader.fadeIn( 'fast' );
+                    messageContainer.fadeOut( 'fast' );
+                    errorContainer.fadeOut( 'fast' );
+                },
+                success      : function ( ajax_response, statusText, xhr, $form ) {
+                    var response = $.parseJSON( ajax_response );
+                    ajaxLoader.fadeOut( 'fast' );
+                    submitButton.removeAttr( 'disabled' );
+                    if ( response.success ) {
+                        $form.resetForm();
+                        messageContainer.html( response.message ).fadeIn( 'fast' );
+
+                        setTimeout( function () {
+                            messageContainer.fadeOut( 'slow' )
+                        }, 5000 );
+
+                        // call reset function if it exists
+                        if ( typeof inspiryResetReCAPTCHA == 'function' ) {
+                            inspiryResetReCAPTCHA();
+                        }
+
+                        if ( typeof CFOSData !== 'undefined' ) {
+                            setTimeout( function () {
+                                window.location.replace( CFOSData.redirectPageUrl );
+                            }, 1000 );
+                        }
+
+                        if ( typeof contactFromData !== 'undefined' ) {
+                            setTimeout( function () {
+                                window.location.replace( contactFromData.redirectPageUrl );
+                            }, 1000 );
+                        }
+                    } else {
+                        errorContainer.html( response.message ).fadeIn( 'fast' );
+                    }
+                }
+            };
+
+            // Contact page form
+            $( '#contact-form .contact-form' ).validate( {
+                errorLabelContainer : errorContainer,
+                submitHandler       : function ( form ) {
+                    $( form ).ajaxSubmit( formOptions );
+                }
+            } );
+
+            // Contact Form Over Slider
+            $( '.cfos_contact_form' ).validate( {
+                errorLabelContainer : errorContainer,
+                submitHandler       : function ( form ) {
+                    $( form ).ajaxSubmit( formOptions );
+                }
+            } );
+
+            // Agent single page form
+            $( '#agent-single-form' ).validate( {
+                errorLabelContainer : errorContainer,
+                submitHandler       : function ( form ) {
+                    $( form ).ajaxSubmit( formOptions );
+                }
+            } );
+        }
+
+
+        /**
+         * Handling Schedule A Tour form functionality
+         *
+         * @since 4.0.0
+         * */
+        if ( jQuery().validate && jQuery().ajaxSubmit ) {
+
+            let submitButton     = $( '#schedule-submit' ),
+                ajaxLoader       = $( '#sat-loader' ),
+                messageContainer = $( '#message-container' ),
+                errorContainer   = $( "#error-container" );
+
+            let satFormOptions = {
+                beforeSubmit : function () {
+                    submitButton.attr( 'disabled', 'disabled' );
+                    ajaxLoader.fadeIn( 'fast' );
+                    messageContainer.fadeOut( 'fast' );
+                    errorContainer.fadeOut( 'fast' );
+                },
+                success      : function ( ajax_response, statusText, xhr, $form ) {
+                    let response = $.parseJSON( ajax_response );
+                    ajaxLoader.fadeOut( 'fast' );
+                    submitButton.removeAttr( 'disabled' );
+                    if ( response.success ) {
+                        $form.resetForm();
+                        messageContainer.html( response.message ).fadeIn( 'fast' );
+
+                        setTimeout( function () {
+                            messageContainer.fadeOut( 'slow' )
+                        }, 5000 );
+
+                        // call reset function if it exists
+                        if ( typeof inspiryResetReCAPTCHA == 'function' ) {
+                            inspiryResetReCAPTCHA();
+                        }
+                    } else {
+                        errorContainer.html( response.message ).fadeIn( 'fast' );
+                    }
+                }
+            };
+
+            // Contact page form
+            $( '#schedule-a-tour' ).validate( {
+                errorLabelContainer : errorContainer,
+                submitHandler       : function ( form ) {
+                    $( form ).ajaxSubmit( satFormOptions );
+                }
+            } );
+        }
+
+        // adding date picker to schedule date field
+        let singleProperty = document.querySelector( '.single-property' );
+        if ( singleProperty ) {
+            let satForm = document.getElementById( 'schedule-a-tour' );
+            if ( satForm ) {
+                $( "#sat-date" ).datepicker( {
+                    minDate  : 0,
+                    showAnim : 'slideDown',
+                    beforeShow: function(input, inst) {
+                        inst.dpDiv[0].classList.add('schedule-calendar-wrapper')
+                    }
+                } );
+            }
+        }
+
+
+        /*-----------------------------------------------------------------*/
+        /* Property Floor Plans
+        /*-----------------------------------------------------------------*/
+        $( '.floor-plans-accordions .floor-plan:first-child' ).addClass( 'current' )
+        .children( '.floor-plan-content' ).css( 'display', 'block' ).end()
+        .find( 'i.fas' ).removeClass( 'fa-plus' ).addClass( 'fa-minus' );
+
+        $( '.floor-plan-title' ).on( 'click', function () {
+            var parent_accordion = $( this ).closest( '.floor-plan' );
+            if ( parent_accordion.hasClass( 'current' ) ) {
+                $( this ).find( 'i.fas' ).removeClass( 'fa-minus' ).addClass( 'fa-plus' );
+                parent_accordion.removeClass( 'current' ).children( '.floor-plan-content' ).stop().slideUp( 300 );
+            } else {
+                $( this ).find( 'i.fas' ).removeClass( 'fa-plus' ).addClass( 'fa-minus' );
+                parent_accordion.addClass( 'current' ).children( '.floor-plan-content' ).stop().slideDown( 300 );
+            }
+            var siblings = parent_accordion.siblings( '.floor-plan' );
+            siblings.find( 'i.fas' ).removeClass( 'fa-minus' ).addClass( 'fa-plus' );
+            siblings.removeClass( 'current' ).children( '.floor-plan-content' ).stop().slideUp( 300 );
+        } );
+
+
+        /**
+         * forEach implementation for Objects/NodeLists/Arrays, automatic type loops and context options
+         *
+         * @private
+         * @author Todd Motto
+         * @link https://github.com/toddmotto/foreach
+         * @param {Array|Object|NodeList} collection - Collection of items to iterate, could be an Array, Object or NodeList
+         * @callback requestCallback      callback   - Callback function for each iteration.
+         * @param {Array|Object|NodeList} scope=null - Object/NodeList/Array that forEach is iterating over, to use as the this value when executing callback.
+         * @returns {}
+         */
+        var forEach = function ( t, o, r ) {
+            if ("[object Object]" === Object.prototype.toString.call(t)) for (var c in t) Object.prototype.hasOwnProperty.call(t, c) && o.call(r, t[c], c, t); else for (var e = 0, l = t.length; l > e; e++) o.call(r, t[e], e, t)
+        };
+
+        var hamburgers = document.querySelectorAll( ".hamburger" );
+        if ( hamburgers.length > 0 ) {
+            forEach( hamburgers, function ( hamburger ) {
+                hamburger.addEventListener( "click", function () {
+                    this.classList.toggle( "is-active" );
+                }, false );
+            } );
+        }
+
+        /* ---------------------------------------------------- */
+        /*  Close Hamburger Menu on modern when click outside
+        /* ---------------------------------------------------- */
+        $( document ).on( 'mouseup', function ( e ) {
+            var container = $( ".main-menu" );
+
+            var innerContainer = container.find( 'ul.rh_menu__responsive' );
+
+            // If the target of the click isn't the container
+
+            if ( ! container.is( e.target ) && container.has( e.target ).length === 0 ) {
+                if ( innerContainer.hasClass( 'rh_menu__responsive_show' ) ) {
+                    innerContainer.removeClass( 'rh_menu__responsive_show' );
+                }
+                if ( $( hamburgers ).hasClass( 'is-active' ) ) {
+                    $( hamburgers ).removeClass( "is-active" );
+                }
+            }
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Hide the note
+        /*-----------------------------------------------------------------------------------*/
+        $( '.icon-remove' ).on( 'click', function ( e ) {
+            e.preventDefault();
+            $( this ).parent().fadeOut( 200 );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Homepage - CTA Buttons Width
+         /*-----------------------------------------------------------------------------------*/
+        if ( $( '.rh_cta__btns .rh_btn--blackBG' ).length > 0 || $( '.rh_cta__btns .rh_btn--whiteBG' ).length > 0 ) {
+            var w1 = $( '.rh_cta__btns .rh_btn--blackBG' ).outerWidth();
+            var w2 = $( '.rh_cta__btns .rh_btn--whiteBG' ).outerWidth();
+
+            if ( w1 > w2 ) {
+                $( '.rh_cta__btns .rh_btn--whiteBG' ).css( 'width', w1 + "px" );
+            } else {
+                $( '.rh_cta__btns .rh_btn--blackBG' ).css( 'width', w2 + "px" );
+            }
+        }
+        if ( $( '.rh_cta__btns .rh_btn--secondary' ).length > 0 || $( '.rh_cta__btns .rh_btn--greyBG' ).length > 0 ) {
+            var w1 = $( '.rh_cta__btns .rh_btn--secondary' ).outerWidth();
+            var w2 = $( '.rh_cta__btns .rh_btn--greyBG' ).outerWidth();
+
+            if ( w1 > w2 ) {
+                $( '.rh_cta__btns .rh_btn--greyBG' ).css( 'width', w1 + "px" );
+            } else {
+                $( '.rh_cta__btns .rh_btn--secondary' ).css( 'width', w2 + "px" );
+            }
+        }
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Optima Express IDX Support
+        /*-----------------------------------------------------------------------------------*/
+        $( '.ihf-grid-result-mlsnum-proptype' ).parent().parent().find( '.col-xs-9' ).toggleClass( 'col-xs-12' );
+        $( '#ihf-main-container .ihf-detail-back-to-results a' ).html( '<span class="fas fa-angle-left"></span><span class="rh_back-link"> Back to Results</span>' );
+        $( "#ihf-refine-search-button" ).on( 'click', function () {
+            $( "#ihf-refine-search .dropdown-menu" ).fadeToggle();
+            $( "#ihf-sort-values" ).fadeOut();
+        } );
+        $( "#ihf-sort-values" ).parent().on( 'click', function () {
+            $( "#ihf-sort-values" ).fadeToggle();
+            $( "#ihf-refine-search .dropdown-menu" ).fadeOut();
+        } );
+        $( "#ihf-main-container" ).on( 'mouseleave', function () {
+            $( "#ihf-sort-values" ).fadeOut();
+            $( "#ihf-refine-search .dropdown-menu" ).fadeOut();
+        } );
+
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Post Nav Support
+        /*-----------------------------------------------------------------------------------*/
+        $( function () {
+            var post_nav = $( '.inspiry-post-nav' );
+            $( window ).on( 'scroll', function () {
+                if ( $( window ).width() > 980 ) {
+                    if ( $( this ).scrollTop() > 650 ) {
+                        post_nav.fadeIn( 'fast' );
+                        return;
+                    }
+                }
+                post_nav.fadeOut( 'fast' );
+            } );
+        } );
+
+        /*-----------------------------------------------------------------------------------*/
+        /*  Property Ratings
+        /*-----------------------------------------------------------------------------------*/
+        if ( jQuery().barrating ) {
+            $( '#rate-it' ).barrating( {
+                theme         : 'fontawesome-stars',
+                initialRating: 5,
+            } );
+        }
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Home page properties pagination
+        /*-----------------------------------------------------------------------------------*/
+        var homePropertiesSection = $( '#home-properties-section' );
+
+        // if homepage
+        if ( homePropertiesSection.length && homePropertiesSection.hasClass( 'ajax-pagination' ) ) {
+
+            $( document ).on( 'click', '#home-properties-section .pagination > a', function ( e ) {
+                e.preventDefault();
+                var homePropertiesContainer = $( '#home-properties-section-wrapper', homePropertiesSection );
+                var paginationLinks         = $( '.pagination > a', homePropertiesSection );
+                var svgLoader               = $( '.svg-loader', homePropertiesSection );
+                var currentButton           = $( this );
+                svgLoader.slideDown( 'fast' );
+                homePropertiesContainer.fadeTo( 'slow', 0.5 );
+                paginationLinks.removeClass( 'current' );
+                currentButton.addClass( 'current' );
+                homePropertiesContainer.load(
+                    currentButton.attr( 'href' ) + ' ' + '#home-properties-section-inner',
+                    function ( response, status, xhr ) {
+                        if ( status == 'success' ) {
+                            homePropertiesContainer.fadeTo( 100, 1, function () {
+                            } );
+                            svgLoader.slideUp( 'fast' );
+
+                            $( 'html, body' ).animate( {
+                                scrollTop : homePropertiesSection.find( '.rh_section__properties' ).offset().top - 32
+                            }, 1000 );
+
+                        } else {
+                            homePropertiesContainer.fadeTo( 'slow', 1 );
+                        }
+                    }
+                );
+            } );
+        }
+
+        /*-----------------------------------------------------------------------------------*/
+        /* AJAX Pagination for Listing & Archive Pages
+        /*-----------------------------------------------------------------------------------*/
+        const propertiesSection = $( '#properties-listing' );
+
+        if ( propertiesSection.length && propertiesSection.hasClass( 'ajax-pagination' ) ) {
+            const propertiesContainer = $( '.rh_page__listing', propertiesSection );
+            const svgLoader           = $( '.svg-loader', propertiesSection );
+            const statsContainer      = $( '.rh_pagination__stats' );
+            const paginationContainer = $( '.rh_pagination' );
+            const mapServiceType      = localized.mapService.toString();
+            const page_id             = statsContainer.data( 'page-id' );
+            $( document ).on( 'click', '#properties-listing .rh_pagination > a', function ( e ) {
+                e.preventDefault();
+                const paginationLinks = $( '.rh_pagination > a', propertiesSection );
+                let currentButton     = $( this );
+                svgLoader.slideDown( 'fast' );
+                propertiesContainer.fadeTo( 'slow', 0.5 );
+                let current_page = parseInt( currentButton.attr( 'data-page-number' ) );
+                statsContainer.attr( 'data-page', current_page );
+                paginationContainer.load( currentButton.attr( 'href' ) + ' ' + '.rh_pagination > *' );
+                statsContainer.load( currentButton.attr( 'href' ) + ' ' + '.rh_pagination__stats > *' );
+                propertiesContainer.load(
+                    currentButton.attr( 'href' ) + ' ' + '.rh_page__listing > *',
+                    function ( response, status, xhr ) {
+                        if ( status == 'success' ) {
+                            propertiesContainer.fadeTo( 100, 1, function () {
+                                paginationLinks.removeClass( 'current' );
+                                currentButton.addClass( 'current' );
+                            } );
+                            svgLoader.slideUp( 'fast' );
+
+                            $( 'html, body' ).animate( {
+                                scrollTop : propertiesSection.find( '.rh_page__listing' ).offset().top - 100
+                            }, 1000 );
+
+                        } else {
+                            propertiesContainer.fadeTo( 'slow', 1 );
+                        }
+                        if ( typeof realhomesInfoboxPopupTrigger === 'function' ) {
+                            realhomesInfoboxPopupTrigger();
+                        }
+
+                        // Binding Favorites & Compare Properties Features
+                        if ( typeof realhomes_update_favorites === 'function' ) {
+                            realhomes_update_favorites();
+                        }
+                        if ( typeof realhomes_update_compare_properties === 'function' ) {
+                            realhomes_update_compare_properties();
+                        }
+                    }
+                );
+                // If this pagination is for ajax search results
+                if ( propertiesSection.hasClass( 'realhomes_ajax_search' ) ) {
+                    realhomes_update_ajax_map_results( current_page );
+                    let currentQueryStrings = statsContainer.data( 'query-strings' );
+                    let searchURL           = $( '.rh_page' ).data( 'search-url' );
+                    if ( current_page === 1 ) {
+                        window.history.pushState( {}, '', searchURL + currentQueryStrings );
+                    } else {
+                        window.history.pushState( {}, '', searchURL + 'page/' + current_page + '/' + currentQueryStrings );
+                    }
+                } else if ( typeof $( '.rh_page' ).data( 'search-url' ) != 'undefined' ) {
+                    $.ajax( {
+                        url     : ajaxurl,
+                        type    : 'post',
+                        data    : {
+                            action  : 'realhomes_map_ajax_search_results',
+                            page_id : page_id,
+                            page    : current_page
+                        },
+                        success : ( response ) => {
+                            let propertiesMapData = response.data.propertiesData;
+                            if ( typeof realhomes_update_open_street_map !== 'undefined' && typeof mapServiceType !== "undefined" && mapServiceType === 'openstreetmaps' ) {
+                                realhomes_update_open_street_map( propertiesMapData );
+                            } else if ( typeof realhomes_update_mapbox !== 'undefined' && typeof mapServiceType !== "undefined" && mapServiceType === 'mapbox' ) {
+                                $( '#map-head' ).empty().append( '<div id="listing-map"></div>' );
+                                realhomes_update_mapbox( propertiesMapData );
+                            } else if ( typeof realhomes_update_google_map !== 'undefined' ) {
+                                realhomes_update_google_map( propertiesMapData );
+                            }
+                        }
+                    } );
+                    window.history.pushState( {}, '', currentButton.attr( 'href' ) );
+                }
+                window.history.pushState( {}, '', currentButton.attr( 'href' ) );
+            } );
+        }
+
+        // Add equal heights to all the rows of all the columns
+        var rowHeight   = -1;
+
+        $( '.rh-compare-properties-row .rh-compare-properties-column p' ).each( function () {
+            rowHeight = rowHeight > $( this ).outerHeight() ? rowHeight : $( this ).outerHeight();
+        } );
+
+        $( '.rh-compare-properties-row .rh-compare-properties-column > p' ).css( {
+            height : rowHeight
+        } );
+
+        /*-------------------------------------------------------*/
+        /*  Isotope
+        /*------------------------------------------------------*/
+        if ( $.isFunction( $.fn.isotope ) ) {
+            const container      = $( '.isotope' ),
+                  filterLinks    = $( '#filter-by a' ),
+                  isotopeOptions = {
+                      filter          : "*",
+                      layoutMode      : 'fitRows',
+                      itemSelector    : '.isotope-item',
+                      animationEngine : 'best-available'
+                  };
+
+            // RTL support
+            if ( $( 'body' ).hasClass( 'rtl' ) ) {
+                isotopeOptions.originLeft = false;
+            }
+
+            /* to fix floating bugs due to variation in height */
+            setTimeout( function () {
+                container.isotope( isotopeOptions );
+            }, 1000 );
+
+            filterLinks.on( 'click', function ( e ) {
+                let selector = $( this ).data( 'filter' );
+                container.isotope( { filter : '.' + selector } );
+                filterLinks.removeClass( 'active' );
+                $( '#filter-by li' ).removeClass( 'current-cat' );
+                $( this ).addClass( 'active' );
+                e.preventDefault();
+            } );
+        }
+
+        // Scroll effect
+        function isInViewport( node ) {
+            var rect = node.getBoundingClientRect()
+            return (
+                ( rect.height > 0 || rect.width > 0 ) &&
+                rect.bottom >= 0 &&
+                rect.right >= 0 &&
+                rect.top <= ( window.innerHeight || document.documentElement.clientHeight ) &&
+                rect.left <= ( window.innerWidth || document.documentElement.clientWidth )
+            )
+        }
+
+        function scrollParallax( selector ) {
+            var scrolled = $( window ).scrollTop();
+            $( selector ).each( function ( index, element ) {
+                var initY  = $( this ).offset().top;
+                var height = $( this ).height();
+                var endY   = initY + $( this ).height();
+
+                // Check if the element is in the viewport.
+                var visible = isInViewport( this );
+                if ( visible ) {
+                    var diff  = -scrolled + initY;
+                    var ratio = Math.round( ( diff / height ) * 100 );
+                    $( this ).css( 'background-position', 'center ' + parseInt( -( ratio ) ) + 'px' )
+                }
+
+            } )
+        }
+
+        function parallaxBanner( selector, unit, speed ) {
+            var docHeight = $( document ).height();
+            var scrolled  = $( window ).scrollTop();
+
+            var parallaxSpeed = ( 0 + ( speed * ( scrolled / docHeight ) ) );
+
+            $( selector ).css( 'background-position', 'center ' + parallaxSpeed + unit );
+        }
+
+        function parallaxBannerReverse( selector, unit, speed ) {
+            var docHeight = $( document ).height();
+            var scrolled  = $( window ).scrollTop();
+
+            var parallaxSpeed = ( 0 - ( speed * ( scrolled / docHeight ) ) );
+
+            $( selector ).css( 'background-position', 'center ' + parallaxSpeed + unit );
+        }
+
+        $( window ).on( 'scroll', function () {
+            // scrollParallax('.rh_mod_parallax_sfoi');
+            scrollParallax( '.rh_parallax_cta' );
+            scrollParallax( '.rh_parallax' );
+            parallaxBanner( '#rh-banner-attachment-parallax', '%', 150 );
+            parallaxBannerReverse( '.rh_mod_parallax_sfoi', '%', 300 );
+        } );
+
+        // Mobile device user nav menu position
+        function userNavPosition( selector ) {
+            if ( window.matchMedia( '(max-width: 767px)' ).matches ) {
+                var getHeaderHeight = $( '.rh_header__wrap' ).height();
+                var getBarHeight    = $( '.rh_menu__user' ).height();
+                var getTopHeight    = getHeaderHeight - getBarHeight;
+                $( selector ).css( 'top', getTopHeight / 2 + 'px' );
+            } else {
+                $( selector ).css( 'top', 'auto' );
+            }
+        }
+
+        userNavPosition( '.rh_header_advance .user_menu_wrapper' );
+        userNavPosition( '.rh_header_advance .rh_menu .main-menu' );
+
+        $( window ).on( 'resize', function () {
+            userNavPosition( '.rh_header_advance .user_menu_wrapper' );
+            userNavPosition( '.rh_header_advance .rh_menu .main-menu' );
+        } );
+
+        // Function to add Whatsapp sharing
+        function decorateWhatsAppLink() {
+            //set up the url
+            var url = 'https://api.whatsapp.com/send?text=';
+
+            var thisShareData = $( '.share-this' );
+
+            //get property title
+            var name = thisShareData.data( 'property-name' );
+
+            //get property permalink
+            var permalink = thisShareData.data( 'property-permalink' );
+
+            //encode the text
+            var encodedText = encodeURIComponent( name + ' ' + permalink );
+
+            //find the link
+            var whatsApp = $( ".inspiry_whats_app_share_link" );
+            //set the href attribute on the link
+            whatsApp.attr( 'href', url + encodedText );
+        }
+
+        decorateWhatsAppLink();
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Geolocation Field Places AutoComplete
+        /*-----------------------------------------------------------------------------------*/
+        if ( typeof google !== undefined ) {
+            let input = document.getElementById( 'geolocation-address' );
+            if ( input ) {
+                function initAutocomplete() {
+                    const locationFieldsWrap = $( '#location-fields-wrap' );
+                    let autocomplete         = new google.maps.places.Autocomplete( input );
+
+                    // Set the data fields to return when the user selects a place.
+                    autocomplete.setFields( ['address_components', 'geometry', 'icon', 'name'] );
+
+                    // Handle place selection
+                    autocomplete.addListener( 'place_changed', function () {
+                        const place = autocomplete.getPlace();
+                        locationFieldsWrap.find( '.location-field-lat' ).val( place.geometry.location.lat() );
+                        locationFieldsWrap.find( '.location-field-lng' ).val( place.geometry.location.lng() );
+                    } );
+                }
+
+                initAutocomplete();
+            }
+        }
+
+        /*-----------------------------------------------------------------------------------*/
+        /* Geolocation Radius Slider for Properties Search Form
+        /*-----------------------------------------------------------------------------------*/
+        const geolocationRadiusWrapper = $( '#geolocation-radius-slider-wrapper' );
+        if ( geolocationRadiusWrapper.length ) {
+            const geolocationRadiusSlider = geolocationRadiusWrapper.find( '#geolocation-radius-slider' );
+            geolocationRadiusSlider.slider( {
+                range : 'max',
+                value : geolocationRadiusSlider.data( 'value' ),
+                min   : geolocationRadiusSlider.data( 'min-value' ),
+                max   : geolocationRadiusSlider.data( 'max-value' ),
+                slide : function ( event, ui ) {
+                    geolocationRadiusWrapper.find( 'strong' ).text( ui.value + ' ' + geolocationRadiusSlider.data( 'unit' ) );
+                    geolocationRadiusWrapper.find( '#rh-geolocation-radius' ).val( ui.value );
+                }
+            } );
+        }
+
+        // Fullscreen search overlay toggle
+        $( '.rh-search-toggle' ).on( 'click', function () {
+            $( '#rh-search-overlay' ).addClass( 'is-active' );
+        } );
+
+        $( document ).on( 'click', '.rh-search-close', function () {
+            $( '#rh-search-overlay' ).removeClass( 'is-active' );
+        } );
+
+        $( document ).on( 'keyup', function ( e ) {
+            if ( e.key === 'Escape' ) {
+                $( '#rh-search-overlay' ).removeClass( 'is-active' );
+            }
+        } );
+
+    } );
+} )( jQuery );

--- a/realhomes/realhomes/assets/ultra/partials/header/submit-property.php
+++ b/realhomes/realhomes/assets/ultra/partials/header/submit-property.php
@@ -1,0 +1,33 @@
+<?php
+$show_submit_button = get_option( 'inspiry_show_submit_on_login', 'false' );
+$submit_url         = '';
+
+if ( is_user_logged_in() || inspiry_guest_submission_enabled() ) {
+	$login_required = '';
+} else {
+	$login_required = ' inspiry_submit_login_required ';
+}
+
+if ( realhomes_get_dashboard_page_url() && realhomes_dashboard_module_enabled( 'inspiry_submit_property_module_display' ) ) {
+	$submit_url = realhomes_get_dashboard_page_url( 'properties&submodule=submit-property' );
+}
+
+if ( ! empty( $submit_url ) && ( 'hide' !== $show_submit_button ) ) {
+
+	if ( inspiry_no_membership_disable_stuff() ) {
+
+		$theme_submit_button_text = get_option( 'theme_submit_button_text' );
+		if ( empty( $theme_submit_button_text ) ) {
+			$theme_submit_button_text = esc_html__( 'Submit', RH_TEXT_DOMAIN );
+		}
+
+$submit_link_format = '<div class="rh-ultra-submit"><a class="%s" href="%s">%s</a><button aria-label="Buscar" class="Header-module--link--3rH8w Header-module--searchLink--ku0tv rh-search-toggle"><svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="Header-module--iconSearchDesktop--29aB_"><path fill-rule="evenodd" clip-rule="evenodd" d="M17 10.5a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0zm-1.562 5.645a7.5 7.5 0 11.707-.707l5.209 5.208-.708.708-5.208-5.209z" fill="currentColor"></path></svg></button></div>';
+		if ( 'true' === $show_submit_button ) {
+			if ( realhomes_get_current_user_role_option( 'property_submit' ) || inspiry_guest_submission_enabled() ) {
+				printf( $submit_link_format, esc_attr( $login_required ), esc_url( $submit_url ), esc_html( $theme_submit_button_text ) );
+			}
+		} else {
+			printf( $submit_link_format, esc_attr( $login_required ), esc_url( $submit_url ), esc_html( $theme_submit_button_text ) );
+		}
+	}
+}

--- a/realhomes/realhomes/functions.php
+++ b/realhomes/realhomes/functions.php
@@ -1,0 +1,1514 @@
+<?php
+/**
+ * The current version of the theme.
+ *
+ * @package realhomes
+ */
+update_option( 'inspiry_realhomes_registered', 'yes' );
+// Framework Path.
+define( 'INSPIRY_FRAMEWORK', get_template_directory() . '/framework/' );
+
+// Text domain for the theme.
+define( 'RH_TEXT_DOMAIN', 'framework' );
+
+// Default Design Variation
+if ( ! defined( 'REALHOMES_DESIGN_VARIATION' ) ) {
+
+	// Define the latest default design variation of Realhomes theme.
+	define( 'REALHOMES_DESIGN_VARIATION', 'ultra' );
+
+	/**
+	 * Verify whether the user has saved their preference for the Classic, Modern or Ultra design; if not,
+	 * set the latest design as the default.
+	 */
+	if ( ! in_array( get_option( 'inspiry_design_variation' ), array( 'classic', 'modern', 'ultra' ) ) ) {
+		update_option( 'inspiry_design_variation', REALHOMES_DESIGN_VARIATION );
+	}
+}
+
+// Design Variation
+if ( ! defined( 'INSPIRY_DESIGN_VARIATION' ) ) {
+	define( 'INSPIRY_DESIGN_VARIATION', get_option( 'inspiry_design_variation', REALHOMES_DESIGN_VARIATION ) );
+}
+
+// Theme assets.
+if ( ! defined( 'INSPIRY_THEME_ASSETS' ) ) {
+	define( 'INSPIRY_THEME_ASSETS', '/assets/' . INSPIRY_DESIGN_VARIATION );
+}
+
+// Theme directory.
+if ( ! defined( 'INSPIRY_THEME_DIR' ) ) {
+	define( 'INSPIRY_THEME_DIR', get_template_directory() . INSPIRY_THEME_ASSETS );
+}
+
+// Theme directory URI.
+if ( ! defined( 'INSPIRY_DIR_URI' ) ) {
+	define( 'INSPIRY_DIR_URI', get_template_directory_uri() . INSPIRY_THEME_ASSETS );
+}
+
+// Theme common directory.
+if ( ! defined( 'INSPIRY_COMMON_DIR' ) ) {
+	define( 'INSPIRY_COMMON_DIR', get_template_directory() . '/common/' );
+}
+
+// Theme common directory URI.
+if ( ! defined( 'INSPIRY_COMMON_URI' ) ) {
+	define( 'INSPIRY_COMMON_URI', get_template_directory_uri() . '/common/' );
+}
+
+/**
+ * Disable the auto registration of the RH_TEXT_DOMAIN text domain and load the theme framework.
+ */
+realhomes_disable_textdomain_autoregistration();
+require_once INSPIRY_FRAMEWORK . '/load.php';
+
+/**
+ * Disable the auto registration of the RH_TEXT_DOMAIN text domain.
+ *
+ * @since 4.4.0
+ */
+function realhomes_disable_textdomain_autoregistration() {
+	if ( isset( $GLOBALS['wp_textdomain_registry'] ) ) {
+		try {
+			$registry   = $GLOBALS['wp_textdomain_registry'];
+			$reflection = new ReflectionClass( $registry );
+			if ( $reflection->hasProperty( 'custom_paths' ) ) {
+				$prop = $reflection->getProperty( 'custom_paths' );
+				$prop->setAccessible( true );
+				$custom_paths = $prop->getValue( $registry );
+				if ( isset( $custom_paths[ RH_TEXT_DOMAIN ] ) ) {
+					unset( $custom_paths[ RH_TEXT_DOMAIN ] );
+					$prop->setValue( $registry, $custom_paths );
+				}
+				$prop->setAccessible( false );
+			}
+		} catch ( Exception $e ) {
+			// Optional: log or fail silently
+			error_log( 'Textdomain registry reflection error: ' . $e->getMessage() );
+		}
+	}
+}
+
+if ( ! function_exists( 'inspiry_theme_setup' ) ) {
+	/**
+	 * 1. Load text domain
+	 * 2. Add custom background support
+	 * 3. Add automatic feed links support
+	 * 4. Add specific post formats support
+	 * 5. Add custom menu support and register a custom menu
+	 * 6. Register required image sizes
+	 * 7. Add title tag support
+	 */
+	function inspiry_theme_setup() {
+
+		/**
+		 * Load text domain for translation purposes
+		 */
+		$languages_dir = get_template_directory() . '/languages';
+		load_theme_textdomain( RH_TEXT_DOMAIN, $languages_dir );
+
+		// Set the default content width.
+		$GLOBALS['content_width'] = 828;
+
+		/**
+		 * Add Theme Support - Custom background
+		 */
+		add_theme_support( 'custom-background' );
+
+		/**
+		 * Add Automatic Feed Links Support
+		 */
+		add_theme_support( 'automatic-feed-links' );
+
+		/**
+		 * Add Post Formats Support
+		 */
+		add_theme_support( 'post-formats', array( 'image', 'video', 'gallery' ) );
+
+		/**
+		 * Register custom menus
+		 */
+		$nav_menus = array(
+			'main-menu'       => esc_html__( 'Main Menu', RH_TEXT_DOMAIN ),
+			'responsive-menu' => esc_html__( 'Responsive Menu', RH_TEXT_DOMAIN ),
+		);
+		register_nav_menus( apply_filters( 'inspiry_nav_menus', $nav_menus ) );
+
+		/**
+		 * Add Post Thumbnails Support and Related Image Sizes
+		 */
+		add_theme_support( 'post-thumbnails' );
+		set_post_thumbnail_size( 150, 150 );                                               // Default Post Thumbnail dimensions.
+		add_image_size( 'modern-property-child-slider', 680, 510, true );       // Moved to common for Dashboard needs. For Gallery, Child Property, Property Card, Property Grid Card, Similar Property.
+		add_image_size( 'property-thumb-image', 488, 326, true );               // For Home page posts thumbnails/Featured Properties carousels thumb.
+		add_image_size( 'property-detail-video-image', 818, 417, true );        // For Property detail page video image.
+		add_image_size( 'agent-image', 210, 210, true );                        // For Agent Picture.
+		add_image_size( 'partners-logo', 600, 9999, true );                     // For partner carousel logos
+
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION || 'ultra' === INSPIRY_DESIGN_VARIATION ) {
+			/**
+			 * Modern Design Image Sizes
+			 */
+			add_image_size( 'post-featured-image', 1240, 720, true );               // For Blog featured image.
+		} else if ( 'classic' === INSPIRY_DESIGN_VARIATION ) {
+			/**
+			 * Classic Design Image Sizes
+			 */
+			add_image_size( 'gallery-two-column-image', 536, 269, true );           // For Gallery Two Column property Thumbnails.
+			add_image_size( 'property-detail-slider-image-two', 1170, 648, true );  // For Property detail page slider image.
+			add_image_size( 'property-detail-slider-thumb', 82, 60, true );         // For Property detail page slider thumb.
+		}
+
+		add_theme_support( 'title-tag' );
+
+		if ( realhomes_is_woocommerce_activated() ) {
+			/**
+			 * Registers support for various WooCommerce features.
+			 *
+			 * @since  3.13.0
+			 */
+			add_theme_support( 'woocommerce' );
+			add_theme_support( 'wc-product-gallery-zoom' );
+			add_theme_support( 'wc-product-gallery-lightbox' );
+			add_theme_support( 'wc-product-gallery-slider' );
+
+			/**
+			 * Add 'realhomes_woocommerce_setup' action.
+			 *
+			 * @since  3.13.0
+			 */
+			do_action( 'realhomes_woocommerce_setup' );
+		}
+
+		/**
+		 * Add theme support for selective refresh
+		 * of widgets in customizer.
+		 */
+		add_theme_support( 'customize-selective-refresh-widgets' );
+
+		// Add support for Block Styles.
+		add_theme_support( 'wp-block-styles' );
+
+		// Add support for full and wide align images.
+		add_theme_support( 'align-wide' );
+
+		// Add support for editor styles.
+		add_theme_support( 'editor-styles' );
+
+		if ( class_exists( 'Header_Footer_Elementor' ) ) {
+			add_theme_support( 'header-footer-elementor' );
+		}
+
+		// Add custom editor font sizes.
+		add_theme_support( 'editor-font-sizes', array(
+			array(
+				'name'      => esc_html__( 'Small', RH_TEXT_DOMAIN ),
+				'shortName' => esc_html__( 'S', RH_TEXT_DOMAIN ),
+				'size'      => 14,
+				'slug'      => 'small',
+			),
+			array(
+				'name'      => esc_html__( 'Normal', RH_TEXT_DOMAIN ),
+				'shortName' => esc_html__( 'M', RH_TEXT_DOMAIN ),
+				'size'      => 16,
+				'slug'      => 'normal',
+			),
+			array(
+				'name'      => esc_html__( 'Large', RH_TEXT_DOMAIN ),
+				'shortName' => esc_html__( 'L', RH_TEXT_DOMAIN ),
+				'size'      => 28,
+				'slug'      => 'large',
+			),
+			array(
+				'name'      => esc_html__( 'Huge', RH_TEXT_DOMAIN ),
+				'shortName' => esc_html__( 'XL', RH_TEXT_DOMAIN ),
+				'size'      => 36,
+				'slug'      => 'huge',
+			),
+		) );
+
+		$editor_color_palette = array(
+			array(
+				'name'  => esc_html__( 'Primary', RH_TEXT_DOMAIN ),
+				'slug'  => 'primary',
+				'color' => '#ec894d',
+			),
+			array(
+				'name'  => esc_html__( 'Orange Dark', RH_TEXT_DOMAIN ),
+				'slug'  => 'orange-dark',
+				'color' => '#dc7d44',
+			),
+			array(
+				'name'  => esc_html__( 'Secondary', RH_TEXT_DOMAIN ),
+				'slug'  => 'secondary',
+				'color' => '#4dc7ec',
+			),
+			array(
+				'name'  => esc_html__( 'Blue Dark', RH_TEXT_DOMAIN ),
+				'slug'  => 'blue-dark',
+				'color' => '#37b3d9',
+			),
+		);
+
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+			$editor_color_palette = array(
+				array(
+					'name'  => esc_html__( 'Primary', RH_TEXT_DOMAIN ),
+					'slug'  => 'primary',
+					'color' => '#ea723d',
+				),
+				array(
+					'name'  => esc_html__( 'Orange Dark', RH_TEXT_DOMAIN ),
+					'slug'  => 'orange-dark',
+					'color' => '#e0652e',
+				),
+				array(
+					'name'  => esc_html__( 'Secondary', RH_TEXT_DOMAIN ),
+					'slug'  => 'secondary',
+					'color' => '#1ea69a',
+				),
+				array(
+					'name'  => esc_html__( 'Green Dark', RH_TEXT_DOMAIN ),
+					'slug'  => 'blue-dark',
+					'color' => '#0b8278',
+				),
+			);
+		} else if ( 'ultra' === INSPIRY_DESIGN_VARIATION ) {
+			$editor_color_palette = array(
+				array(
+					'name'  => esc_html__( 'Primary', RH_TEXT_DOMAIN ),
+					'slug'  => 'primary',
+					'color' => '#1db2ff',
+				),
+				array(
+					'name'  => esc_html__( 'Primary Light', RH_TEXT_DOMAIN ),
+					'slug'  => 'primary-light',
+					'color' => '#e7f6fd',
+				),
+				array(
+					'name'  => esc_html__( 'Primary Dark', RH_TEXT_DOMAIN ),
+					'slug'  => 'primary-dark',
+					'color' => '#dbf0fa',
+				),
+				array(
+					'name'  => esc_html__( 'Secondary', RH_TEXT_DOMAIN ),
+					'slug'  => 'secondary',
+					'color' => '#f58220',
+				),
+			);
+		}
+
+		$editor_color_palette[] = array(
+			'name'  => esc_html__( 'Black', RH_TEXT_DOMAIN ),
+			'slug'  => 'black',
+			'color' => '#394041',
+		);
+
+		$editor_color_palette[] = array(
+			'name'  => esc_html__( 'White', RH_TEXT_DOMAIN ),
+			'slug'  => 'white',
+			'color' => '#fff',
+		);
+
+		// Editor color palette.
+		add_theme_support( 'editor-color-palette', $editor_color_palette );
+
+		// Add support for responsive embedded content.
+		add_theme_support( 'responsive-embeds' );
+
+		// Disables the Widget Block Editor
+		remove_theme_support( 'widgets-block-editor' );
+
+		global $pagenow;
+		if ( is_admin() && 'themes.php' == $pagenow && isset( $_GET['activated'] ) ) {
+			wp_redirect( admin_url( "admin.php?page=realhomes-design" ) );
+		}
+	}
+
+	add_action( 'after_setup_theme', 'inspiry_theme_setup' );
+}
+
+if ( ! function_exists( 'inspiry_content_width' ) ) {
+	/**
+	 * Set the content width in pixels, based on the theme's design and stylesheet.
+	 *
+	 * Priority 0 to make it available to lower priority callbacks.
+	 *
+	 * @global int $content_width
+	 */
+	function inspiry_content_width() {
+
+		$content_width = $GLOBALS['content_width'];
+
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+			if ( is_page_template( 'templates/full-width.php' ) ) {
+				$content_width = 1140;
+			} else if ( is_singular( 'property' ) || is_singular( 'agent' ) || is_singular( 'agency' ) ) {
+				$content_width = 778;
+			} else if ( is_singular( 'post' ) || is_page() ) {
+				$content_width = 738;
+			}
+		} else {
+			if ( is_page_template( 'templates/full-width.php' ) ) {
+				$content_width = 1128;
+			} else if ( is_singular( 'agent' ) || is_singular( 'agency' ) ) {
+				$content_width = 578;
+			} else if ( is_singular( 'post' ) ) {
+				$content_width = 708;
+			}
+		}
+
+		/**
+		 * Filter RealHomes content width of the theme.
+		 *
+		 * @since RealHomes 3.6.1
+		 *
+		 * @param int $content_width Content width in pixels.
+		 *
+		 */
+		$GLOBALS['content_width'] = apply_filters( 'inspiry_content_width', $content_width );
+	}
+
+	add_action( 'template_redirect', 'inspiry_content_width', 0 );
+}
+
+if ( ! function_exists( 'inspiry_add_editor_style' ) ) :
+	/**
+	 * Add editor styles and fonts
+	 */
+	function inspiry_add_editor_style() {
+
+		wp_enqueue_style(
+			'rh-font-awesome',
+			get_theme_file_uri( 'common/font-awesome/css/all.min.css' ),
+			array(),
+			'5.13.1',
+			'all'
+		);
+
+		wp_enqueue_style(
+			'inspiry-google-fonts',
+			inspiry_google_fonts(),
+			array(),
+			INSPIRY_THEME_VERSION
+		);
+
+		wp_enqueue_style(
+			'inspiry-gutenberg-editor-style',
+			get_theme_file_uri( INSPIRY_THEME_ASSETS . '/styles/css/editor-style.css' ),
+			array(),
+			INSPIRY_THEME_VERSION
+		);
+	}
+
+	add_action( 'enqueue_block_editor_assets', 'inspiry_add_editor_style' );
+endif;
+
+if ( ! function_exists( 'inspiry_safe_include_svg' ) ) {
+	/**
+	 * Includes svg file in the theme.
+	 *
+	 * @since 3.10.2
+	 *
+	 * @param string $path
+	 *
+	 * @param string $file
+	 */
+	function inspiry_safe_include_svg( $file, $path = INSPIRY_THEME_ASSETS ) {
+		$file = get_theme_file_path( $path . $file );
+		if ( file_exists( $file ) ) {
+			include( $file );
+		}
+	}
+}
+
+
+
+if ( ! function_exists( 'inspiry_theme_sidebars' ) ) {
+	/**
+	 * Sidebars, Footer and other Widget areas
+	 */
+	function inspiry_theme_sidebars() {
+
+		// Location: Default Sidebar.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Default Sidebar', RH_TEXT_DOMAIN ),
+			'id'            => 'default-sidebar',
+			'description'   => esc_html__( 'Widget area for default sidebar on news and post pages.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Sidebar Pages.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Pages Sidebar', RH_TEXT_DOMAIN ),
+			'id'            => 'default-page-sidebar',
+			'description'   => esc_html__( 'Widget area for default page template sidebar.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Sidebar for contact page.
+		if ( 'classic' === INSPIRY_DESIGN_VARIATION ) {
+			register_sidebar( array(
+				'name'          => esc_html__( 'Contact Sidebar', RH_TEXT_DOMAIN ),
+				'id'            => 'contact-sidebar',
+				'description'   => esc_html__( 'Widget area for contact page sidebar.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+		// Location: Sidebar Property.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Property Sidebar', RH_TEXT_DOMAIN ),
+			'id'            => 'property-sidebar',
+			'description'   => esc_html__( 'Widget area for property detail page sidebar.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Sidebar Properties List.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Properties Pages Sidebar', RH_TEXT_DOMAIN ),
+			'id'            => 'property-listing-sidebar',
+			'description'   => esc_html__( 'Widget area for sidebar in properties list, grid and archive pages.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Footer First Column.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Footer First Column', RH_TEXT_DOMAIN ),
+			'id'            => 'footer-first-column',
+			'description'   => esc_html__( 'Widget area for first column in footer.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Footer Second Column.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Footer Second Column', RH_TEXT_DOMAIN ),
+			'id'            => 'footer-second-column',
+			'description'   => esc_html__( 'Widget area for second column in footer.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Footer Third Column.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Footer Third Column', RH_TEXT_DOMAIN ),
+			'id'            => 'footer-third-column',
+			'description'   => esc_html__( 'Widget area for third column in footer.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		// Location: Footer Fourth Column.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Footer Fourth Column', RH_TEXT_DOMAIN ),
+			'id'            => 'footer-fourth-column',
+			'description'   => esc_html__( 'Widget area for fourth column in footer.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		if ( post_type_exists( 'agent' ) ) {
+			// Location: Sidebar Agent.
+			register_sidebar( array(
+				'name'          => esc_html__( 'Agent Sidebar', RH_TEXT_DOMAIN ),
+				'id'            => 'agent-sidebar',
+				'description'   => esc_html__( 'Sidebar widget area for agent detail page.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+		if ( post_type_exists( 'agency' ) ) {
+			// Location: Sidebar Agency.
+			register_sidebar( array(
+				'name'          => esc_html__( 'Agency Sidebar', RH_TEXT_DOMAIN ),
+				'id'            => 'agency-sidebar',
+				'description'   => esc_html__( 'Sidebar widget area for agency detail page.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+		// Location: Property Search Template.
+		register_sidebar( array(
+			'name'          => esc_html__( 'Property Search Sidebar', RH_TEXT_DOMAIN ),
+			'id'            => 'property-search-sidebar',
+			'description'   => esc_html__( 'Widget area for property search template with sidebar.', RH_TEXT_DOMAIN ),
+			'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h3 class="title">',
+			'after_title'   => '</h3>',
+		) );
+
+		if ( 'classic' !== INSPIRY_DESIGN_VARIATION ) {
+			// Location: Property Search Template.
+			register_sidebar( array(
+				'name'          => esc_html__( '404 Page Widgets', RH_TEXT_DOMAIN ),
+				'id'            => '404-sidebar',
+				'description'   => esc_html__( 'Widget area for 404 template content area.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+		// Create additional sidebar to use with visual composer if needed.
+		if ( class_exists( 'Vc_Manager' ) ) {
+
+			// Additional Sidebars.
+			register_sidebars( 4, array(
+				'name'          => esc_html__( 'Additional Sidebar %d', RH_TEXT_DOMAIN ),
+				'description'   => esc_html__( 'An extra sidebar to use with Visual Composer if needed.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+
+		}
+
+		// Create additional sidebar to use with Optima Express if needed.
+		if ( class_exists( 'iHomefinderAdmin' ) ) {
+
+			// Location: Home Search Area.
+			register_sidebar( array(
+				'name'          => esc_html__( 'Home Search Area', RH_TEXT_DOMAIN ),
+				'id'            => 'home-search-area',
+				'description'   => esc_html__( 'Widget area for only IDX Search Widget. Using this area means you want to display IDX search form instead of default search form.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="home-idx-search" class="clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="home-widget-label">',
+				'after_title'   => '</h3>',
+			) );
+
+			// Additional Sidebars.
+			register_sidebar( array(
+				'name'          => esc_html__( 'Optima Express Sidebar', RH_TEXT_DOMAIN ),
+				'id'            => 'optima-express-page-sidebar',
+				'description'   => esc_html__( 'An extra sidebar to use with Optima Express if needed.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+		// Creates additional sidebar to use with WooCommerce page if needed.
+		if ( realhomes_is_woocommerce_activated() ) {
+
+			// Shop Sidebar.
+			register_sidebar( array(
+				'name'          => esc_html__( 'Shop Sidebar', RH_TEXT_DOMAIN ),
+				'id'            => 'shop-page-sidebar',
+				'description'   => esc_html__( 'An extra sidebar to use with WooCommerce pages if needed.', RH_TEXT_DOMAIN ),
+				'before_widget' => '<section id="%1$s" class="widget clearfix %2$s">',
+				'after_widget'  => '</section>',
+				'before_title'  => '<h3 class="title">',
+				'after_title'   => '</h3>',
+			) );
+		}
+
+	}
+
+	add_action( 'widgets_init', 'inspiry_theme_sidebars' );
+}
+
+if ( ! function_exists( 'inspiry_google_fonts' ) ) {
+	/**
+	 * Google fonts enqueue url
+	 */
+	function inspiry_google_fonts() {
+
+		$font_families = array();
+		$fonts_url     = '';
+		$subsets       = 'latin,latin-ext';
+
+		// Body Font
+		$body_font = get_option( 'inspiry_body_font', 'Default' );
+		if ( 'Default' !== $body_font ) {
+			$font_families[] = $body_font . ':' . Inspiry_Google_Fonts::get_font_weights( $body_font, false, true );
+		} else {
+			// Open Sans is theme's default text font.
+			$font_families[] = 'Open+Sans:400,400i,600,600i,700,700i';
+		}
+
+		// Heading Font
+		$heading_font = get_option( 'inspiry_heading_font', 'Default' );
+		if ( 'Default' !== $heading_font ) {
+			$font_families[] = $heading_font . ':' . Inspiry_Google_Fonts::get_font_weights( $heading_font, false, true );
+		} else {
+			// Lato is theme's default heading font.
+			$font_families[] = 'Lato:400,400i,700,700i';
+		}
+
+		// Secondary Font
+		$secondary_font = get_option( 'inspiry_secondary_font', 'Default' );
+		if ( 'Default' !== $secondary_font ) {
+			$font_families[] = $secondary_font . ':' . Inspiry_Google_Fonts::get_font_weights( $secondary_font, false, true );
+		} else {
+			// Robot is theme's default secondary font.
+			$font_families[] = 'Roboto:400,400i,500,500i,700,700i';
+		}
+
+		/*
+         * This font is used on dashboard membership order completion page and will be included only on dashboard template.
+         *
+         * Translators: If there are characters in your language that are not
+         * supported by Damion, translate this to 'off'. Do not translate into your own language.
+         */
+		if ( 'off' !== _x( 'on', 'Damion font: on or off', RH_TEXT_DOMAIN ) && is_page_template( 'templates/dashboard.php' ) ) {
+			$font_families[] = 'Damion';
+		}
+
+		if ( ( 'modern' === INSPIRY_DESIGN_VARIATION ) || is_page_template( 'templates/dashboard.php' ) ) {
+			/*
+			 * Translators: If there are characters in your language that are not
+			 * supported by Rubik, translate this to 'off'. Do not translate into your own language.
+			 */
+			if ( 'off' !== _x( 'on', 'Rubik font: on or off', RH_TEXT_DOMAIN ) ) {
+				$font_families[] = 'Rubik:400,400i,500,500i,700,700i';
+			}
+		}
+
+		if ( 'ultra' === INSPIRY_DESIGN_VARIATION ) {
+			/*
+	 * Translators: If there are characters in your language that are not
+	 * supported by DM Sans, translate this to 'off'. Do not translate into your own language.
+	 */
+			if ( 'off' !== _x( 'on', 'DM Sans font: on or off', RH_TEXT_DOMAIN ) ) {
+				$font_families[] = 'DM Sans:400,400i,500,500i,700,700i';
+			}
+		}
+
+		if ( ! empty( $font_families ) ) {
+			$query_args = array(
+				'family'  => implode( '|', array_unique( $font_families ) ),
+				'subset'  => urlencode( $subsets ),
+				'display' => urlencode( 'fallback' ),
+			);
+
+			$fonts_url = add_query_arg( $query_args, '//fonts.googleapis.com/css' );
+		}
+
+		return esc_url_raw( $fonts_url );
+	}
+}
+
+if ( ! function_exists( 'inspiry_update_page_templates' ) ) {
+
+	/**
+	 * Function to update page templates.
+	 *
+	 * @since 3.0.0
+	 */
+	function inspiry_update_page_templates() {
+
+		if ( ! is_page_template() ) {
+			return;
+		}
+
+		$page_id = get_queried_object_id();
+		if ( ! empty( $page_id ) ) {
+			$page_template = get_post_meta( $page_id, '_wp_page_template', true );
+		}
+
+		if ( empty( $page_template ) ) {
+			return;
+		}
+
+		$latest_templates = array(
+			// Updated properties list & grid templates
+			'templates/list-layout.php'                     => 'templates/properties.php',
+			'templates/list-layout-full-width.php'          => 'templates/properties.php',
+			'templates/grid-layout.php'                     => 'templates/properties.php',
+			'templates/grid-layout-full-width.php'          => 'templates/properties.php',
+			'templates/half-map-layout.php'                 => 'templates/properties.php',
+			'template-property-listing.php'                 => 'templates/properties.php',
+			'templates/template-property-listing.php'       => 'templates/properties.php',
+			'template-property-grid-listing.php'            => 'templates/properties.php',
+			'templates/template-property-grid-listing.php'  => 'templates/properties.php',
+			'template-map-based-listing.php'                => 'templates/properties.php',
+			'templates/template-map-based-listing.php'      => 'templates/properties.php',
+
+			// Updated Full and Fluid width templates
+			'template-fullwidth.php'                        => '',
+			'templates/template-fullwidth.php'              => '',
+			'templates/full-width.php'                      => '',
+			'templates/fluid-width.php'                     => '',
+
+			// Gallery template
+			'templates/2-columns-gallery.php'               => 'templates/properties-gallery.php',
+			'templates/3-columns-gallery.php'               => 'templates/properties-gallery.php',
+			'templates/4-columns-gallery.php'               => 'templates/properties-gallery.php',
+
+			// Updated agents list template
+			'template-agent-listing.php'                    => 'templates/agents-list.php',
+			'templates/template-agent-listing.php'          => 'templates/agents-list.php',
+
+			// Updated compare properties template
+			'template-compare.php'                          => 'templates/compare-properties.php',
+			'templates/template-compare.php'                => 'templates/compare-properties.php',
+
+			// Updated contact template
+			'template-contact.php'                          => 'templates/contact.php',
+			'templates/template-contact.php'                => 'templates/contact.php',
+
+			// Updated home template
+			'template-home.php'                             => 'templates/home.php',
+			'templates/template-home.php'                   => 'templates/home.php',
+
+			// Updated login template
+			'template-login.php'                            => 'templates/login-register.php',
+			'templates/template-login.php'                  => 'templates/login-register.php',
+
+			// Updated optima express template
+			'template-optima-express.php'                   => 'templates/optima-express.php',
+			'templates/template-optima-express.php'         => 'templates/optima-express.php',
+
+			// Updated search template
+			'template-search.php'                           => 'templates/properties-search.php',
+			'templates/template-search.php'                 => 'templates/properties-search.php',
+			'templates/properties-search-half-map.php'      => 'templates/properties-search.php',
+
+			// Updated search template with right sidebar
+			'templates/properties-search-right-sidebar.php' => 'templates/properties-search.php',
+			'template-search-right-sidebar.php'             => 'templates/properties-search.php',
+			'templates/template-search-right-sidebar.php'   => 'templates/properties-search.php',
+
+			// Updated search template with left sidebar
+			'templates/properties-search-left-sidebar.php'  => 'templates/properties-search.php',
+			'template-search-sidebar.php'                   => 'templates/properties-search.php',
+			'templates/template-search-sidebar.php'         => 'templates/properties-search.php',
+
+			// Updated users list template
+			'template-users-listing.php'                    => 'templates/users-lists.php',
+			'templates/template-users-listing.php'          => 'templates/users-lists.php',
+		);
+
+		if ( ! empty( $page_template ) && array_key_exists( $page_template, $latest_templates ) ) {
+
+			if ( in_array( $page_template, array( 'template-fullwidth.php', 'templates/template-fullwidth.php', 'templates/full-width.php', ) ) ) {
+				update_post_meta( $page_id, 'realhomes_page_layout', 'fullwidth' );
+
+			} else if ( 'templates/fluid-width.php' === $page_template ) {
+				update_post_meta( $page_id, 'realhomes_page_layout', 'fluid_width' );
+
+			} else if ( in_array( $page_template, array( 'templates/list-layout.php', 'templates/list-layout-full-width.php', 'templates/grid-layout.php', 'templates/grid-layout-full-width.php', 'templates/half-map-layout.php' ) ) ) {
+
+				if ( in_array( $page_template, array( 'templates/list-layout.php', 'templates/list-layout-full-width.php', 'templates/half-map-layout.php' ) ) ) {
+					update_post_meta( $page_id, 'realhomes_property_card', 'list' );
+
+					if ( 'templates/half-map-layout.php' === $page_template ) {
+						update_post_meta( $page_id, 'realhomes_property_half_map', '1' );
+
+					} else if ( 'templates/list-layout-full-width.php' === $page_template ) {
+						update_post_meta( $page_id, 'realhomes_page_layout', 'fullwidth' );
+					}
+
+				} else if ( in_array( $page_template, array( 'templates/grid-layout.php', 'templates/grid-layout-full-width.php' ) ) ) {
+					update_post_meta( $page_id, 'realhomes_property_card', 'grid' );
+
+					if ( 'templates/grid-layout-full-width.php' === $page_template ) {
+						update_post_meta( $page_id, 'realhomes_page_layout', 'fullwidth' );
+						update_post_meta( $page_id, 'realhomes_properties_grid_fullwidth_column', '3' );
+					}
+				}
+
+			} else if ( in_array( $page_template, array(
+				'templates/properties-search-half-map.php',
+				'templates/properties-search-right-sidebar.php',
+				'template-search-right-sidebar.php',
+				'templates/template-search-right-sidebar.php',
+				'templates/properties-search-left-sidebar.php',
+				'template-search-sidebar.php',
+				'templates/template-search-sidebar.php'
+			) ) ) {
+
+				if ( in_array( $page_template, array( 'templates/properties-search-right-sidebar.php', 'template-search-right-sidebar.php', 'templates/template-search-right-sidebar.php' ) ) ) {
+					update_post_meta( $page_id, 'realhomes_page_layout', 'sidebar_right' );
+
+				} else if ( in_array( $page_template, array( 'templates/properties-search-left-sidebar.php', 'template-search-sidebar.php', 'templates/template-search-sidebar.php' ) ) ) {
+					update_post_meta( $page_id, 'realhomes_page_layout', 'sidebar_left' );
+
+				} else if ( in_array( $page_template, array( 'templates/properties-search-half-map.php' ) ) ) {
+					update_post_meta( $page_id, 'realhomes_property_half_map', '1' );
+				}
+
+			} else if ( in_array( $page_template, array( 'templates/2-columns-gallery.php', 'templates/3-columns-gallery.php', 'templates/4-columns-gallery.php' ) ) ) {
+				update_post_meta( $page_id, 'realhomes_properties_gallery_column', preg_replace( '/[^0-9]/', '', $page_template ) );
+			}
+
+		}
+
+		if ( ! empty( $page_template ) && array_key_exists( $page_template, $latest_templates ) && ! defined( 'DSIDXPRESS_PLUGIN_VERSION' ) ) {
+			$updated_template = $latest_templates[ $page_template ];
+
+			update_post_meta( $page_id, '_wp_page_template', $updated_template );
+			echo '<meta HTTP-EQUIV="Refresh" CONTENT="1">';
+
+		} else if ( ! empty( $page_template ) && false !== strpos( $page_template, 'template-' ) && false === strpos( $page_template, 'templates/' ) && ! defined( 'DSIDXPRESS_PLUGIN_VERSION' ) ) {
+			update_post_meta( $page_id, '_wp_page_template', 'templates/' . $page_template );
+			echo '<meta HTTP-EQUIV="Refresh" CONTENT="1">';
+		}
+	}
+
+	add_action( 'wp_head', 'inspiry_update_page_templates' );
+}
+
+// Enable shortcodes in text widgets.
+add_filter( 'widget_text', 'do_shortcode' );
+
+if ( ! function_exists( 'inspiry_header_variation_body_classes' ) ) {
+	/**
+	 * Header variation body classes.
+	 */
+	function inspiry_header_variation_body_classes( $classes ) {
+		$get_header_variations = apply_filters( 'inspiry_header_variation', get_option( 'inspiry_header_mod_variation_option', 'one' ) );
+		$class_name            = 'inspiry_mod_header_variation_' . $get_header_variations;
+
+		if ( inspiry_show_header_search_form() ) {
+			$class_name .= ' inspiry_header_search_form_enabled';
+		}
+
+		if ( 'search-form-over-image' == get_post_meta( get_the_ID(), 'theme_homepage_module', true ) ) {
+			$class_name .= ' inspiry_search_form_over_image_enabled';
+		}
+
+		$classes[] = $class_name;
+
+		return $classes;
+	}
+
+	if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+		add_filter( 'body_class', 'inspiry_header_variation_body_classes' );
+	}
+}
+
+if ( ! function_exists( 'inspiry_search_form_variation_body_classes' ) ) {
+	/**
+	 * Search form variation body classes.
+	 */
+	function inspiry_search_form_variation_body_classes( $classes ) {
+		$get_header_variations = get_option( 'inspiry_search_form_mod_layout_options', 'default' );
+		$get_header_location   = get_option( 'inspiry_show_search_in_header', '1' );
+
+		if ( is_home() ) {
+			$page_id = get_queried_object_id();
+		} else {
+			$page_id = get_the_ID();
+		}
+
+		$REAL_HOMES_hide_advance_search = get_post_meta( $page_id, 'REAL_HOMES_hide_advance_search', true );
+
+		if ( '0' === $get_header_location || '1' === $REAL_HOMES_hide_advance_search ) {
+			$classes[] = 'inspriry_search_form_hidden_in_header';
+		}
+
+		$class_name = 'inspiry_mod_search_form_' . $get_header_variations;
+		$classes[]  = $class_name;
+
+		return $classes;
+	}
+
+	if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+		add_filter( 'body_class', 'inspiry_search_form_variation_body_classes' );
+	}
+}
+
+if ( ! function_exists( 'inspiry_add_meta_based_class' ) ) {
+	function inspiry_add_meta_based_class( $class ) {
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+			$REAL_HOMES_page_top_bottom_padding_nil = get_post_meta( get_the_ID(), 'REAL_HOMES_page_top_bottom_padding_nil', true );
+			if ( $REAL_HOMES_page_top_bottom_padding_nil == 1 ) {
+				$class[] = 'REAL_HOMES_page_top_bottom_padding_nil';
+			}
+		}
+		$REAL_HOMES_content_area_padding_nil = get_post_meta( get_the_ID(), 'REAL_HOMES_content_area_padding_nil', true );
+		if ( $REAL_HOMES_content_area_padding_nil == 1 ) {
+			$class[] = 'REAL_HOMES_content_area_padding_nil';
+		}
+
+		return $class;
+	}
+
+	add_filter( 'body_class', 'inspiry_add_meta_based_class' );
+
+}
+
+if ( ! function_exists( 'inspiry_floating_bar_class' ) ) {
+	/**
+	 * Search form variation body classes.
+	 */
+	function inspiry_floating_bar_class( $classes ) {
+		$inspiry_default_floating_bar_display = get_theme_mod( 'inspiry_default_floating_bar_display', 'show' );
+		if ( 'show' == $inspiry_default_floating_bar_display ) {
+			$class_name = 'inspiry_body_floating_features_show';
+		} else {
+			$class_name = 'inspiry_body_floating_features_hide';
+		}
+
+		$classes[] = $class_name;
+
+		return $classes;
+	}
+
+	add_filter( 'body_class', 'inspiry_floating_bar_class' );
+}
+
+if ( ! function_exists( 'inspiry_elementor_styles' ) ) {
+	/**
+	 * enqueue Elementor styles.
+	 */
+	function inspiry_elementor_styles() {
+		wp_enqueue_style(
+			'inspiry-elementor-style',
+			get_theme_file_uri( 'common/css/elementor-styles.min.css' ),
+			array(),
+			INSPIRY_THEME_VERSION
+		);
+	}
+
+	add_action( 'elementor/frontend/after_enqueue_styles', 'inspiry_elementor_styles' );
+}
+
+if ( function_exists( 'realhomes_currency_switcher_enabled' ) && realhomes_currency_switcher_enabled() ) {
+
+	if ( ! function_exists( 'inspiry_currency_switcher_flags' ) ) {
+		/**
+		 * Enqueue currency switcher flags css.
+		 */
+		function inspiry_currency_switcher_flags() {
+			wp_enqueue_style(
+				'inspiry-currency-flags',
+				get_theme_file_uri( 'common/css/currency-flags.min.css' ),
+				array(),
+				INSPIRY_THEME_VERSION
+			);
+		}
+
+		add_action( 'wp_enqueue_scripts', 'inspiry_currency_switcher_flags' );
+	}
+}
+
+if ( ! function_exists( 'inspiry_frontend_styles' ) ) {
+	/**
+	 * enqueue Elementor styles.
+	 */
+	function inspiry_frontend_styles() {
+		wp_enqueue_style(
+			'inspiry-frontend-style',
+			get_theme_file_uri( 'common/css/frontend-styles.min.css' ),
+			array(),
+			INSPIRY_THEME_VERSION
+		);
+	}
+
+	add_action( 'wp_enqueue_scripts', 'inspiry_frontend_styles' );
+}
+
+if ( ! function_exists( 'inspiry_sanitize_field' ) ) {
+	function inspiry_sanitize_field( $str ) {
+		/**
+		 * Filters a sanitized textarea field string.
+		 */
+
+		$allowed_html = array(
+			'a'      => array(
+				'href'   => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'strong' => array(),
+			'i'      => array(),
+			'em'     => array(),
+		);
+
+		$str = wp_kses( $str, $allowed_html );
+
+		return apply_filters( 'inspiry_sanitize_field', $str );
+	}
+}
+
+if ( ! function_exists( 'inspiry_kses' ) ) {
+	function inspiry_kses( $str ) {
+		/**
+		 * Filters content and keeps only allowable HTML elements.
+		 */
+		$allowed_html = array(
+			'a'      => array(
+				'href'   => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'strong' => array(),
+			'i'      => array(),
+			'em'     => array(),
+		);
+
+		$str = wp_kses( $str, $allowed_html );
+
+		return apply_filters( 'inspiry_kses', $str );
+	}
+}
+
+// Register Theme Locations For Elementor Templates
+if ( ! function_exists( 'inspiry_register_elementor_locations' ) ) {
+
+	function inspiry_register_elementor_locations( $elementor_theme_manager ) {
+
+		$elementor_theme_manager->register_location( 'header' );
+		$elementor_theme_manager->register_location( 'footer' );
+		$elementor_theme_manager->register_location( 'single' );
+		$elementor_theme_manager->register_location( 'archive' );
+		$elementor_theme_manager->register_location(
+			'single-property',
+			[
+				'label'           => esc_html__( 'Single Property', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'single-property-fullwidth',
+			[
+				'label'           => esc_html__( 'Single Property Fullwidth', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'single-agent',
+			[
+				'label'           => esc_html__( 'Single Agent', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'single-agency',
+			[
+				'label'           => esc_html__( 'Single Agency', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'properties-listings-grid',
+			[
+				'label'           => esc_html__( 'Properties Grid Layout', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'properties-listings-grid-fullwidth',
+			[
+				'label'           => esc_html__( 'Properties Grid Layout Fullwidth', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'properties-listings-list',
+			[
+				'label'           => esc_html__( 'Properties List Layout', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'properties-listings-list-fullwidth',
+			[
+				'label'           => esc_html__( 'Properties List Layout Fullwidth', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'agents-listings',
+			[
+				'label'           => esc_html__( 'Agents Listings', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+		$elementor_theme_manager->register_location(
+			'agency-listings',
+			[
+				'label'           => esc_html__( 'Agency Listings', RH_TEXT_DOMAIN ),
+				'multiple'        => true,
+				'edit_in_content' => true,
+			]
+		);
+	}
+
+	add_action( 'elementor/theme/register_locations', 'inspiry_register_elementor_locations' );
+}
+
+if ( ! function_exists( 'inspiry_post_classes' ) ) {
+
+	function inspiry_post_classes( $classes ) {
+
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+
+			if ( is_home() || is_archive() || is_search() || is_singular( 'post' ) ) {
+				$classes[] = 'rh_blog__post';
+
+			} else if ( is_page() ) {
+				$classes[] = 'rh_blog__post';
+
+				if ( 'hide' != get_post_meta( get_the_ID(), 'REAL_HOMES_page_title_display', true ) ) {
+					$classes[] = 'entry-header-margin-fix';
+				}
+			}
+
+		} else {
+			if ( is_page_template( 'templates/optima-express.php' ) ) {
+				$classes[] = 'optima-express clearfix';
+			} else if ( is_page() ) {
+				$classes[] = 'clearfix';
+			}
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'post_class', 'inspiry_post_classes' );
+}
+
+if ( ! function_exists( 'realhomes_content_width' ) ) {
+	/**
+	 * Adds css class to body when related sidebar is not active
+	 */
+	function realhomes_content_width( $classes ) {
+
+		if ( 'classic' === INSPIRY_DESIGN_VARIATION ) {
+			if ( ! is_active_sidebar( 'contact-sidebar' ) && is_page_template( 'templates/contact.php' ) ) {
+				$classes[] = 'realhomes-content-fullwidth contact-sidebar-inactive';
+			} else if ( ! is_active_sidebar( 'default-page-sidebar' ) && is_page_template( array(
+					'templates/agents-list.php',
+					'templates/agencies-list.php'
+				) )
+			) {
+				$classes[] = 'realhomes-content-fullwidth default-page-sidebar-inactive';
+			}
+		}
+
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+			if ( ! is_active_sidebar( 'property-listing-sidebar' ) && is_page_template( array(
+					'templates/agents-list.php',
+					'templates/agencies-list.php',
+				) )
+			) {
+				$classes[] = 'realhomes-content-fullwidth property-listing-sidebar-inactive';
+			}
+		}
+
+		if ( ! is_active_sidebar( 'property-listing-sidebar' ) && ( is_tax() || is_page_template( array( 'templates/users-lists.php' ) ) )
+		) {
+			$classes[] = 'realhomes-content-fullwidth property-listing-sidebar-inactive';
+
+		} else if ( ! is_active_sidebar( 'dsidx-sidebar' ) && is_page_template( 'templates/dsIDXpress.php' ) ) {
+			$classes[] = 'realhomes-content-fullwidth dsidx-sidebar-inactive';
+
+		} else if ( ! is_active_sidebar( 'agent-sidebar' ) && ( is_singular( 'agent' ) || is_author() ) ) {
+			$classes[] = 'realhomes-content-fullwidth agent-sidebar-inactive';
+
+		} else if ( ! is_active_sidebar( 'agency-sidebar' ) && is_singular( 'agency' ) ) {
+			$classes[] = 'realhomes-content-fullwidth agency-sidebar-inactive';
+
+		} else if ( ! is_active_sidebar( 'default-page-sidebar' ) && is_page() && ! is_page_template() ) {
+			$classes[] = 'realhomes-content-fullwidth default-page-sidebar-inactive';
+
+		} else if ( ! is_active_sidebar( 'default-sidebar' ) && ! is_tax() && ( is_singular( 'post' ) || is_home() || is_archive() || is_search() ) ) {
+			$classes[] = 'realhomes-content-fullwidth default-sidebar-inactive';
+		} else if ( ! is_active_sidebar( 'shop-page-sidebar' ) && realhomes_is_woocommerce_activated() && ( is_post_type_archive( 'product' ) || is_singular( 'product' ) ) ) {
+			$classes[] = 'realhomes-content-fullwidth shop-sidebar-inactive';
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'body_class', 'realhomes_content_width' );
+}
+
+if ( ! function_exists( 'inspiry_half_map_fixed_classes' ) ) {
+
+	function inspiry_half_map_fixed_classes( $classes ) {
+		if ( realhomes_is_half_map_template() ) {
+			$classes[] = 'inspiry_half_map_fixed';
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'body_class', 'inspiry_half_map_fixed_classes' );
+}
+
+if ( ! function_exists( 'inspiry_home_search_form_class' ) ) {
+
+// Adds css class to body when search form is disable on Home Page
+
+
+	function inspiry_home_search_form_class( $classes ) {
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION && is_page_template( 'templates/home.php' ) ) {
+			if ( 'false' == get_post_meta( get_the_ID(), 'theme_show_home_search', true ) ) {
+				$classes[] = 'inspiry-home-search-form-hide';
+			}
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'body_class', 'inspiry_home_search_form_class' );
+}
+
+if ( ! function_exists( 'inspiry_responsive_header' ) ) {
+
+// Adds Responsive header css class to body
+	function inspiry_responsive_header( $classes ) {
+		if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+			$get_responsive_header = get_option( 'inspiry_responsive_header_option', 'solid' );
+			$classes[]             = 'inspiry_responsive_header_' . $get_responsive_header;
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'body_class', 'inspiry_responsive_header' );
+}
+
+if ( ! function_exists( 'rh_sfoi_data_fetch' ) ) {
+
+	function rh_sfoi_data_fetch() {
+		$the_query = new WP_Query( array(
+			'posts_per_page' => 50,
+			's'              => esc_attr( $_POST['keyword'] ),
+			'post_type'      => 'property',
+		) );
+		if ( $the_query->have_posts() ) {
+			while ( $the_query->have_posts() ) {
+				$the_query->the_post(); ?>
+
+                <a href="<?php the_permalink(); ?>">
+                    <span class="sfoi_ajax_thumb"><?php the_post_thumbnail( 'thumbnail' ) ?></span>
+                    <span class="sfoi_ajax_title"><?php the_title(); ?></span>
+                    <span class="sfoi_ajax_status"><?php echo esc_html( display_property_status( get_the_ID() ) ); ?></span>
+                </a>
+
+				<?php
+			}
+			wp_reset_postdata();
+		}
+		die();
+	}
+
+	add_action( 'wp_ajax_rh_sfoi_data_fetch', 'rh_sfoi_data_fetch' );
+	add_action( 'wp_ajax_nopriv_rh_sfoi_data_fetch', 'rh_sfoi_data_fetch' );
+}
+
+// Set theme logo to custom_logo (for Elementor Site Logo widget)
+if ( ! function_exists( 'inspiry_theme_logo_to_custom_logo' ) ) {
+
+	function inspiry_theme_logo_to_custom_logo() {
+		$get_attachment_id = '';
+		$get_site_log_url  = get_option( 'theme_sitelogo' );
+		if ( ! empty( $get_site_log_url ) ) {
+			$get_attachment_id = attachment_url_to_postid( $get_site_log_url );
+		}
+		set_theme_mod( 'custom_logo', $get_attachment_id );
+	}
+
+	add_action( 'customize_save_after', 'inspiry_theme_logo_to_custom_logo' );
+}
+
+// Remove theme mod of core colors after settings them as theme options
+if ( ! function_exists( 'inspiry_update_theme_mod_to_options' ) ) {
+	function inspiry_update_theme_mod_to_options() {
+		$keys = array(
+			'inspiry_default_styles',
+			'theme_core_mod_color_orange',
+			'theme_core_mod_color_green_dark',
+			'theme_core_mod_color_green',
+			'theme_core_color_orange_light',
+			'theme_core_color_orange_dark',
+			'theme_core_color_orange_glow',
+			'theme_core_color_orange_burnt',
+			'theme_core_color_blue_light',
+			'theme_core_color_blue_dark',
+		);
+
+		foreach ( $keys as $key ) {
+			$key_theme_mod = get_theme_mod( $key );
+			if ( ! empty( $key_theme_mod ) ) {
+				update_option( $key, $key_theme_mod );
+				remove_theme_mod( $key );
+			}
+		}
+	}
+
+	add_action( 'upgrader_process_complete', 'inspiry_update_theme_mod_to_options' );
+}
+
+// Remove default image sizes here.
+if ( ! function_exists( 'inspiry_remove_default_images' ) ) {
+	function inspiry_remove_default_images( $sizes ) {
+		if ( 'true' == get_option( 'inspiry_unset_default_image_sizes' ) ) {
+			unset( $sizes['small'] ); // 150px
+			unset( $sizes['medium'] ); // 300px
+			unset( $sizes['medium_large'] ); // 768px
+			unset( $sizes['1536x1536'] ); // 2x medium_large size.
+			unset( $sizes['large'] ); // 1024px
+			unset( $sizes['2048x2048'] ); // // 2x large size.
+		}
+
+		return $sizes;
+	}
+
+	add_filter( 'intermediate_image_sizes_advanced', 'inspiry_remove_default_images' );
+}
+
+/**
+ * This function runs when WordPress theme completes its upgrade process.
+ *
+ * @param $upgrader_object Array
+ * @param $options         Array
+ */
+function inspiry_upgrade_function( $upgrader_object, $options ) {
+
+	if ( 'update' === $options['action'] && 'theme' === $options['type'] ) {
+
+		delete_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice_inspiry' );
+	}
+}
+
+add_action( 'upgrader_process_complete', 'inspiry_upgrade_function', 10, 2 );
+
+if ( ! function_exists( 'inspiry_filesize_formatted' ) ) {
+	/**
+	 * This function returns the file size of specified path
+	 *
+	 * @param string $path Path of the file
+	 *
+	 * @return string File size with units
+	 */
+	function inspiry_filesize_formatted( $path ) {
+		$size  = filesize( $path );
+		$units = array( 'b', 'kb', 'mb', 'gb', 'tb' );
+		$power = $size > 0 ? floor( log( $size, 1024 ) ) : 0;
+
+		return number_format( $size / pow( 1024, $power ), 2, '.', ',' ) . ' ' . $units[ $power ];
+	}
+}
+
+if ( ! function_exists( 'inspiry_active_nav_class' ) ) {
+	function inspiry_active_nav_class( $classes ) {
+		if ( in_array( 'current-menu-ancestor', $classes ) || in_array( 'current-menu-item', $classes ) ) {
+			$classes[] = 'rh-active';
+		}
+
+		return $classes;
+	}
+
+	add_filter( 'nav_menu_css_class', 'inspiry_active_nav_class', 10, 1 );
+}
+
+if ( ! function_exists( 'realhomes_unset_page_templates' ) ) {
+
+	/**
+	 * This function unset the Page Templates from dropdown
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array $page_templates Page templates.
+	 *
+	 * @return array modified page templates array
+	 */
+
+	function realhomes_unset_page_templates( $page_templates ) {
+
+		if ( 'ultra' === INSPIRY_DESIGN_VARIATION ) {
+			unset( $page_templates['templates/optima-express.php'] );
+		}
+
+		return $page_templates;
+	}
+
+	add_filter( 'theme_page_templates', 'realhomes_unset_page_templates' );
+}
+
+if ( ! function_exists( 'realhomes_hide_price_separator_class' ) ) {
+
+	/**
+	 * Show or hide price separator "/" between price value and post fix
+	 *
+	 * @since 4.3.2
+	 *
+	 */
+	function realhomes_hide_price_separator_class() {
+		if ( 'hide' === get_option( 'realhomes_property_price_separator', 'hide' ) ) {
+			echo esc_attr( 'hide-ultra-price-postfix-separator' );
+		}
+	}
+}
+
+if ( ! function_exists( 'realhomes_fullscreen_search_overlay' ) ) {
+
+/**
+ * Output fullscreen search overlay markup in footer.
+ */
+function realhomes_fullscreen_search_overlay() {
+?>
+<div id="rh-search-overlay" class="rh-search-overlay">
+    <button type="button" class="rh-search-close" aria-label="<?php esc_attr_e( 'Fechar', RH_TEXT_DOMAIN ); ?>"><i class="fa fa-times"></i></button>
+    <div class="rh-search-overlay-form">
+        <?php get_search_form(); ?>
+    </div>
+</div>
+<?php
+}
+add_action( 'wp_footer', 'realhomes_fullscreen_search_overlay' );
+}
+
+/**
+ * Enqueue script for fullscreen search overlay.
+ */
+function realhomes_enqueue_search_overlay_assets() {
+        wp_enqueue_script(
+                'realhomes-search-overlay',
+                get_template_directory_uri() . '/assets/js/search-overlay.js',
+                array(),
+                null,
+                true
+        );
+}
+add_action( 'wp_enqueue_scripts', 'realhomes_enqueue_search_overlay_assets' );

--- a/realhomes/realhomes/style.css
+++ b/realhomes/realhomes/style.css
@@ -1,0 +1,67 @@
+/*
+	Theme Name: RealHomes
+	Theme URI: http://themeforest.net/item/real-homes-wordpress-real-estate-theme/5373914
+	Author: InspiryThemes
+	Author URI: https://www.inspirythemes.com/
+	Description: RealHomes is a handcrafted WordPress theme for real estate websites. It offers purpose-oriented design with all the essential features that a real estate website needs. RealHomes theme facilitates its users on both the front-end and admin-side, making property management a breeze.
+    Requires at least: 6.0
+    Tested up to: 6.8.2
+    Requires PHP: 8.3
+	Version: 4.4.2
+	Text Domain: framework
+    Domain Path: /languages
+	License: GNU General Public License version 3.0
+	License URI: http://www.gnu.org/licenses/gpl-3.0.html
+	Tags: custom-background, light, one-column, two-columns, three-columns, four-columns, right-sidebar, flexible-header, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready
+
+        ----------------------------------------------------------------------------------------------------------------*/
+
+/* Fullscreen search overlay styles */
+.rh-search-toggle {
+    background: none;
+    border: 0;
+    margin-left: 10px;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+}
+
+.rh-search-toggle svg {
+    width: 24px;
+    height: 24px;
+    display: block;
+}
+
+.rh-search-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.rh-search-overlay.is-active {
+    display: flex;
+}
+
+.rh-search-overlay-form {
+    width: 80%;
+    max-width: 600px;
+}
+
+.rh-search-close {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+    background: none;
+    border: 0;
+    color: #fff;
+    font-size: 32px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- enqueue a dedicated script for the header search overlay
- implement vanilla JS to open/close the overlay on icon click, close button, and ESC key

## Testing
- `php -l realhomes/realhomes/functions.php`
- `php -l realhomes/realhomes/assets/modern/partials/header/submit-property.php`
- `php -l realhomes/realhomes/assets/ultra/partials/header/submit-property.php`
- `node --check realhomes/realhomes/assets/js/search-overlay.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3b565418832b9f9d4305f43e499a