### PR TITLE
Add customizable location and category filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+wp-content/*
+!wp-content/wp-content/
+wp-content/wp-content/*
+!wp-content/wp-content/plugins/
+wp-content/wp-content/plugins/*
+!wp-content/wp-content/plugins/easy-real-estate/
+wp-content/wp-content/plugins/easy-real-estate/*
+!wp-content/wp-content/plugins/easy-real-estate/includes/
+wp-content/wp-content/plugins/easy-real-estate/includes/*
+!wp-content/wp-content/plugins/easy-real-estate/includes/widgets/
+!wp-content/wp-content/plugins/easy-real-estate/includes/functions/
+wp-content/wp-content/plugins/easy-real-estate/includes/widgets/*
+wp-content/wp-content/plugins/easy-real-estate/includes/functions/*
+!wp-content/wp-content/plugins/easy-real-estate/includes/widgets/property-filters.php
+!wp-content/wp-content/plugins/easy-real-estate/includes/functions/basic.php

--- a/wp-content/wp-content/plugins/easy-real-estate/includes/functions/basic.php
+++ b/wp-content/wp-content/plugins/easy-real-estate/includes/functions/basic.php
@@ -1,0 +1,1395 @@
+<?php
+/**
+ * Contains Basic Functions for Easy Real Estate plugin.
+ */
+
+/**
+ * Get template part for ERE plugin.
+ *
+ * @access public
+ *
+ * @param mixed  $slug Template slug.
+ * @param string $name Template name (default: '').
+ */
+function ere_get_template_part( $slug, string $name = '' ) {
+	$template = '';
+
+	// Get slug-name.php.
+	if ( $name && file_exists( ERE_PLUGIN_DIR . "/{$slug}-{$name}.php" ) ) {
+		$template = ERE_PLUGIN_DIR . "/{$slug}-{$name}.php";
+	}
+
+	// Get slug.php.
+	if ( ! $template && file_exists( ERE_PLUGIN_DIR . "/{$slug}.php" ) ) {
+		$template = ERE_PLUGIN_DIR . "/{$slug}.php";
+	}
+
+	// Allow 3rd party plugins to filter template file from their plugin.
+	$template = apply_filters( 'ere_get_template_part', $template, $slug, $name );
+
+	if ( $template ) {
+		load_template( $template, false );
+	}
+}
+
+if ( ! function_exists( 'ere_log' ) ) {
+	/**
+	 * Function to help in debugging
+	 *
+	 * @param $message
+	 */
+	function ere_log( $message ) {
+		if ( WP_DEBUG === true ) {
+			if ( is_array( $message ) || is_object( $message ) ) {
+				error_log( print_r( $message, true ) );
+			} else {
+				error_log( $message );
+			}
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_exclude_CPT_meta_keys_from_rest_api' ) ) {
+
+	add_filter( 'ere_property_rest_api_meta', 'ere_exclude_CPT_meta_keys_from_rest_api' );
+	add_filter( 'ere_agency_rest_api_meta', 'ere_exclude_CPT_meta_keys_from_rest_api' );
+	add_filter( 'ere_agent_rest_api_meta', 'ere_exclude_CPT_meta_keys_from_rest_api' );
+
+	function ere_exclude_CPT_meta_keys_from_rest_api( $post_meta ) {
+
+		$exclude_keys = array(
+			//'_thumbnail_id',
+			'_vc_post_settings',
+			'_dp_original',
+			'_edit_lock',
+			'_wp_old_slug',
+			'slide_template',
+			'REAL_HOMES_banner_sub_title',
+		);
+
+		// excluding keys
+		foreach ( $exclude_keys as $key ) {
+			if ( key_exists( $key, $post_meta ) ) {
+				unset( $post_meta[ $key ] );
+			}
+		}
+
+		// return the post meta
+		return $post_meta;
+	}
+}
+
+if ( ! function_exists( 'ere_get_current_user_ip' ) ) {
+	/**
+	 * Return current user IP
+	 *
+	 * @return string|string[]|null
+	 */
+	function ere_get_current_user_ip() {
+		return preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
+	}
+}
+
+if ( ! function_exists( 'ere_generate_posts_list' ) ) {
+	/**
+	 * Generates options list for given post arguments
+	 *
+	 * @param     $post_args
+	 * @param int $selected
+	 */
+	function ere_generate_posts_list( $post_args, $selected = 0 ) {
+
+		$defaults = array( 'posts_per_page' => -1, 'suppress_filters' => true );
+
+		if ( is_array( $post_args ) ) {
+			$post_args = wp_parse_args( $post_args, $defaults );
+		} else {
+			$post_args = wp_parse_args( array( 'post_type' => $post_args ), $defaults );
+		}
+
+		$posts = get_posts( $post_args );
+
+		if ( isset( $selected ) && is_array( $selected ) ) {
+			foreach ( $posts as $post ) :
+				?>
+                <option value="<?php echo esc_attr( $post->ID ); ?>" <?php if ( in_array( $post->ID, $selected ) ) {
+				echo "selected";
+			} ?>><?php echo esc_html( $post->post_title ); ?></option><?php
+			endforeach;
+		} else {
+			foreach ( $posts as $post ) :
+				?>
+                <option value="<?php echo esc_attr( $post->ID ); ?>" <?php if ( isset( $selected ) && ( $selected == $post->ID ) ) {
+				echo "selected";
+			} ?>><?php echo esc_html( $post->post_title ); ?></option><?php
+			endforeach;
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_display_property_label' ) ) {
+	/**
+	 * Display property label
+	 *
+	 * @param $post_id
+	 */
+	function ere_display_property_label( $post_id ) {
+
+		$label_text = get_post_meta( $post_id, 'inspiry_property_label', true );
+		$color      = get_post_meta( $post_id, 'inspiry_property_label_color', true );
+		if ( ! empty ( $label_text ) ) {
+			?>
+            <span <?php if ( ! empty( $color ) ){ ?>style="background: <?php echo esc_attr( $color ); ?>"<?php } ?>
+                  class='property-label'><?php echo esc_html( $label_text ); ?></span>
+			<?php
+
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_include_compare_icon' ) ) {
+	/**
+	 * Include compare icon
+	 */
+	function ere_include_compare_icon() {
+
+		if ( defined( 'INSPIRY_THEME_DIR' ) ) {
+			include( INSPIRY_THEME_DIR . '/images/icons/icon-compare.svg' );
+		} else {
+			include( ERE_PLUGIN_DIR . '/images/icons/icon-compare.svg' );
+		}
+
+	}
+}
+
+if ( ! function_exists( 'ere_framework_excerpt' ) ) {
+	/**
+	 * Output custom excerpt of required length
+	 *
+	 * @param int    $len  number of words
+	 * @param string $trim string to appear after excerpt
+	 */
+	function ere_framework_excerpt( $len = 15, $trim = "&hellip;" ) {
+		echo ere_get_framework_excerpt( $len, $trim );
+	}
+}
+
+if ( ! function_exists( 'ere_get_framework_excerpt' ) ) {
+	/**
+	 * Returns custom excerpt of required length
+	 *
+	 * @param int    $len  number of words
+	 * @param string $trim string after excerpt
+	 *
+	 * @return array|string
+	 */
+	function ere_get_framework_excerpt( $len = 15, $trim = "&hellip;" ) {
+		$limit     = $len + 1;
+		$excerpt   = explode( ' ', get_the_excerpt(), $limit );
+		$num_words = count( $excerpt );
+		if ( $num_words >= $len ) {
+			array_pop( $excerpt );
+		} else {
+			$trim = "";
+		}
+		$excerpt = implode( " ", $excerpt ) . "$trim";
+
+		return $excerpt;
+	}
+}
+
+if ( ! function_exists( 'ere_social_networks' ) ) {
+	/**
+	 * Print social networks
+	 *
+	 * @param array $args Optional. Arguments to change container and icon classes.
+	 *
+	 * @return string
+	 */
+	function ere_social_networks( $args = array() ) {
+
+		// Return if social menu display options is disabled.
+		if ( 'true' !== get_option( 'theme_show_social_menu', 'false' ) ) {
+			return false;
+		}
+
+		$defaults = array(
+			'echo'            => 1,
+			'container'       => 'ul',
+			'container_class' => 'social_networks clearfix',
+			'icon_size_class' => 'fa-lg',
+			'replace_icons'   => array(),
+			'link_target'     => '_blank',
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		$default_social_networks = array(
+			'facebook'  => array(
+				'url'  => get_option( 'theme_facebook_link' ),
+				'icon' => 'fab fa-facebook-square'
+			),
+			'twitter'   => array(
+				'url'  => get_option( 'theme_twitter_link' ),
+				'icon' => 'fab fa-twitter'
+			),
+			'linkedin'  => array(
+				'url'  => get_option( 'theme_linkedin_link' ),
+				'icon' => 'fab fa-linkedin'
+			),
+			'instagram' => array(
+				'url'  => get_option( 'theme_instagram_link' ),
+				'icon' => 'fab fa-instagram'
+			),
+			'pinterest' => array(
+				'url'  => get_option( 'theme_pinterest_link' ),
+				'icon' => 'fab fa-pinterest'
+			),
+			'youtube'   => array(
+				'url'  => get_option( 'theme_youtube_link' ),
+				'icon' => 'fab fa-youtube'
+			),
+			'skype'     => array(
+				'url'  => get_option( 'theme_skype_username' ),
+				'icon' => 'fab fa-skype'
+			),
+			'rss'       => array(
+				'url'  => get_option( 'theme_rss_link' ),
+				'icon' => 'fas fa-rss'
+			),
+			'line'      => array(
+				'url'  => get_option( 'theme_line_id' ),
+				'icon' => 'fab fa-line'
+			),
+		);
+
+		$additional_social_networks = get_option( 'theme_social_networks', array() );
+		$social_networks            = apply_filters( 'inspiry_header_social_networks', $default_social_networks + $additional_social_networks );
+
+		$html = '<' . $args['container'] . ' class="' . esc_attr( $args['container_class'] ) . '">';
+
+		foreach ( $social_networks as $title => $social_network ) {
+
+			$social_network_title = $title;
+			$social_network_url   = $social_network['url'];
+			$social_network_icon  = $social_network['icon'];
+
+			if ( isset( $social_network['title'] ) && ! empty( $social_network['title'] ) ) {
+				$social_network_title = strtolower( str_replace( ' ', '-', $social_network['title'] ) );
+			}
+
+			if ( ! empty( $social_network_title ) && ! empty( $social_network_url ) && ! empty( $social_network_icon ) ) {
+
+				if ( 'skype' === $social_network_title ) {
+					$social_network_url = esc_attr( 'skype:' . $social_network_url );
+				} else if ( 'line' === $social_network_title ) {
+					$social_network_url = esc_url( 'https://line.me/ti/p/' . $social_network_url );
+				} else {
+					$social_network_url = esc_url( $social_network_url );
+				}
+
+				if ( ! empty( $args['replace_icons'] ) ) {
+
+					if ( array_key_exists( $social_network_title, $args['replace_icons'] ) ) {
+						$social_network_icon = $args['replace_icons'][ $social_network_title ];
+					}
+				}
+
+				$social_network_icon = array(
+					$social_network_icon,
+					$args['icon_size_class']
+				);
+				$icon_classes        = implode( " ", $social_network_icon );
+
+				if ( 'ul' === $args['container'] ) {
+					$format = '<li class="%s"><a href="%s" target="%s"><i class="%s"></i></a></li>';
+				} else {
+					$format = '<a class="%s" href="%s" target="%s"><i class="%s"></i></a>';
+				}
+
+				$html .= sprintf( $format, esc_attr( $social_network_title ), $social_network_url, esc_attr( $args['link_target'] ), esc_attr( $icon_classes ) );
+			}
+		}
+
+		$html .= '</' . $args['container'] . '>';
+
+		if ( $args['echo'] ) {
+			echo $html;
+		} else {
+			return $html;
+		}
+	}
+}
+
+if ( is_admin() && ! function_exists( 'inspiry_remove_revolution_slider_meta_boxes' ) ) {
+	/**
+	 * Remove Rev Slider Metabox
+	 */
+	function inspiry_remove_revolution_slider_meta_boxes() {
+
+		$post_types = apply_filters( 'inspiry_remove_revolution_slider_meta_boxes',
+			array(
+				'page',
+				'post',
+				'property',
+				'agency',
+				'agent',
+				'partners',
+				'slide',
+			)
+		);
+
+		remove_meta_box( 'mymetabox_revslider_0', $post_types, 'normal' );
+	}
+
+	add_action( 'do_meta_boxes', 'inspiry_remove_revolution_slider_meta_boxes' );
+}
+
+if ( ! function_exists( 'inspiry_is_property_analytics_enabled' ) ) {
+	/**
+	 * Check property analytics feature is enabled or disabled.
+	 */
+	function inspiry_is_property_analytics_enabled() {
+		return 'enabled' === get_option( 'inspiry_property_analytics_status', 'disabled' );
+	}
+}
+
+if ( ! function_exists( 'ere_epc_default_fields' ) ) {
+	/**
+	 * Return Enenergy Performance Certificate default fields.
+	 */
+	function ere_epc_default_fields() {
+
+		return apply_filters(
+			'ere_epc_default_fields',
+			array(
+				array(
+					'name'  => 'A+',
+					'color' => '#00845a',
+				),
+				array(
+					'name'  => 'A',
+					'color' => '#18b058',
+				),
+				array(
+					'name'  => 'B',
+					'color' => '#8dc643',
+				),
+				array(
+					'name'  => 'C',
+					'color' => '#ffcc01',
+				),
+				array(
+					'name'  => 'D',
+					'color' => '#f6ac63',
+				),
+				array(
+					'name'  => 'E',
+					'color' => '#f78622',
+				),
+				array(
+					'name'  => 'F',
+					'color' => '#ef1d3a',
+				),
+				array(
+					'name'  => 'G',
+					'color' => '#d10400',
+				),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'ere_safe_include_svg' ) ) {
+	/**
+	 * Includes svg file in the ERE Plugin.
+	 *
+	 * @param string $file
+	 *
+	 */
+	function ere_safe_include_svg( $file ) {
+		$file = ERE_PLUGIN_DIR . $file;
+		if ( file_exists( $file ) ) {
+			include( $file );
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_property_meta_icon' ) ) {
+	/**
+	 * Displays property meta icon based on field name.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $field_name The name of the property field associated with the icon.
+	 * @param string $icon_name The name of the SVG icon to be displayed.
+	 *
+	 * @return void
+	 */
+	function ere_property_meta_icon( $field_name, $icon_name ) {
+		if ( function_exists( 'realhomes_property_meta_icon_custom' ) && ! realhomes_property_meta_icon_custom( $field_name ) ) {
+			ere_safe_include_svg( '/images/icons/' . $icon_name . '.svg' );
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_stylish_meta' ) ) {
+	function ere_stylish_meta( $label, $post_meta_key, $icon, $postfix = '' ) {
+		$property_id = get_the_ID();
+		$post_meta   = get_post_meta( $property_id, $post_meta_key, true );
+
+		if ( isset( $post_meta ) && ! empty( $post_meta ) ) {
+			?>
+            <div class="rh_prop_card__meta">
+				<?php
+				if ( $label ) {
+					?>
+                    <span class="rh_meta_titles"><?php echo esc_html( $label ); ?></span>
+					<?php
+				}
+				?>
+                <div class="rh_meta_icon_wrapper">
+	                <?php ere_property_meta_icon( $post_meta_key, $icon ); ?>
+                    <span class="figure"><?php echo esc_html( $post_meta ); ?></span>
+	                <?php
+	                if ( ! empty( $postfix ) ) {
+		                if ( 'REAL_HOMES_property_size_postfix' === $postfix ) {
+			                $get_postfix = realhomes_get_area_unit( $property_id );
+		                } else if ( 'REAL_HOMES_property_lot_size_postfix' === $postfix ) {
+			                $get_postfix = realhomes_get_lot_unit( $property_id );
+		                } else {
+			                $get_postfix = get_post_meta( $property_id, $postfix, true );
+		                }
+
+		                if ( ! empty( $get_postfix ) ) {
+			                ?>
+                            <span class="label"><?php echo esc_html( $get_postfix ); ?></span>
+			                <?php
+		                }
+	                }
+	                ?>
+                </div>
+            </div>
+			<?php
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_stylish_meta_smart' ) ) {
+	function ere_stylish_meta_smart( $label, $post_meta_key, $icon, $postfix = '' ) {
+		$property_id = get_the_ID();
+		$post_meta   = get_post_meta( $property_id, $post_meta_key, true );
+
+		if ( isset( $post_meta ) && ! empty( $post_meta ) ) {
+			?>
+            <div class="rh_prop_card__meta">
+				<?php
+				if ( $label ) {
+					?>
+                    <span class="rhea_meta_titles"><?php echo esc_html( $label ); ?></span>
+					<?php
+				}
+				?>
+                <div class="rhea_meta_icon_wrapper">
+                    <span data-tooltip="<?php echo esc_html( $label ) ?>">
+					<?php ere_property_meta_icon( $post_meta_key, $icon ); ?>
+                    </span>
+                    <span class="rhea_meta_smart_box">
+                    <span class="figure"><?php echo esc_html( $post_meta ); ?></span>
+	                    <?php
+	                    if ( ! empty( $postfix ) ) {
+		                    if ( 'REAL_HOMES_property_size_postfix' === $postfix ) {
+			                    $get_postfix = realhomes_get_area_unit( $property_id );
+		                    } else if ( 'REAL_HOMES_property_lot_size_postfix' === $postfix ) {
+			                    $get_postfix = realhomes_get_lot_unit( $property_id );
+		                    } else {
+			                    $get_postfix = get_post_meta( $property_id, $postfix, true );
+		                    }
+
+		                    if ( ! empty( $get_postfix ) ) {
+			                    ?>
+                                <span class="label"><?php echo esc_html( $get_postfix ); ?></span>
+			                    <?php
+		                    }
+	                    }
+	                    ?>
+                    </span>
+                </div>
+            </div>
+			<?php
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_ultra_meta' ) ) {
+	function ere_ultra_meta( $label, $post_meta_key, $icon, $postfix = '' ) {
+		$property_id = get_the_ID();
+		$post_meta   = get_post_meta( $property_id, $post_meta_key, true );
+
+		if ( isset( $post_meta ) && ! empty( $post_meta ) ) {
+			?>
+            <div class="rh-ultra-prop-card-meta">
+                <div class="rh-ultra-meta-icon-wrapper">
+                    <span class="rh-ultra-meta-icon" data-tooltip="<?php echo esc_html( $label ) ?>">
+					<?php ere_property_meta_icon( $post_meta_key, $icon ); ?>
+                    </span>
+                    <span class="rh-ultra-meta-box">
+                    <span class="figure"><?php echo esc_html( $post_meta ); ?></span>
+	                    <?php
+	                    if ( ! empty( $postfix ) ) {
+		                    if ( 'REAL_HOMES_property_size_postfix' === $postfix ) {
+			                    $get_postfix = realhomes_get_area_unit( $property_id );
+		                    } else if ( 'REAL_HOMES_property_lot_size_postfix' === $postfix ) {
+			                    $get_postfix = realhomes_get_lot_unit( $property_id );
+		                    } else {
+			                    $get_postfix = get_post_meta( $property_id, $postfix, true );
+		                    }
+
+		                    if ( ! empty( $get_postfix ) ) {
+			                    ?>
+                                <span class="label"><?php echo esc_html( $get_postfix ); ?></span>
+			                    <?php
+		                    }
+	                    }
+	                    ?>
+                    </span>
+                </div>
+            </div>
+			<?php
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_display_property_status_html' ) ) {
+	/**
+	 * Display property status.
+	 *
+	 * @param $post_id
+	 *
+	 */
+	function ere_display_property_status_html( $post_id ) {
+		$status_terms = get_the_terms( $post_id, 'property-status' );
+
+		if ( ! empty( $status_terms ) && ! is_wp_error( $status_terms ) ) {
+
+
+			foreach ( $status_terms as $term ) {
+
+				$inspiry_property_status_bg = get_term_meta( $term->term_id, 'inspiry_property_status_bg', true );
+				$status_bg                  = '';
+				if ( ! empty( $inspiry_property_status_bg ) ) {
+					$status_bg = " background:" . "$inspiry_property_status_bg; ";
+				}
+				$inspiry_property_status_text = get_term_meta( $term->term_id, 'inspiry_property_status_text', true );
+
+				$status_text = '';
+				if ( ! empty( $inspiry_property_status_text ) ) {
+					$status_text = " color:" . "$inspiry_property_status_text; ";
+				}
+
+				?>
+                <span class="rh_prop_status_sty" style="<?php echo esc_attr( $status_bg . $status_text ) ?>">
+                <?php
+                echo esc_html( $term->name );
+                ?>
+				</span>
+				<?php
+			}
+		}
+
+	}
+}
+
+if ( ! function_exists( 'ere_get_scheduled_times' ) ) {
+	/**
+	 * Get scheduled times for the current property
+	 *
+	 * @since  2.0.0
+	 *
+	 * @return string 
+	 */
+	function ere_get_scheduled_times( $current_schedules ) {
+
+		if ( ! empty( $current_schedules ) ) {
+			$table = '<table class="schedule-time-list">';
+			$table .= '<tr>';
+			$table .= '<th>' . esc_html__( 'Date/Time', ERE_TEXT_DOMAIN ) . '</th>';
+			$table .= '<th>' . esc_html__( 'Tour Type', ERE_TEXT_DOMAIN ) . '</th>';
+			$table .= '<th>' . esc_html__( 'Name', ERE_TEXT_DOMAIN ) . '</th>';
+			$table .= '<th>' . esc_html__( 'Phone', ERE_TEXT_DOMAIN ) . '</th>';
+			$table .= '<th>' . esc_html__( 'Email', ERE_TEXT_DOMAIN ) . '</th>';
+			$table .= '</tr>';
+
+			// reversing the existing array to display the new requests on the top
+			$current_schedules = array_reverse( $current_schedules );
+
+			foreach ( $current_schedules as $schedule ) {
+				$table .= '<tr>';
+				$table .= ( isset( $schedule['selected_date'] ) || isset( $schedule['selected_time'] ) ) ? '<td>' . esc_html( $schedule['selected_date'] ) . ', ' . esc_html( $schedule['selected_time'] ) . '</td>' : '<td></td>';
+				$table .= isset( $schedule['schedule_type'] ) ? '<td>' . esc_html( $schedule['schedule_type'] ) . '</td>' : '<td></td>';
+				$table .= isset( $schedule['user_name'] ) ? '<td>' . esc_html( $schedule['user_name'] ) . '</td>' : '<td></td>';
+				$table .= isset( $schedule['user_phone'] ) ? '<td>' . esc_html( $schedule['user_phone'] ) . '</td>' : '<td></td>';
+				$table .= isset( $schedule['user_email'] ) ? '<td>' . esc_html( $schedule['user_email'] ) . '</td>' : '<td></td>';
+				$table .= '</tr>';
+			}
+
+			$table .= '</table>';
+
+			return $table;
+		}
+
+		return '<div class="sat-no-tours">' . esc_html__( 'There are no tour requests for this property.', ERE_TEXT_DOMAIN ) . '</div>';
+	}
+}
+if ( ! function_exists( 'ere_share_post' ) ) {
+	/**
+	 * Displays post social sharing links.
+	 *
+	 * @since 1.*.*
+	 *
+	 * @param int|WP_Post $post_id Optional. Post ID or WP_Post object. Default is the global `$post`.
+	 *
+	 * @return void
+	 */
+	function ere_share_post( $post_id = 0 ) {
+		$post = get_post( $post_id );
+
+		// Holds HTML structure of social sharing buttons
+		$output = '';
+
+		// Get current page URL
+		$post_link = get_permalink();
+
+		// Get current page title
+		$post_title = str_replace( ' ', '%20', get_the_title() );
+
+		// Social Sharing Links data array
+		$social_sharing_links = array(
+			'facebook'  => array(
+				'icon'          => '<i class="fab fa-facebook"></i>',
+				'url'           => 'https://www.facebook.com/sharer/sharer.php?u=' . $post_link,
+				'new_window'    => true,
+				'window_width'  => 600,
+				'window_height' => 300,
+			),
+			'twitter'   => array(
+				'icon'          => '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"></path></svg>',
+				'url'           => 'https://twitter.com/intent/tweet?text=' . esc_html( $post_title ) . '&amp;url=' . $post_link,
+				'new_window'    => true,
+				'window_width'  => 600,
+				'window_height' => 300,
+			),
+			'mail'      => array(
+				'icon'       => '<i class="fa fa-envelope"></i>',
+				'url'        => 'mailto:?body=' . $post_link,
+				'new_window' => false,
+			),
+		);
+
+		// Get Post Thumbnail for pinterest
+		$post_thumbnail = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
+		if ( $post_thumbnail ) {
+			$social_sharing_links['pinterest'] = array(
+				'icon'          => '<i class="fab fa-pinterest"></i>',
+				'url'           => 'https://pinterest.com/pin/create/button/?url=' . $post_link . '&amp;media=' . $post_thumbnail[0] . '&amp;description=' . esc_html( $post_title ),
+				'new_window'    => true,
+				'window_width'  => 600,
+				'window_height' => 600,
+			);
+		}
+
+		$title = esc_html__( 'Share', ERE_TEXT_DOMAIN );
+
+		$output .= '<div class="post-share">';
+		$output .= '<h3 class="post-share-title">' . $title . '</h3>';
+		$output .= '<div class="post-share-links">';
+
+		foreach ( $social_sharing_links as $social_media_title => $social_sharing_data ) {
+
+			$icon                    = $social_sharing_data['icon'];
+			$url                     = $social_sharing_data['url'];
+			$new_window              = $social_sharing_data['new_window'];
+			$open_in_separate_window = '';
+
+			if ( $new_window ) {
+				$window_width            = $social_sharing_data['window_width'];
+				$window_height           = $social_sharing_data['window_height'];
+				$open_in_separate_window = sprintf( 'onclick="window.open(this.href, \'%s\', \'width=%d,height=%d\'); return false;"', $social_media_title, $window_width, $window_height );
+			}
+
+			$output .= sprintf( '<a rel="nofollow" href="%s" ' . $open_in_separate_window . '" title="Share on %s">%s</a>', $url, $social_media_title, $icon );
+		}
+
+		$output .= '</div>';
+		$output .= '</div>';
+
+		echo wp_kses( $output, array(
+			'div' => array(
+				'class' => true,
+			),
+			'h3' => array(
+				'class' => true,
+			),
+			'a' => array(
+				'href'   => true,
+				'title'  => true,
+				'rel'    => true,
+				'class'  => true,
+				'onclick'=> true,
+			),
+			'i' => array(
+				'class' => true,
+			),
+			'svg' => array(
+				'xmlns'       => true,
+				'viewBox'     => true,
+				'width'       => true,
+				'height'      => true,
+				'fill'        => true,
+				'aria-hidden' => true,
+			),
+			'path' => array(
+				'd' => true,
+			),
+		) );
+	}
+}
+
+
+if ( ! function_exists( 'ere_process_filter_widget_taxonomies' ) ) {
+	/**
+	 * Process taxonomies listings for filter properties widget
+	 *
+	 * @since  2.0.3
+	 *
+	 * @param $taxonomy
+	 * @param $view_limit
+	 * @param $hide_empty
+	 */
+        function ere_process_filter_widget_taxonomies( $taxonomy, $view_limit, $hide_empty, $include_terms = array() ) {
+
+		// to ensure that view limit is not set under 1
+		if ( 1 > intval( $view_limit ) ) {
+			$view_limit = 6;
+		}
+
+		// fetching the taxonomies object
+                $args = array(
+                        'taxonomy'   => $taxonomy,
+                        'hide_empty' => $hide_empty
+                );
+                if ( ! empty( $include_terms ) ) {
+                        $args['include'] = $include_terms;
+                }
+                $taxonomies_obj = get_terms( $args );
+
+		// checking if taxonomy is throwing an error
+		if ( ! is_wp_error( $taxonomies_obj ) && ! empty( $taxonomies_obj ) ) {
+			?>
+            <div class="items-visible">
+				<?php
+				$tax_count = count( $taxonomies_obj );
+				if ( $tax_count < $view_limit ) {
+					$view_limit = $tax_count;
+				}
+
+				// generating taxonomies before the max view limit
+				for ( $tax_num = 0; $tax_num < $view_limit; $tax_num++ ) {
+					if ( ! empty( $taxonomies_obj[ $tax_num ] ) ) {
+						echo '<span data-term-slug="' . esc_attr( $taxonomies_obj[ $tax_num ]->slug ) . '">' . esc_html( $taxonomies_obj[ $tax_num ]->name ) . '<i>&#10003;</i></span>';
+					}
+				}
+				?>
+            </div>
+
+			<?php
+			// generating taxonomies after the max view limit
+			if ( $tax_count > $view_limit ) {
+				?>
+                <div class="items-view-more">
+					<?php
+					for ( $tax_num = $view_limit; $tax_num < $tax_count; $tax_num++ ) {
+						if ( ! empty( $taxonomies_obj[ $tax_num ] ) ) {
+							echo '<span data-term-slug="' . esc_attr( $taxonomies_obj[ $tax_num ]->slug ) . '">' . esc_html( $taxonomies_obj[ $tax_num ]->name ) . '<i>&#10003;</i></span>';
+						}
+					}
+					?>
+                </div>
+
+                <a class="view-more"><?php esc_html_e( 'View More', ERE_TEXT_DOMAIN ); ?></a>
+                <a class="view-less"><?php esc_html_e( 'View Less', ERE_TEXT_DOMAIN ); ?></a>
+				<?php
+			}
+		}
+	}
+}
+
+
+if ( ! function_exists( 'ere_taxonomy_has_terms' ) ) {
+	/**
+	 * Check if given taxonomy has any terms
+	 *
+	 * @since  2.0.3
+	 *
+	 * @param string $taxonomy
+	 * @param boolean $hide_empty
+     *
+     * @return boolean
+	 */
+    function ere_taxonomy_has_terms( $taxonomy, $hide_empty = false ) {
+
+        if( taxonomy_exists( $taxonomy ) ) {
+	        $terms = get_terms(
+                    array(
+                        'taxonomy' => $taxonomy,
+                        'hide_empty' => $hide_empty
+                    )
+            );
+
+	        if( 0 < count( $terms ) ) {
+		        return true;
+	        }
+        }
+
+        return false;
+    }
+}
+
+
+if ( ! function_exists( 'ere_new_field_for_section' ) ) {
+	/**
+	 * Check if current section can show any of the additional fields
+	 * It is being checked against the section key in the given fields array
+	 * It is required to assess that if the given section can be displayed at all
+	 *
+	 * @since  2.0.3
+	 *
+	 * @param string $section_key
+	 * @param array  $fields_array
+	 *
+	 * @return boolean
+	 */
+	function ere_new_field_for_section( $section_key, $fields_array ) {
+
+		if ( is_array( $fields_array ) ) {
+			foreach ( $fields_array as $field ) {
+				if ( ! empty( $field['field_display'] ) && in_array( $section_key, $field['field_display'] ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}
+
+
+if ( ! function_exists( 'ere_process_filter_widget_post_types' ) ) {
+	/**
+	 * Process taxonomies listings for filter properties widget
+	 *
+	 * @since  2.0.3
+	 *
+	 * @param array $args arguments to manage lists
+	 *                    - post_type           (post, page, {custom post type name} etc.)
+	 *                    - display_type        (thumbnail, radio)
+	 *                    - view_limit          The number of items after which the 'view more' will be displayed
+	 *                    - wrapper_classes     Post type specific classes for filter section
+	 *                    - section_title       Section display title
+	 *                    - display_title       Display title tag to show selection above posts listings
+	 *                    - target_id           JS target ID which will be used to target this section
+	 *                    - thumb_placeholder   Placeholder if not thumbnail exists (Default is user image)
+	 */
+	function ere_process_filter_widget_post_types( $args = array() ) {
+
+		$post_type         = ! empty( $args['post_type'] ) ? $args['post_type'] : 'post';
+		$display_type      = ! empty( $args['display_type'] ) ? $args['display_type'] : 'radio';
+		$view_limit        = ! empty( $args['view_limit'] ) ? $args['view_limit'] : 6;
+		$wrapper_classes   = ! empty( $args['wrapper_classes'] ) ? $args['wrapper_classes'] : 'post-options';
+		$section_title     = ! empty( $args['section_title'] ) ? $args['section_title'] : esc_html__( 'Posts', ERE_TEXT_DOMAIN );
+		$display_tag_title = ! empty( $args['display_title'] ) ? $args['display_title'] : esc_html__( 'Post', ERE_TEXT_DOMAIN );
+		$js_target_id      = ! empty( $args['target_id'] ) ? $args['target_id'] : 'posts';
+		$image_size        = ! empty( $args['image_size'] ) ? $args['image_size'] : 'thumbnail';
+		$thumb_placeholder = ! empty( $args['thumb_placeholder'] ) ? $args['thumb_placeholder'] : get_template_directory_uri() . '/common/images/profile-img-placeholder.png';
+
+
+		// to ensure that view limit is not set under 1
+		if ( 1 > intval( $view_limit ) ) {
+			$view_limit = 6;
+		}
+
+		// fetching the posts
+		$posts = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'posts_per_page' => -1
+			)
+		);
+
+		if ( ! is_wp_error( $posts ) && is_array( $posts ) ) {
+
+			// if sitepress WPML is enabled
+			if ( class_exists( 'SitePress' ) ) {
+				$current_posts = array();
+
+				// Filter IDs to get content in current language only
+				foreach ( $posts as $post ) {
+					if ( ! in_array( $post->ID, $current_posts ) ) {
+						if ( apply_filters( 'wpml_object_id', $post->ID, $post_type, false ) !== null ) {
+							$current_posts[] = apply_filters( 'wpml_object_id', $post->ID, $post_type, false );
+						}
+					}
+				}
+
+				if ( 0 < count( $current_posts ) ) {
+					$posts = get_posts(
+						array(
+							'post_type'      => $post_type,
+							'posts_per_page' => -1,
+							'post__in'       => $current_posts
+						)
+					);
+				} else {
+					$posts = array();
+				}
+			}
+
+			// Counter variable to honor view limit of the checkboxes
+			$counter = 1;
+
+			// if there are posts available
+			if ( 0 < count( $posts ) ) {
+				?>
+                <div class="filter-wrapper <?php echo esc_attr( $wrapper_classes ); ?>">
+                    <h4><?php echo esc_html( $section_title ); ?></h4>
+                    <div class="filter-section posts-list display-type-<?php echo esc_attr( $display_type ); ?>" data-meta-name="<?php echo esc_attr( $js_target_id ); ?>" data-display-title="<?php echo esc_attr( $display_tag_title ); ?>">
+                        <div class="items-visible">
+							<?php
+							foreach ( $posts as $post ) {
+								// foreach will break after generating checkboxes under the selected limit
+								if ( $counter <= $view_limit ) {
+									$post_id = $post->ID;
+									?>
+                                    <div class="pt-item <?php echo esc_attr( $display_type ); ?>" data-post-id="<?php echo esc_attr( $post_id ) . '|' . get_the_title( $post_id ); ?>">
+										<?php
+										if ( $display_type === 'thumbnail' ) {
+											if ( has_post_thumbnail( $post_id ) ) {
+												?>
+                                                <figure><?php echo get_the_post_thumbnail( $post_id, $image_size ); ?></figure>
+												<?php
+											} else {
+												?>
+                                                <figure>
+                                                    <img src="<?php echo esc_url( $thumb_placeholder ); ?>" alt="<?php echo get_the_title( $post_id ); ?>">
+                                                </figure>
+												<?php
+											}
+											?>
+                                            <div class="item-content">
+                                                <h5 class="pt-title"><?php echo get_the_title( $post_id ); ?></h5>
+                                            </div>
+											<?php
+										} else {
+											?>
+                                            <span><?php echo get_the_title( $post_id ); ?><i>&#10003;</i></span>
+											<?php
+										}
+										?>
+                                    </div>
+									<?php
+								} else {
+									break;
+								}
+								$counter++;
+							}
+							?>
+                        </div>
+						<?php
+						// if we still have items after the limit
+						if ( $view_limit < count( $posts ) ) {
+
+							// slicing the array to skip already generated checkboxes
+							$more_posts = array_slice( $posts, $view_limit );
+							if ( 0 < count( $more_posts ) ) {
+								?>
+                                <div class="items-view-more">
+									<?php
+									foreach ( $more_posts as $post ) {
+										$post_id = $post->ID;
+										?>
+                                        <div class="pt-item <?php echo esc_attr( $display_type ); ?>" data-post-id="<?php echo esc_attr( $post_id ) . '|' . get_the_title( $post_id ); ?>">
+											<?php
+											if ( $display_type === 'thumbnail' ) {
+												if ( has_post_thumbnail( $post_id ) ) {
+													?>
+                                                    <figure><?php echo get_the_post_thumbnail( $post_id, 'thumbnail' ); ?></figure>
+													<?php
+												}
+												?>
+                                                <div class="item-content">
+                                                    <h5 class="pt-title"><?php echo get_the_title( $post_id ); ?></h5>
+                                                </div>
+												<?php
+											} else {
+												?>
+                                                <span><?php echo get_the_title( $post_id ); ?><i>&#10003;</i></span>
+												<?php
+											}
+											?>
+                                        </div>
+										<?php
+									}
+									?>
+                                </div>
+
+                                <a class="view-more"><?php esc_html_e( 'View More', ERE_TEXT_DOMAIN ); ?></a>
+                                <a class="view-less"><?php esc_html_e( 'View Less', ERE_TEXT_DOMAIN ); ?></a>
+								<?php
+							}
+						}
+						?>
+                    </div>
+                </div>
+				<?php
+			}
+
+		}
+	}
+}
+
+if ( ! function_exists( 'ere_process_filter_widget_tiles' ) ) {
+	/**
+	 * Process given data into single or multi-select tiles
+	 *
+	 * @since  2.3.0
+	 *
+	 * @param array $args arguments to manage lists
+	 *                    - list_array          (post, page, {custom post type name} etc.)
+	 *                    - display_type        (thumbnail, radio)
+	 *                    - view_limit          The number of items after which the 'view more' will be displayed
+	 *                    - wrapper_classes     Post type specific classes for filter section
+	 *                    - section_title       Section display title
+	 *                    - display_title       Display title tag to show selection above posts listings
+	 *                    - target_id           JS target ID which will be used to target this section
+	 */
+	function ere_process_filter_widget_tiles( $args = array() ) {
+
+		$items_array       = isset( $args['items_array'] ) ? $args['items_array'] : false;
+		$selection_type    = isset( $args['selection_type'] ) ? $args['selection_type'] : 'single';
+		$view_limit        = isset( $args['view_limit'] ) ? $args['view_limit'] : 6;
+		$wrapper_classes   = isset( $args['wrapper_classes'] ) ? $args['wrapper_classes'] : 'items-list';
+		$section_title     = isset( $args['section_title'] ) ? $args['section_title'] : esc_html__( 'Items', ERE_TEXT_DOMAIN );
+		$meta_key          = isset( $args['meta_key'] ) ? $args['meta_key'] : '';
+		$display_tag_title = isset( $args['display_title'] ) ? $args['display_title'] : esc_html__( 'Check List', ERE_TEXT_DOMAIN );
+
+		// Counter variable to honor view limit of the checkboxes
+		$counter = 1;
+
+        // if is array and have items
+        if ( is_array( $items_array ) && 0 < count( $items_array ) ) {
+            ?>
+            <div class="filter-wrapper <?php echo esc_attr( $wrapper_classes ); ?>">
+                <h4><?php echo esc_html( $section_title ); ?></h4>
+                <div class="filter-section ad-select-list selection-type-<?php echo esc_attr( $selection_type ); ?>" data-meta-key="<?php echo esc_attr( $meta_key ); ?>" data-display-title="<?php echo esc_attr( $display_tag_title ); ?>">
+                    <div class="items-visible">
+                        <?php
+                        foreach ( $items_array as $item ) {
+                            // foreach will break after generating checkboxes under the selected limit
+                            if ( $counter <= $view_limit ) {
+	                            $item_slug = strtolower( str_replace( ' ', '-', $item ) );
+                                ?>
+                                <div id="<?php echo esc_attr( $meta_key ) . '-' . esc_attr( $item_slug ); ?>" class="ad-select-item <?php echo esc_attr( $selection_type ); ?>" data-filter-value="<?php echo esc_attr( $item_slug ); ?>">
+                                    <span class="selection"></span>
+                                    <div class="item-content">
+                                        <h5 class="ad-select-title"><?php echo esc_html( $item ); ?></h5>
+                                    </div>
+                                </div>
+                                <?php
+                            } else {
+                                break;
+                            }
+                            $counter++;
+                        }
+                        ?>
+                    </div>
+                    <?php
+                    // if we still have items after the limit
+                    if ( $view_limit < count( $items_array ) ) {
+
+                        // slicing the array to skip already generated checkboxes
+	                    $more_list_items = array_slice( $items_array, $view_limit );
+                        if ( 0 < count( $more_list_items ) ) {
+                            ?>
+                            <div class="items-view-more">
+                                <?php
+                                foreach ( $more_list_items as $item ) {
+	                                $item_slug = strtolower( str_replace( ' ', '-', $item ) );
+	                                ?>
+                                    <div id="<?php echo esc_attr( $meta_key ) . '-' . esc_attr( $item_slug ); ?>" class="ad-select-item <?php echo esc_attr( $selection_type ); ?>" data-filter-value="<?php echo esc_attr( $item_slug ); ?>">
+                                        <span class="selection"></span>
+                                        <div class="item-content">
+                                            <h5 class="ad-select-title"><?php echo esc_html( $item ); ?></h5>
+                                        </div>
+                                    </div>
+                                    <?php
+                                }
+                                ?>
+                            </div>
+
+                            <a class="view-more"><?php esc_html_e( 'View More', ERE_TEXT_DOMAIN ); ?></a>
+                            <a class="view-less"><?php esc_html_e( 'View Less', ERE_TEXT_DOMAIN ); ?></a>
+                            <?php
+                        }
+                    }
+                    ?>
+                </div>
+            </div>
+            <?php
+        }
+	}
+}
+
+
+if ( ! function_exists( 'ere_add_media_string' ) ) {
+	/**
+	 * Modify + Add Media string for gallery images and other metabox settings
+	 *
+	 * @since 2.0.3
+	 *
+	 * @return string
+	 */
+	function ere_add_media_string() {
+		return esc_html__( '+ Add Media', ERE_TEXT_DOMAIN );
+	}
+
+	add_filter( 'rwmb_media_add_string', 'ere_add_media_string' );
+
+}
+
+if ( ! function_exists( 'ere_email_template_styles' ) ) {
+	/**
+	 * RealHomes Email Templates Styles
+	 *
+	 * @since 2.1.1
+	 *
+	 * @return array
+	 */
+	function ere_email_template_styles() {
+
+		$email_styles                   = array();
+		$email_styles['header_content'] = get_option( 'ere_email_template_header_content', 'image' );
+		$email_styles['footer_text']    = get_option( 'ere_email_template_footer_text', '' );
+
+		// Getting Email Template Color Scheme
+		$email_color_scheme = get_option( 'ere_email_color_scheme', 'default' );
+
+		if ( 'default' == $email_color_scheme ) {
+
+			if ( 'ultra' === INSPIRY_DESIGN_VARIATION ) {
+
+				$email_styles['header_title_color'] = '#0ba3f2';
+				$email_styles['background_color']   = '#e7f6fd';
+				$email_styles['body_link_color']    = '#1db2ff';
+				$email_styles['footer_text_color']  = '#808080';
+				$email_styles['footer_link_color']  = '#1a1a1a';
+
+			} else if ( 'modern' === INSPIRY_DESIGN_VARIATION ) {
+
+				$email_styles['header_title_color'] = '#333333';
+				$email_styles['background_color']   = '#e9eaec';
+				$email_styles['body_link_color']    = '#0b8278';
+				$email_styles['footer_text_color']  = '#808080';
+				$email_styles['footer_link_color']  = '#1a1a1a';
+
+			} else if ( 'classic' === INSPIRY_DESIGN_VARIATION ) {
+
+				$email_styles['header_title_color'] = '#333333';
+				$email_styles['background_color']   = '#e9eaec';
+				$email_styles['body_link_color']    = '#ff7f50';
+				$email_styles['footer_text_color']  = '#aaaaaa';
+				$email_styles['footer_link_color']  = '#949494';
+
+			}
+
+		} else {
+
+			$email_styles['header_title_color'] = get_option( 'ere_email_template_header_title_color', '#333333' );
+			$email_styles['background_color']   = get_option( 'ere_email_template_background_color', '#e9eaec' );
+			$email_styles['body_link_color']    = get_option( 'ere_email_template_body_link_color', '#ff7f50' );
+			$email_styles['footer_text_color']  = get_option( 'ere_email_template_footer_text_color', '#aaaaaa' );
+			$email_styles['footer_link_color']  = get_option( 'ere_email_template_footer_link_color', '#949494' );
+
+		}
+
+		return $email_styles;
+	}
+
+}
+
+
+if ( ! function_exists( 'ere_get_users_by_approval_status' ) ) {
+	/**
+	 * This function is used to get the list of users with specific status or all
+     * By default the administrators are skipped unless $show_admin is stated as true
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string  $status
+	 * @param boolean $show_admin
+	 *
+	 * @return array|boolean
+	 */
+	function ere_get_users_by_approval_status( $status = 'all', $show_admin = false ) {
+
+		$user_args = array();
+
+		// Setting up meta query
+		if ( $status != 'all' ) {
+			$user_args['meta_query'] = array(
+				array(
+					'key'     => 'ere_user_approval_status',
+					'value'   => $status,
+					'compare' => '='
+				)
+			);
+		}
+
+		// skipping the administrators by default
+		if ( ! $show_admin ) {
+			$user_args['role__not_in'] = 'Administrator';
+		}
+
+		$users = get_users( $user_args );
+
+		if ( ! is_wp_error( $users ) ) {
+			return $users;
+		}
+
+		return false;
+	}
+}
+
+
+if ( ! function_exists( 'ere_get_user_approval_status' ) ) {
+	/**
+	 * Get the status of given user ID
+	 *
+	 * @since 2.2.0
+	 *
+     * @param int $user_id
+     *
+	 * @return string
+	 */
+	function ere_get_user_approval_status( $user_id ) {
+		$user_status = get_user_meta( $user_id, 'ere_user_approval_status', true );
+
+		if ( empty( $user_status ) ) {
+			return 'approved';
+		}
+
+		return $user_status;
+	}
+}
+
+if ( ! function_exists( 'ere_current_class' ) ) {
+	/**
+	 * Print or return given class in case the given target and needle are matched
+     * This is a helper function just like 'selected' or 'checked' php functions
+     * It is created to enter 'current' class based on matching needle and target strings
+     * It shortens the code and help when need multiple occurrences of this type of code
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string  $needle
+	 * @param string  $target
+	 * @param boolean $echo
+	 * @param string  $class_name
+	 *
+	 * @return mixed
+	 */
+	function ere_current_class( $needle, $target, $echo = true, $class_name = 'current' ) {
+
+		if ( $needle === $target ) {
+			if ( $echo ) {
+				echo $class_name;
+			} else {
+				return $class_name;
+			}
+		}
+
+		return null;
+	}
+}
+
+if ( ! function_exists( 'ere_admin_taxonomy_terms' ) ) {
+
+	/**
+	 * Comma separated taxonomy terms with admin side links.
+	 *
+	 * @since  1.0.0
+	 *
+	 * @param string $taxonomy  - Taxonomy name.
+	 * @param string $post_type - Post type.
+	 *
+	 * @param int    $post_id   - Post ID.
+	 *
+	 * @return string|bool
+	 */
+	function ere_admin_taxonomy_terms( $post_id, $taxonomy, $post_type ) {
+
+		$terms = get_the_terms( $post_id, $taxonomy );
+
+		if ( ! empty( $terms ) ) {
+			$out = array();
+			/* Loop through each term, linking to the 'edit posts' page for the specific term. */
+			foreach ( $terms as $term ) {
+				$out[] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url(
+						add_query_arg(
+							array(
+								'post_type' => $post_type,
+								$taxonomy   => $term->slug,
+							), 'edit.php'
+						)
+					),
+					esc_html( sanitize_term_field( 'name', $term->name, $term->term_id, $taxonomy, 'display' ) )
+				);
+			}
+
+			/* Join the terms, separating them with a comma. */
+
+			return join( ', ', $out );
+		}
+
+		return false;
+	}
+}
+
+
+/**
+ * Adds Easy Real Estate settings link to the admin bar.
+ *
+ * @since 2.2.2
+ *
+ * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
+ */
+function ere_add_settings_link_to_admin_bar( $wp_admin_bar ) {
+	// Only show to users who can manage options
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node( array(
+		'id'    => 'ere-settings',
+		'title' => esc_html__( 'ERE Settings', ERE_TEXT_DOMAIN ),
+		'href'  => admin_url( 'admin.php?page=ere-settings' ),
+		'meta'  => array(
+			'class' => 'ere-settings-toolbar',
+			'title' => esc_html__( 'Easy Real Estate Settings', ERE_TEXT_DOMAIN )
+		)
+	) );
+
+}
+
+add_action( 'admin_bar_menu', 'ere_add_settings_link_to_admin_bar', 100 );

--- a/wp-content/wp-content/plugins/easy-real-estate/includes/widgets/property-filters.php
+++ b/wp-content/wp-content/plugins/easy-real-estate/includes/widgets/property-filters.php
@@ -1,0 +1,1054 @@
+<?php
+/**
+ * Adds Properties Filter Widget
+ *
+ * @since 2.0.3
+ */
+
+if ( ! class_exists( 'Properties_Filter_Widget' ) ) {
+
+	class Properties_Filter_Widget extends WP_Widget {
+		/**
+		 * Registering widget with WordPress.
+		 */
+		public function __construct() {
+			parent::__construct(
+				'properties_filter_widget',
+				esc_html__( 'RealHomes - Properties Filter Widget', ERE_TEXT_DOMAIN ),
+				array(
+					'description' => esc_html__( 'This widget provides users with filter options to refine their search criteria for property listings templates.', ERE_TEXT_DOMAIN )
+				)
+			);
+		}
+
+		/**
+		 * Front-end display of widget.
+		 *
+		 * @param array $args     Widget arguments.
+		 * @param array $instance Saved values from database.
+		 *
+		 * @see WP_Widget::widget()
+		 *
+		 */
+		public function widget( $args, $instance ) {
+			extract( $args );
+			$title                 = apply_filters( 'widget_title', $instance['title'] );
+                        $property_types        = $instance['property-types'];
+                        $property_location     = $instance['property-location'];
+                        $location_terms        = ! empty( $instance['location-terms'] ) ? (array) $instance['location-terms'] : array();
+                        $property_categories   = $instance['property-categories'];
+                        $category_terms        = ! empty( $instance['category-terms'] ) ? (array) $instance['category-terms'] : array();
+                        $property_status       = $instance['property-status'];
+                        $property_features     = $instance['property-features'];
+			$checkboxes_view_limit = $instance['checkboxes-view-limit'];
+			$hide_empty            = $instance['hide_empty'];
+			$price_range           = $instance['price-ranges'];
+			$price_range_type      = $instance['price-range-type'];
+			$custom_price_ranges   = $instance['custom-price-ranges'];
+			$price_slider_min      = $instance['price-slider-min'];
+			$price_slider_max      = $instance['price-slider-max'];
+			$area_range            = $instance['area-ranges'];
+			$area_range_type       = $instance['area-range-type'];
+			$custom_area_ranges    = $instance['custom-area-ranges'];
+			$area_unit             = $instance['area-unit'];
+			$area_slider_min       = $instance['area-slider-min'];
+			$area_slider_max       = $instance['area-slider-max'];
+			$bedroom_options       = $instance['bedroom-options'];
+			$bedrooms_max_value    = $instance['bedrooms-max-value'];
+			$bathroom_options      = $instance['bathroom-options'];
+			$bathrooms_max_value   = $instance['bathrooms-max-value'];
+			$garage_options        = $instance['garage-options'];
+			$garages_max_value     = $instance['garages-max-value'];
+			$agent_options         = $instance['agent-options'];
+			$agent_display_type    = ! empty( $instance['agent-display-type'] ) ? $instance['agent-display-type'] : 'thumbnail';
+			$agency_options        = $instance['agency-options'];
+			$agency_display_type   = ! empty( $instance['agency-display-type'] ) ? $instance['agency-display-type'] : 'thumbnail';
+			$property_id           = $instance['property-id'];
+			$additional_fields     = $instance['additional-fields'];
+			$hide_empty            = filter_var( $hide_empty, FILTER_VALIDATE_BOOLEAN ); // making sure if provided val is bool
+			echo $before_widget;
+
+			if ( ! empty( $title ) ) {
+				echo '<h4 class="title filters-heading">' . esc_html( $title ) . '<i class="fa-duotone fa-filters"></i></h4>';
+			}
+
+			if ( ! is_page_template( 'templates/properties.php' ) ) {
+
+				echo '<p class="alert alert-error filters-wrong-template"><strong>' . esc_html__( 'Note:', ERE_TEXT_DOMAIN ) . '</strong> ' . esc_html__( 'The properties filters widget is specifically designed to work with properties listing templates and cannot be used on other types of pages.', ERE_TEXT_DOMAIN ) . '</p>';
+
+			} else if ( function_exists( 'realhomes_is_header_search_form_configured' ) && realhomes_is_header_search_form_configured() ) {
+
+				echo '<p class="alert alert-error filters-wrong-template"><strong>' . esc_html__( 'Note:', ERE_TEXT_DOMAIN ) . '</strong> ' . esc_html__( 'Advance Search is already enabled in the header. For the filters to work you need to disable the header search form as they do not work simultaneously.', ERE_TEXT_DOMAIN ) . '</p>';
+
+			} else {
+				?>
+                <div class="filters-widget-wrap">
+                    <div class="property-filters">
+                        <div class="collapse-button">
+                            <span class="pop-open-all hidden">
+                                <span class="button-text"><?php esc_html_e( 'Open All', ERE_TEXT_DOMAIN ); ?></span>&nbsp; <i class="fas fa-angle-double-down"></i>
+                            </span>
+                            <span class="pop-collapse-all">
+                                <span class="button-text"><?php esc_html_e( 'Collapse All', ERE_TEXT_DOMAIN ); ?></span>&nbsp; <i class="fas fa-angle-double-up"></i>
+                            </span>
+                        </div>
+						<?php
+						// Adding property type taxonomy filter
+						if ( $property_types === 'true' && ere_taxonomy_has_terms( 'property-type', $hide_empty ) ) {
+							?>
+                            <div class="filter-wrapper property-types">
+                                <h4><?php esc_html_e( 'Property Types', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section terms-list" data-taxonomy="types" data-display-title="<?php esc_html_e( 'Type', ERE_TEXT_DOMAIN ); ?>">
+									<?php
+									ere_process_filter_widget_taxonomies( 'property-type', $checkboxes_view_limit, $hide_empty );
+									?>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						// Adding property city taxonomy filter
+                                                if ( $property_location === 'true' && ere_taxonomy_has_terms( 'property-city', $hide_empty ) ) {
+                                                        ?>
+                            <div class="filter-wrapper property-locations">
+                                <h4><?php esc_html_e( 'Property Locations', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section terms-list" data-taxonomy="locations" data-display-title="<?php esc_html_e( 'Location', ERE_TEXT_DOMAIN ); ?>">
+                                                                        <?php
+                                                                        ere_process_filter_widget_taxonomies( 'property-city', $checkboxes_view_limit, $hide_empty, $location_terms );
+                                                                        ?>
+                                </div>
+                            </div>
+                                                        <?php
+                                                }
+
+                                                // Adding property category taxonomy filter
+                                                if ( $property_categories === 'true' && ere_taxonomy_has_terms( 'property-category', $hide_empty ) ) {
+                                                        ?>
+                            <div class="filter-wrapper property-categories">
+                                <h4><?php esc_html_e( 'Property Categories', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section terms-list" data-taxonomy="categories" data-display-title="<?php esc_html_e( 'Category', ERE_TEXT_DOMAIN ); ?>">
+                                                                        <?php
+                                                                        ere_process_filter_widget_taxonomies( 'property-category', $checkboxes_view_limit, $hide_empty, $category_terms );
+                                                                        ?>
+                                </div>
+                            </div>
+                                                        <?php
+                                                }
+
+                                                // Adding property status taxonomy filter
+                                                if ( $property_status === 'true' && ere_taxonomy_has_terms( 'property-status', $hide_empty ) ) {
+                                                        ?>
+                            <div class="filter-wrapper property-statuses">
+                                <h4><?php esc_html_e( 'Property Status', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section terms-list" data-taxonomy="statuses" data-display-title="<?php esc_html_e( 'Status', ERE_TEXT_DOMAIN ); ?>">
+                                                                        <?php
+                                                                        ere_process_filter_widget_taxonomies( 'property-status', $checkboxes_view_limit, $hide_empty );
+                                                                        ?>
+                                </div>
+                            </div>
+                                                        <?php
+                                                }
+
+						// Adding property features filter
+						if ( $property_features === 'true' && ere_taxonomy_has_terms( 'property-feature', $hide_empty ) ) {
+							?>
+                            <div class="filter-wrapper property-features">
+                                <h4><?php esc_html_e( 'Property Features', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section terms-list" data-taxonomy="features" data-display-title="<?php esc_html_e( 'Feature', ERE_TEXT_DOMAIN ); ?>">
+									<?php
+									ere_process_filter_widget_taxonomies( 'property-feature', $checkboxes_view_limit, $hide_empty );
+									?>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						// Adding price options
+						if ( $price_range === 'true' ) {
+							?>
+                            <div class="filter-wrapper price-ranges" data-price-range-type="<?php echo esc_attr( $price_range_type ); ?>">
+								<?php
+								if ( 'radio' == $price_range_type ) {
+									$price_ranges = array(
+										'1000 - 5000',
+										'5001 - 10000',
+										'10001 - 50000',
+										'50001 - 100000',
+										'100000 - 150000',
+										'150001 - 200000',
+										'200001 - 250000'
+									);
+
+									// If custom price ranges area set in widget settings
+									if ( ! empty( $custom_price_ranges ) ) {
+										$custom_prices_array = preg_split( '/\r\n|\r|\n/', $custom_price_ranges );
+										$price_ranges        = $custom_prices_array;
+									}
+
+									array_unshift( $price_ranges, esc_html__( 'All', ERE_TEXT_DOMAIN ) );
+									?>
+                                    <h4><?php esc_html_e( 'Price Ranges', ERE_TEXT_DOMAIN ); ?></h4>
+                                    <div class="filter-section range-list">
+										<?php
+										if ( is_array( $price_ranges ) ) {
+											foreach ( $price_ranges as $p_range ) {
+												$prices   = '';
+												$range_id = str_replace( ' ', '', $p_range );
+												if ( $p_range === 'All' ) {
+													$prices = $p_range;
+												} else {
+													$range_array = explode( ' - ', $p_range );
+													if ( 1 < count( $range_array ) && is_numeric( $range_array[0] ) && is_numeric( $range_array[1] ) ) {
+														$prices = ere_format_amount( $range_array[0] ) . ' - ' . ere_format_amount( $range_array[1] );
+													}
+												}
+												if ( ! empty( $prices ) ) {
+													?>
+                                                    <p class="radio-wrap" data-meta-name="price" data-display-title="<?php esc_html_e( 'Price', ERE_TEXT_DOMAIN ); ?>">
+                                                        <input type="radio" id="price-<?php echo esc_attr( $range_id ); ?>" data-display-value="<?php echo esc_attr( $prices ); ?>" name="price-range" value="<?php echo esc_attr( $p_range ); ?>">
+                                                        <label for="price-<?php echo esc_attr( $range_id ); ?>"><span class="radio-fancy"></span><?php echo esc_html( $prices ); ?></label>
+                                                    </p>
+													<?php
+												}
+											}
+										}
+										?>
+                                    </div>
+									<?php
+								} else {
+									?>
+                                    <h4><?php esc_html_e( 'Price Filter', ERE_TEXT_DOMAIN ); ?></h4>
+                                    <div class="filter-section range-slider price-range-slider" data-meta-name="price" data-display-title="<?php esc_html_e( 'Price', ERE_TEXT_DOMAIN ); ?>" data-values-sign="<?php echo ere_get_currency_sign(); ?>" data-sign-position="before">
+                                        <div class="ranges">
+                                            <span class="min-value price" data-range="<?php echo esc_attr( $price_slider_min ); ?>"><?php echo ere_format_amount( $price_slider_min ); ?></span>
+                                            <span class="max-value price" data-range="<?php echo esc_attr( $price_slider_max ); ?>"><?php echo ere_format_amount( $price_slider_max ); ?></span>
+                                        </div>
+                                        <div class="range-slider-trigger price-slider"></div>
+                                        <div class="current-values">
+                                            <span class="min-value"></span> - <span class="max-value"></span>
+                                        </div>
+                                    </div>
+									<?php
+								}
+								?>
+                            </div>
+							<?php
+						}
+
+						// Adding area options
+						if ( $area_range === 'true' ) {
+							?>
+                            <div class="filter-wrapper area-ranges">
+								<?php
+
+								if ( 'radio' == $area_range_type ) {
+									$area_ranges = array(
+										'50 - 100',
+										'101 - 500',
+										'501 - 1000',
+										'1001 - 5000',
+										'5001 - 10000'
+									);
+
+									// If custom area ranges area set in widget settings
+									if ( ! empty( $custom_area_ranges ) ) {
+										$custom_areas_array = preg_split( '/\r\n|\r|\n/', $custom_area_ranges );
+										$area_ranges        = $custom_areas_array;
+									}
+
+									array_unshift( $area_ranges, esc_html__( 'All', ERE_TEXT_DOMAIN ) );
+									?>
+                                    <h4><?php esc_html_e( 'Area Ranges', ERE_TEXT_DOMAIN ); ?></h4>
+                                    <div class="filter-section range-list">
+										<?php
+										if ( is_array( $area_ranges ) ) {
+											foreach ( $area_ranges as $a_range ) {
+												$areas    = '';
+												$range_id = str_replace( ' ', '', $a_range );
+												if ( $a_range === 'All' ) {
+													$areas = $a_range;
+												} else {
+													$range_array = explode( ' - ', $a_range );
+													if ( 1 < count( $range_array ) && is_numeric( $range_array[0] ) && is_numeric( $range_array[1] ) ) {
+														$areas = $range_array[0] . ' <sub>' . $area_unit . '</sub>' . ' - ' . $range_array[1] . ' <sub>' . $area_unit . '</sub>';
+													}
+												}
+
+												if ( ! empty( $areas ) ) {
+													?>
+                                                    <p class="radio-wrap" data-meta-name="area" data-display-title="<?php esc_html_e( 'Area', ERE_TEXT_DOMAIN ); ?>">
+                                                        <input type="radio" id="area-<?php echo esc_attr( $range_id ); ?>" data-display-value="<?php echo wp_kses_post( $areas ); ?>" name="area-range" value="<?php echo esc_attr( $a_range ); ?>">
+                                                        <label for="area-<?php echo esc_attr( $range_id ); ?>"><span class="radio-fancy"></span><?php echo wp_kses_post( $areas ); ?></label>
+                                                    </p>
+													<?php
+												}
+											}
+										}
+										?>
+                                    </div>
+									<?php
+								} else {
+									?>
+                                    <h4><?php esc_html_e( 'Area Filter', ERE_TEXT_DOMAIN ); ?></h4>
+                                    <div class="filter-section range-slider area-range-slider" data-meta-name="area" data-display-title="<?php esc_html_e( 'Area', ERE_TEXT_DOMAIN ); ?>" data-values-sign=" <?php echo esc_attr( $area_unit ); ?>" data-sign-position="after" data-min-trigger-key="minArea" data-max-trigger-key="maxArea">
+                                        <div class="ranges">
+                                            <span class="min-value area" data-range="<?php echo esc_attr( $area_slider_min ); ?>"><?php echo esc_attr( $area_slider_min . ' ' . $area_unit ); ?></span>
+                                            <span class="max-value area" data-range="<?php echo esc_attr( $area_slider_max ); ?>"><?php echo esc_attr( $area_slider_max . ' ' . $area_unit ); ?></span>
+                                        </div>
+                                        <div class="range-slider-trigger area-slider"></div>
+                                        <div class="current-values">
+                                            <span class="min-value"></span> - <span class="max-value"></span>
+                                        </div>
+                                    </div>
+									<?php
+								}
+								?>
+                            </div>
+							<?php
+						}
+
+						if ( post_type_exists( 'agent' ) ) {
+							$agent_posts = wp_count_posts( 'agent' );
+							if ( $agent_options === 'true' && intval( $agent_posts->publish ) > 0 ) {
+								$agents_arguments = array(
+									'post_type'       => 'agent',
+									'view_limit'      => $checkboxes_view_limit,
+									'wrapper_classes' => 'agent-options',
+									'section_title'   => esc_html__( 'Agents', ERE_TEXT_DOMAIN ),
+									'display_type'    => $agent_display_type,
+									'display_title'   => esc_html__( 'Agent', ERE_TEXT_DOMAIN ),
+									'target_id'       => 'agent'
+								);
+								ere_process_filter_widget_post_types( $agents_arguments );
+							}
+						}
+
+						if ( post_type_exists( 'agency' ) ) {
+							$agency_posts = wp_count_posts( 'agency' );
+							if ( $agency_options === 'true' && intval( $agency_posts->publish ) > 0 ) {
+								$agency_arguments = array(
+									'post_type'       => 'agency',
+									'view_limit'      => $checkboxes_view_limit,
+									'wrapper_classes' => 'agency-options',
+									'section_title'   => esc_html__( 'Agencies', ERE_TEXT_DOMAIN ),
+									'display_type'    => $agency_display_type,
+									'display_title'   => esc_html__( 'Agency', ERE_TEXT_DOMAIN ),
+									'target_id'       => 'agencies',
+									'thumb_placeholder' => get_template_directory_uri() . '/common/images/agency-placeholder.png'
+								);
+								ere_process_filter_widget_post_types( $agency_arguments );
+							}
+						}
+
+						if ( $bedroom_options === 'true' ) {
+							?>
+                            <div class="filter-wrapper radio-buttons">
+                                <h4><?php esc_html_e( 'Min Bedrooms', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section buttons-list" data-meta-name="bedrooms" data-display-title="<?php esc_html_e( 'Min Beds', ERE_TEXT_DOMAIN ); ?>">
+                                    <div class="number-option-wrap bedroom-options">
+                                        <span class="option-num">
+                                            <input type="radio" name="min-bedrooms" id="min-bedroom-all" value="0" checked>
+                                            <label for="min-bedroom-all"><?php esc_html_e( 'All', ERE_TEXT_DOMAIN ) ?></label>
+                                        </span>
+										<?php
+										if ( empty( $bedrooms_max_value ) || 0 > intval( $bedrooms_max_value ) ) {
+											$bedrooms_max_value = 9;
+										}
+										for ( $bed = 1; $bed <= $bedrooms_max_value; $bed++ ) {
+											?>
+                                            <span class="option-num">
+                                                <input type="radio" name="min-bedrooms" id="min-bedroom-<?php echo esc_attr( $bed ); ?>" value="<?php echo esc_html( $bed ); ?>">
+                                                <label for="min-bedroom-<?php echo esc_attr( $bed ); ?>"><?php echo esc_html( $bed ); ?></label>
+                                            </span>
+											<?php
+										}
+										?>
+                                    </div>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						if ( $bathroom_options === 'true' ) {
+							?>
+                            <div class="filter-wrapper radio-buttons">
+                                <h4><?php esc_html_e( 'Min Bathrooms', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section buttons-list" data-meta-name="bathrooms" data-display-title="<?php esc_html_e( 'Min Baths', ERE_TEXT_DOMAIN ); ?>">
+                                    <div class="number-option-wrap bathroom-options">
+                                        <span class="option-num">
+                                            <input type="radio" name="min-bathrooms" id="min-bathroom-all" value="0" checked>
+                                            <label for="min-bathroom-all"><?php esc_html_e( 'All', ERE_TEXT_DOMAIN ) ?></label>
+                                        </span>
+										<?php
+										if ( empty( $bathrooms_max_value ) || 0 > intval( $bathrooms_max_value ) ) {
+											$bathrooms_max_value = 12;
+										}
+										for ( $bath = 1; $bath <= $bathrooms_max_value; $bath++ ) {
+											?>
+                                            <span class="option-num">
+                                                <input type="radio" name="min-bathrooms" id="min-bathroom-<?php echo esc_attr( $bath ); ?>" value="<?php echo esc_html( $bath ); ?>">
+                                                <label for="min-bathroom-<?php echo esc_attr( $bath ); ?>"><?php echo esc_html( $bath ); ?></label>
+                                            </span>
+											<?php
+										}
+										?>
+                                    </div>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						if ( $garage_options === 'true' ) {
+							?>
+                            <div class="filter-wrapper radio-buttons">
+                                <h4><?php esc_html_e( 'Min Garages', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section buttons-list" data-meta-name="garages" data-display-title="<?php esc_html_e( 'Min Garages', ERE_TEXT_DOMAIN ); ?>">
+                                    <div class="number-option-wrap garage-options">
+                                        <span class="option-num">
+                                            <input type="radio" name="min-garages" id="min-garage-all" value="0" checked>
+                                            <label for="min-garage-all"><?php esc_html_e( 'All', ERE_TEXT_DOMAIN ) ?></label>
+                                        </span>
+										<?php
+										if ( empty( $garages_max_value ) || 0 > intval( $garages_max_value ) ) {
+											$garages_max_value = 5;
+										}
+										for ( $garage = 1; $garage <= $garages_max_value; $garage++ ) {
+											?>
+                                            <span class="option-num">
+                                                <input type="radio" name="min-garages" id="min-garage-<?php echo esc_attr( $garage ); ?>" value="<?php echo esc_html( $garage ); ?>">
+                                                <label for="min-garage-<?php echo esc_attr( $garage ); ?>"><?php echo esc_html( $garage ); ?></label>
+                                            </span>
+											<?php
+										}
+										?>
+                                    </div>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						if ( $property_id === 'true' ) {
+							?>
+                            <div class="filter-wrapper input-wrapper">
+                                <h4 for="property-id"><?php esc_html_e( 'Property ID', ERE_TEXT_DOMAIN ); ?></h4>
+                                <div class="filter-section input-filter" data-meta-name="propertyID" data-display-title="<?php esc_html_e( 'Property ID', ERE_TEXT_DOMAIN ); ?>">
+                                    <p class="input-wrap" data-meta-name="propertyID">
+                                        <input type="text" id="property-id" name="property-id" placeholder="<?php esc_html_e( 'Any', ERE_TEXT_DOMAIN ); ?>">
+                                    </p>
+                                </div>
+                            </div>
+							<?php
+						}
+
+						// Adding additional meta details
+						if ( $additional_fields === 'true' ) {
+							$additional_fields = get_option( 'inspiry_property_additional_fields' );
+
+							if ( isset( $additional_fields['inspiry_additional_fields_list'] ) && 0 < count( $additional_fields['inspiry_additional_fields_list'] ) ) {
+								$additional_fields = $additional_fields['inspiry_additional_fields_list'];
+								if ( is_array( $additional_fields ) && 0 < count( $additional_fields ) && ere_new_field_for_section( 'filters_widget', $additional_fields ) ) {
+									?>
+                                    <div class="filter-wrapper additional-fields">
+                                        <h4><?php esc_html_e( 'Additional Details', ERE_TEXT_DOMAIN ); ?></h4>
+                                        <div class="filter-section additional-items" data-meta-name="additional-fields">
+											<?php
+											foreach ( $additional_fields as $field ) {
+												$field_name    = $field['field_name'] ?? '';
+												$field_type    = $field['field_type'] ?? '';
+												$field_display = $field['field_display'] ?? '';
+
+												if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+													$field_reg_name  = $field_name . ' Label';
+													$field_reg_value = $field_name . ' Value';
+													$field_name      = apply_filters( 'wpml_translate_single_string', $field_name, 'Additional Fields', $field_reg_name, ICL_LANGUAGE_CODE );
+												}
+
+												// Checking if this field is allowed to be displayed here
+												if ( is_array( $field_display ) && in_array( 'filters_widget', $field_display ) ) {
+													$field_slug = 'inspiry_' . strtolower( str_replace( ' ', '_', $field_name ) );
+													?>
+                                                    <div class="additional-item <?php echo esc_attr( $field_slug );
+													echo ' ad-' . esc_attr( $field_type ) . '-wrap'; ?>">
+														<?php
+														if ( $field_type === 'text' ) {
+															?>
+                                                            <p class="input-wrap input-filter" data-field-name="<?php echo esc_attr( $field_name ); ?>">
+                                                                <label for="<?php echo esc_attr( $field_slug ); ?>"><?php echo esc_html( $field_name ); ?></label>
+                                                                <input type="text" id="<?php echo esc_attr( $field_slug ); ?>" name="<?php echo esc_attr( $field_slug ); ?>" placeholder="<?php esc_html_e( 'Any', ERE_TEXT_DOMAIN ); ?>" value="">
+                                                            </p>
+															<?php
+														} else if ( $field_type === 'select' ) {
+															$field_options = $field['field_options'];
+															if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+																$field_options = apply_filters( 'wpml_translate_single_string', $field_options, 'Additional Fields', $field_reg_value, ICL_LANGUAGE_CODE );
+															}
+															$field_options = explode( ', ', $field_options );
+
+															if ( ! empty( $field['multi_select'] ) && 'yes' === $field['multi_select'] ) {
+																ere_process_filter_widget_tiles(
+																	array(
+																		'items_array'     => $field_options,
+																		'selection_type'  => 'multiselect',
+																		'view_limit'      => $checkboxes_view_limit,
+																		'wrapper_classes' => 'items-list multi-select-wrap',
+																		'section_title'   => $field_name,
+																		'meta_key'        => $field_slug,
+																		'display_type'    => $agency_display_type,
+																		'target_id'       => 'check-list'
+																	)
+																);
+															} else {
+																if ( is_array( $field_options ) && 0 < count( $field_options ) ) {
+																	?>
+                                                                    <p class="select-wrap select-filter" data-field-name="<?php echo esc_attr( $field_name ); ?>" data-field-type="<?php echo esc_attr( $field_type ); ?>">
+                                                                        <label for="<?php echo esc_attr( $field_slug ); ?>"><?php echo esc_html( $field_name ); ?></label>
+                                                                        <select name="<?php echo esc_attr( $field_slug ); ?>" id="<?php echo esc_attr( $field_slug ); ?>">
+                                                                            <option value=""><?php esc_html_e( 'None', ERE_TEXT_DOMAIN ); ?></option>
+																			<?php
+																			foreach ( $field_options as $option ) {
+																				$option_slug = strtolower( str_replace( ' ', '-', $option ) );
+																				?>
+                                                                                <option value="<?php echo esc_attr( $option_slug ); ?>" id="<?php echo esc_attr( $field_slug ) . '-' . esc_attr( $option_slug ); ?>"><?php echo esc_html( $option ); ?></option>
+																				<?php
+																			}
+																			?>
+                                                                        </select>
+                                                                    </p>
+																	<?php
+																}
+															}
+														} else if ( $field_type === 'radio' ) {
+															$field_options = $field['field_options'];
+
+															if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+																$field_options = apply_filters( 'wpml_translate_single_string', $field_options, 'Additional Fields', $field_reg_value, ICL_LANGUAGE_CODE );
+															}
+
+															$field_options = explode( ', ', $field_options );
+															?>
+                                                            <div class="radio-filter" data-field-name="<?php echo esc_attr( $field_name ); ?>" data-field-slug="<?php echo esc_attr( $field_slug ); ?>">
+                                                                <h5><?php echo esc_html( $field_name ); ?></h5>
+                                                                <p class="radio-wrap">
+                                                                    <input type="radio" id="<?php echo esc_attr( $field_slug ); ?>-none" name="<?php echo esc_attr( $field_slug ); ?>" value="">
+                                                                    <label for="<?php echo esc_attr( $field_slug ); ?>-none"><span class="radio-fancy"></span> <?php esc_html_e( 'None', ERE_TEXT_DOMAIN ); ?></label>
+                                                                </p>
+																<?php
+																foreach ( $field_options as $option ) {
+																	$option_slug = strtolower( str_replace( ' ', '-', $option ) );
+																	?>
+                                                                    <p class="radio-wrap">
+                                                                        <input type="radio" id="<?php echo esc_attr( $option_slug ); ?>" name="<?php echo esc_attr( $field_slug ); ?>" value="<?php echo esc_attr( $option ); ?>">
+                                                                        <label for="<?php echo esc_attr( $option_slug ); ?>"><span class="radio-fancy"></span> <?php echo esc_attr( $option ); ?></label>
+                                                                    </p>
+																	<?php
+																}
+																?>
+                                                            </div>
+															<?php
+														} else if ( $field_type === 'checkbox_list' ) {
+															$field_options = $field['field_options'];
+
+															if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+																$field_options = apply_filters( 'wpml_translate_single_string', $field_options, 'Additional Fields', $field_reg_value, ICL_LANGUAGE_CODE );
+															}
+
+															$field_options = explode( ', ', $field_options );
+															?>
+                                                            <div class="checkbox-wrap checkbox-filter" data-field-name="<?php echo esc_attr( $field_name ); ?>" data-field-slug="<?php echo esc_attr( $field_slug ); ?>">
+                                                                <h5><?php echo esc_html( $field_name ); ?></h5>
+																<?php
+																foreach ( $field_options as $option ) {
+																	$option_slug = strtolower( str_replace( ' ', '-', $option ) );
+																	?>
+                                                                    <p class="cb-wrap" data-field-name="<?php echo esc_attr( $field_name ); ?>">
+                                                                        <input type="checkbox" id="<?php echo esc_attr( $option_slug ); ?>" name="<?php echo esc_attr( $field_slug ); ?>" value="<?php echo esc_attr( $option ); ?>">
+                                                                        <label for="<?php echo esc_attr( $option_slug ); ?>"><?php echo esc_attr( $option ); ?><i>&#10003;</i></label>
+                                                                    </p>
+																	<?php
+																}
+																?>
+                                                            </div>
+															<?php
+														} else if ( $field_type === 'textarea' ) {
+															?>
+                                                            <p class="input-wrap input-filter" data-field-name="<?php echo esc_attr( $field_name ); ?>">
+                                                                <label for="<?php echo esc_attr( $field_slug ); ?>"><?php echo esc_html( $field_name ); ?></label>
+                                                                <input type="text" id="<?php echo esc_attr( $field_slug ); ?>" name="<?php echo esc_attr( $field_slug ); ?>" placeholder="<?php esc_html_e( 'Any', ERE_TEXT_DOMAIN ); ?>">
+                                                            </p>
+															<?php
+														}
+														?>
+                                                    </div>
+													<?php
+												}
+											}
+											?>
+                                        </div>
+                                    </div>
+									<?php
+								}
+							}
+						}
+						?>
+                    </div> <!-- .property-filters -->
+                </div>
+
+				<?php
+				do_action( 'realhomes_after_filter_properties_widget' );
+			}
+
+			echo $after_widget;
+		}
+
+		/**
+		 * Back-end widget form.
+		 *
+		 * @param array $instance Previously saved values from database.
+		 *
+		 * @see WP_Widget::form()
+		 *
+		 */
+		public function form( $instance ) {
+
+			$title                 = ! empty( $instance['title'] ) ? $instance['title'] : esc_html__( 'Filter Properties', ERE_TEXT_DOMAIN );
+			$hide_empty            = $instance['hide_empty'] ?? 'false';
+			$property_types        = $instance['property-types'] ?? 'true';
+                        $property_location     = $instance['property-location'] ?? 'true';
+                        $location_terms        = $instance['location-terms'] ?? array();
+                        $property_categories   = $instance['property-categories'] ?? 'true';
+                        $category_terms        = $instance['category-terms'] ?? array();
+                        $property_status       = $instance['property-status'] ?? 'true';
+                        $property_features     = $instance['property-features'] ?? 'true';
+			$checkboxes_view_limit = $instance['checkboxes-view-limit'] ?? 6;
+			$price_ranges          = $instance['price-ranges'] ?? 'true';
+			$price_range_type      = $instance['price-range-type'] ?? 'radio';
+			$custom_price_ranges   = $instance['custom-price-ranges'] ?? '';
+			$price_slider_min      = $instance['price-slider-min'] ?? '';
+			$price_slider_max      = $instance['price-slider-max'] ?? '';
+			$area_ranges           = $instance['area-ranges'] ?? 'true';
+			$area_range_type       = $instance['area-range-type'] ?? 'radio';
+			$custom_area_ranges    = $instance['custom-area-ranges'] ?? '';
+			$area_slider_min       = $instance['area-slider-min'] ?? '';
+			$area_slider_max       = $instance['area-slider-max'] ?? '';
+			$area_unit             = $instance['area-unit'] ?? 'sq ft';
+			$bedrooms_options      = $instance['bedroom-options'] ?? 'true';
+			$bedrooms_max_value    = $instance['bedrooms-max-value'] ?? 9;
+			$bathrooms_options     = $instance['bathroom-options'] ?? 'true';
+			$bathrooms_max_value   = $instance['bathrooms-max-value'] ?? 9;
+			$garages_options       = $instance['garage-options'] ?? 'true';
+			$garages_max_value     = $instance['garages-max-value'] ?? 4;
+			$agent_options         = $instance['agent-options'] ?? 'true';
+			$agent_display_type    = $instance['agent-display-type'] ?? 'thumbnail';
+			$agency_options        = $instance['agency-options'] ?? 'true';
+			$agency_display_type   = $instance['agency-display-type'] ?? 'thumbnail';
+			$property_id           = $instance['property-id'] ?? 'true';
+			$additional_fields     = $instance['additional-fields'] ?? 'true';
+			?>
+            <p>
+                <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title' ); ?></label>
+                <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+            </p>
+
+            <hr>
+
+            <h4><?php esc_html_e( 'Show/Hide Taxonomies', ERE_TEXT_DOMAIN ); ?></h4>
+
+            <p class="fancy-checkbox-option-button property-type-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property Type', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-types' ); ?>" name="<?php echo $this->get_field_name( 'property-types' ); ?>" value="true" <?php echo checked( $property_types, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-types' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="fancy-checkbox-option-button property-location-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property Location', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-location' ); ?>" name="<?php echo $this->get_field_name( 'property-location' ); ?>" value="true" <?php echo checked( $property_location, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-location' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="location-terms-wrapper">
+                <label for="<?php echo $this->get_field_id( 'location-terms' ); ?>"><?php esc_html_e( 'Select Locations', ERE_TEXT_DOMAIN ); ?></label>
+                <select class="widefat" multiple id="<?php echo $this->get_field_id( 'location-terms' ); ?>" name="<?php echo $this->get_field_name( 'location-terms' ); ?>[]">
+                                        <?php
+                                        $locations = get_terms( array( 'taxonomy' => 'property-city', 'hide_empty' => false ) );
+                                        if ( ! is_wp_error( $locations ) ) {
+                                                foreach ( $locations as $loc ) {
+                                                        $selected = in_array( $loc->term_id, (array) $location_terms ) ? 'selected' : '';
+                                                        echo '<option value="' . esc_attr( $loc->term_id ) . '" ' . esc_attr( $selected ) . '>' . esc_html( $loc->name ) . '</option>';
+                                                }
+                                        }
+                                        ?>
+                </select>
+                <span class="description"><?php esc_html_e( 'Choose which locations appear in filters.', ERE_TEXT_DOMAIN ); ?></span>
+            </p>
+
+            <p class="fancy-checkbox-option-button property-categories-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property Categories', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-categories' ); ?>" name="<?php echo $this->get_field_name( 'property-categories' ); ?>" value="true" <?php echo checked( $property_categories, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-categories' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="category-terms-wrapper">
+                <label for="<?php echo $this->get_field_id( 'category-terms' ); ?>"><?php esc_html_e( 'Select Categories', ERE_TEXT_DOMAIN ); ?></label>
+                <select class="widefat" multiple id="<?php echo $this->get_field_id( 'category-terms' ); ?>" name="<?php echo $this->get_field_name( 'category-terms' ); ?>[]">
+                                        <?php
+                                        $categories = get_terms( array( 'taxonomy' => 'property-category', 'hide_empty' => false ) );
+                                        if ( ! is_wp_error( $categories ) ) {
+                                                foreach ( $categories as $cat ) {
+                                                        $selected = in_array( $cat->term_id, (array) $category_terms ) ? 'selected' : '';
+                                                        echo '<option value="' . esc_attr( $cat->term_id ) . '" ' . esc_attr( $selected ) . '>' . esc_html( $cat->name ) . '</option>';
+                                                }
+                                        }
+                                        ?>
+                </select>
+                <span class="description"><?php esc_html_e( 'Choose which categories appear in filters.', ERE_TEXT_DOMAIN ); ?></span>
+            </p>
+
+            <p class="fancy-checkbox-option-button property-status-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property Status', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-status' ); ?>" name="<?php echo $this->get_field_name( 'property-status' ); ?>" value="true" <?php echo checked( $property_status, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-status' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="fancy-checkbox-option-button property-features-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property Features', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-features' ); ?>" name="<?php echo $this->get_field_name( 'property-features' ); ?>" value="true" <?php echo checked( $property_features, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-features' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p>
+                <label for="<?php echo esc_attr( $this->get_field_id( 'hide_empty' ) ); ?>"><?php esc_html_e( 'Hide Empty Taxonomies', ERE_TEXT_DOMAIN ); ?></label><br>
+                <select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'hide_empty' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'hide_empty' ) ); ?>">
+                    <option value="true" <?php echo selected( 'true', $hide_empty ); ?>><?php esc_html_e( 'True', ERE_TEXT_DOMAIN ) ?></option>
+                    <option value="false" <?php echo selected( 'false', $hide_empty ); ?>><?php esc_html_e( 'False', ERE_TEXT_DOMAIN ) ?></option>
+                </select>
+            </p>
+
+            <p>
+                <label for="<?php echo $this->get_field_id( 'checkboxes-view-limit' ); ?>"><?php esc_html_e( 'Checkboxes View Limit', ERE_TEXT_DOMAIN ); ?></label><br>
+                <input class="widefat" type="number" id="<?php echo $this->get_field_id( 'checkboxes-view-limit' ); ?>" name="<?php echo $this->get_field_name( 'checkboxes-view-limit' ); ?>" value="<?php echo esc_attr( $checkboxes_view_limit ); ?>">
+            </p>
+
+            <hr>
+
+            <p class="fancy-checkbox-option-button price-ranges-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Price Ranges', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'price-ranges' ); ?>" name="<?php echo $this->get_field_name( 'price-ranges' ); ?>" value="true" <?php echo checked( $price_ranges, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'price-ranges' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <div class="fancy-radio-options price-range-type-wrapper">
+                <br>
+                <strong class="widget-field-40 fancy-field-title"><?php esc_html_e( 'Price Range Type', ERE_TEXT_DOMAIN ); ?></strong>
+                <div class="option-align-right">
+                    <span class="buttons-wrap">
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'price-range-type' ); ?>" id="<?php echo $this->get_field_id( 'price-range-type-radio' ); ?>" value="radio" <?php echo checked( $price_range_type, 'radio' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'price-range-type-radio' ); ?>"><?php esc_html_e( 'Radio Options', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'price-range-type' ); ?>" id="<?php echo $this->get_field_id( 'price-range-type-slider' ); ?>" value="slider" <?php echo checked( $price_range_type, 'slider' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'price-range-type-slider' ); ?>"><?php esc_html_e( 'Slider Controls', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                    </span>
+                </div>
+            </div>
+
+            <div id="price-ranges" class="clearfix custom-price-ranges-wrapper option-dependent-control">
+                <p class="widget-fat">
+                    <label for="<?php echo $this->get_field_id( 'custom-price-ranges' ); ?>-default"><?php esc_html_e( 'Custom Price Ranges (optional)', ERE_TEXT_DOMAIN ); ?></label>
+                    <textarea class="widefat" id="<?php echo $this->get_field_id( 'custom-price-ranges' ); ?>" name="<?php echo $this->get_field_name( 'custom-price-ranges' ); ?>" type="radio"><?php echo esc_html( $custom_price_ranges ); ?></textarea>
+                    <span class="description"><?php esc_html_e( 'Leave this area empty for default values. Put each range in new line in the given format. ( i.e. 5000 - 10000 )', ERE_TEXT_DOMAIN ); ?></span>
+                </p>
+            </div>
+
+            <div class="price-min-max-wrap option-dependent-control">
+                <p class="widget-field-half">
+                    <label for="<?php echo $this->get_field_id( 'price-slider-min' ); ?>"><?php esc_html_e( 'Price Slider Min', ERE_TEXT_DOMAIN ); ?></label><br>
+                    <input type="text" id="<?php echo $this->get_field_id( 'price-slider-min' ); ?>" name="<?php echo $this->get_field_name( 'price-slider-min' ); ?>" value="<?php echo esc_attr( $price_slider_min ); ?>"><br>
+                </p>
+                <p class="widget-field-half">
+                    <label for="<?php echo $this->get_field_id( 'price-slider-min' ); ?>"><?php esc_html_e( 'Price Slider Max', ERE_TEXT_DOMAIN ); ?></label><br>
+                    <input type="text" id="<?php echo $this->get_field_id( 'price-slider-max' ); ?>" name="<?php echo $this->get_field_name( 'price-slider-max' ); ?>" value="<?php echo esc_attr( $price_slider_max ); ?>">
+                </p>
+            </div>
+
+            <hr>
+
+            <p class="fancy-checkbox-option-button area-ranges-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Area Ranges', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_name( 'area-ranges' ); ?>" name="<?php echo $this->get_field_name( 'area-ranges' ); ?>" value="true" <?php echo checked( $area_ranges, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_name( 'area-ranges' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="area-unit-wrapper">
+                <label for="<?php echo $this->get_field_id( 'area-unit' ); ?>"><?php esc_html_e( 'Area Unit', ERE_TEXT_DOMAIN ); ?></label><br>
+                <input class="widefat" type="text" id="<?php echo $this->get_field_id( 'area-unit' ); ?>" name="<?php echo $this->get_field_name( 'area-unit' ); ?>" value="<?php echo esc_attr( $area_unit ); ?>">
+            </p>
+
+            <div class="fancy-radio-options area-range-type-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Area Range Type', ERE_TEXT_DOMAIN ); ?></strong>
+                <div class="option-align-right">
+                    <span class="buttons-wrap">
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'area-range-type' ); ?>" id="<?php echo $this->get_field_id( 'area-range-type-radio' ); ?>" value="radio" <?php echo checked( $area_range_type, 'radio' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'area-range-type-radio' ); ?>"><?php esc_html_e( 'Radio Options', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'area-range-type' ); ?>" id="<?php echo $this->get_field_id( 'area-range-type-slider' ); ?>" value="slider" <?php echo checked( $area_range_type, 'slider' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'area-range-type-slider' ); ?>"><?php esc_html_e( 'Slider Controls', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                    </span>
+                </div>
+            </div>
+
+            <div id="area-ranges" class="clearfix custom-area-ranges-wrapper option-dependent-control">
+                <p class="widget-fat">
+                    <label for="<?php echo $this->get_field_id( 'custom-area-ranges' ); ?>-default"><?php esc_html_e( 'Custom Area Ranges (optional)', ERE_TEXT_DOMAIN ); ?></label>
+                    <textarea class="widefat" id="<?php echo $this->get_field_id( 'custom-area-ranges' ); ?>" name="<?php echo $this->get_field_name( 'custom-area-ranges' ); ?>" type="radio"><?php echo esc_html( $custom_area_ranges ); ?></textarea>
+                    <span class="description"><?php esc_html_e( 'Leave this area empty for default values. Put each range in new line in the given format. ( i.e. 200 - 400 )', ERE_TEXT_DOMAIN ); ?></span>
+                </p>
+            </div>
+
+            <div class="area-min-max-wrap option-dependent-control <?php echo $area_range_type == 'radio' ? 'hidden' : ''; ?>">
+                <p class="widget-field-half">
+                    <label for="<?php echo $this->get_field_id( 'area-slider-min' ); ?>"><?php esc_html_e( 'Area Slider Min', ERE_TEXT_DOMAIN ); ?></label><br>
+                    <input type="text" id="<?php echo $this->get_field_id( 'area-slider-min' ); ?>" name="<?php echo $this->get_field_name( 'area-slider-min' ); ?>" value="<?php echo esc_attr( $area_slider_min ); ?>"><br>
+                </p>
+                <p class="widget-field-half">
+                    <label for="<?php echo $this->get_field_id( 'area-slider-max' ); ?>"><?php esc_html_e( 'Area Slider Max', ERE_TEXT_DOMAIN ); ?></label><br>
+                    <input type="text" id="<?php echo $this->get_field_id( 'area-slider-max' ); ?>" name="<?php echo $this->get_field_name( 'area-slider-max' ); ?>" value="<?php echo esc_attr( $area_slider_max ); ?>">
+                </p>
+            </div>
+
+            <hr>
+
+			<?php
+			if ( post_type_exists( 'agent' ) ) {
+				?>
+                <p class="fancy-checkbox-option-button agent-options-wrapper">
+                    <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Agent Options', ERE_TEXT_DOMAIN ); ?></strong>
+                    <input type="checkbox" id="<?php echo $this->get_field_id( 'agent-options' ); ?>" name="<?php echo $this->get_field_name( 'agent-options' ); ?>" value="true" <?php echo checked( $agent_options, 'true' ); ?>>
+                    <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'agent-options' ); ?>">
+                        <span class="cb-btn-wrapper">
+                            <span class="cb-btn-trigger"></span>
+                        </span>
+                    </label>
+                </p>
+
+                <div class="fancy-radio-options agent-display-type-wrapper">
+                    <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Display Type', ERE_TEXT_DOMAIN ); ?></strong>
+                    <div class="option-align-right">
+                        <span class="buttons-wrap">
+                            <span class="inner-buttons">
+                                <input type="radio" name="<?php echo $this->get_field_name( 'agent-display-type' ); ?>" id="<?php echo $this->get_field_id( 'agent-display-type-thumbnails' ); ?>" value="thumbnail" <?php echo checked( $agent_display_type, 'thumbnail' ); ?>>
+                                <label for="<?php echo $this->get_field_id( 'agent-display-type-thumbnails' ); ?>"><?php esc_html_e( 'Thumbnails', ERE_TEXT_DOMAIN ); ?></label>
+                            </span>
+                            <span class="inner-buttons">
+                                <input type="radio" name="<?php echo $this->get_field_name( 'agent-display-type' ); ?>" id="<?php echo $this->get_field_id( 'agent-display-type-checkboxes' ); ?>" value="checkbox" <?php echo checked( $agent_display_type, 'checkbox' ); ?>>
+                                <label for="<?php echo $this->get_field_id( 'agent-display-type-checkboxes' ); ?>"><?php esc_html_e( 'Checkboxes', ERE_TEXT_DOMAIN ); ?></label>
+                            </span>
+                        </span>
+                    </div>
+                </div>
+
+                <hr>
+				<?php
+			}
+
+			if ( post_type_exists( 'agency' ) ) {
+				?>
+                <p class="fancy-checkbox-option-button agency-options-wrapper">
+                    <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Agency Options', ERE_TEXT_DOMAIN ); ?></strong>
+                    <input type="checkbox" id="<?php echo $this->get_field_id( 'agency-options' ); ?>" name="<?php echo $this->get_field_name( 'agency-options' ); ?>" value="true" <?php echo checked( $agency_options, 'true' ); ?>>
+                    <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'agency-options' ); ?>">
+                        <span class="cb-btn-wrapper">
+                            <span class="cb-btn-trigger"></span>
+                        </span>
+                    </label>
+                </p>
+
+                <div class="fancy-radio-options agency-display-type-wrapper">
+                    <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Display Type', ERE_TEXT_DOMAIN ); ?></strong>
+                    <div class="option-align-right">
+                    <span class="buttons-wrap">
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'agency-display-type' ); ?>" id="<?php echo $this->get_field_id( 'agency-display-type-thumbnails' ); ?>" value="thumbnail" <?php echo checked( $agency_display_type, 'thumbnail' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'agency-display-type-thumbnails' ); ?>"><?php esc_html_e( 'Thumbnails', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                        <span class="inner-buttons">
+                            <input type="radio" name="<?php echo $this->get_field_name( 'agency-display-type' ); ?>" id="<?php echo $this->get_field_id( 'agency-display-type-checkboxes' ); ?>" value="checkbox" <?php echo checked( $agency_display_type, 'checkbox' ); ?>>
+                            <label for="<?php echo $this->get_field_id( 'agency-display-type-checkboxes' ); ?>"><?php esc_html_e( 'Checkboxes', ERE_TEXT_DOMAIN ); ?></label>
+                        </span>
+                    </span>
+                    </div>
+                </div>
+
+                <hr>
+				<?php
+			}
+			?>
+
+            <p class="fancy-checkbox-option-button bedroom-options-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Bedroom Options', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'bedroom-options' ); ?>" name="<?php echo $this->get_field_name( 'bedroom-options' ); ?>" value="true" <?php echo checked( $bedrooms_options, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'bedroom-options' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="mini-option bedrooms-max-value option-align-right bedrooms-max-value-wrapper">
+                <label for="<?php echo $this->get_field_id( 'bedrooms-max-value' ); ?>"><?php esc_html_e( 'Maximum Bedrooms', ERE_TEXT_DOMAIN ); ?></label>
+                <input class="" type="number" id="<?php echo $this->get_field_id( 'bedrooms-max-value' ); ?>" name="<?php echo $this->get_field_name( 'bedrooms-max-value' ); ?>" value="<?php echo esc_attr( $bedrooms_max_value ); ?>">
+            </p>
+
+            <hr>
+
+            <p class="fancy-checkbox-option-button bathroom-options-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Bathroom Options', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'bathroom-options' ); ?>" name="<?php echo $this->get_field_name( 'bathroom-options' ); ?>" value="true" <?php echo checked( $bathrooms_options, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'bathroom-options' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="mini-option bathrooms-max-value option-align-right bathrooms-max-value-wrapper">
+                <label for="<?php echo $this->get_field_id( 'bathrooms-max-value' ); ?>"><?php esc_html_e( 'Maximum Bathrooms', ERE_TEXT_DOMAIN ); ?></label>
+                <input class="" type="number" id="<?php echo $this->get_field_id( 'bathrooms-max-value' ); ?>" name="<?php echo $this->get_field_name( 'bathrooms-max-value' ); ?>" value="<?php echo esc_attr( $bathrooms_max_value ); ?>">
+            </p>
+
+            <hr>
+
+            <p class="fancy-checkbox-option-button garage-options-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Garage Options', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'garage-options' ); ?>" name="<?php echo $this->get_field_name( 'garage-options' ); ?>" value="true" <?php echo checked( $garages_options, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'garage-options' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="mini-option garages-max-value option-align-right garages-max-value-wrapper">
+                <label for="<?php echo $this->get_field_id( 'garages-max-value' ); ?>"><?php esc_html_e( 'Maximum Garages', ERE_TEXT_DOMAIN ); ?></label>
+                <input class="" type="number" id="<?php echo $this->get_field_id( 'garages-max-value' ); ?>" name="<?php echo $this->get_field_name( 'garages-max-value' ); ?>" value="<?php echo esc_attr( $garages_max_value ); ?>">
+            </p>
+
+            <hr>
+
+            <p class="fancy-checkbox-option-button property-id-options-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Property ID', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'property-id' ); ?>" name="<?php echo $this->get_field_name( 'property-id' ); ?>" value="true" <?php echo checked( $property_id, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'property-id' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <p class="fancy-checkbox-option-button property-id-options-wrapper">
+                <strong class="widget-field-half fancy-field-title"><?php esc_html_e( 'Additional Fields', ERE_TEXT_DOMAIN ); ?></strong>
+                <input type="checkbox" id="<?php echo $this->get_field_id( 'additional-fields' ); ?>" name="<?php echo $this->get_field_name( 'additional-fields' ); ?>" value="true" <?php echo checked( $additional_fields, 'true' ); ?>>
+                <label class="fancy-button-label widget-field-half option-align-right" for="<?php echo $this->get_field_id( 'additional-fields' ); ?>">
+                    <span class="cb-btn-wrapper">
+                        <span class="cb-btn-trigger"></span>
+                    </span>
+                </label>
+            </p>
+
+            <hr><br>
+			<?php
+		}
+
+		/**
+		 * Sanitize widget form values as they are saved.
+		 *
+		 * @param array $new_instance Values just sent to be saved.
+		 * @param array $old_instance Previously saved values from database.
+		 *
+		 * @return array Updated safe values to be saved.
+		 * @see WP_Widget::update()
+		 *
+		 */
+		public function update( $new_instance, $old_instance ) {
+			$instance                          = array();
+			$instance['title']                 = ! empty( $new_instance['title'] ) ? strip_tags( $new_instance['title'] ) : '';
+			$instance['hide_empty']            = ! empty( $new_instance['hide_empty'] ) ? $new_instance['hide_empty'] : '';
+			$instance['property-types']        = ! empty( $new_instance['property-types'] ) ? $new_instance['property-types'] : '';
+                        $instance['property-location']     = ! empty( $new_instance['property-location'] ) ? $new_instance['property-location'] : '';
+                        $instance['location-terms']        = ! empty( $new_instance['location-terms'] ) ? (array) $new_instance['location-terms'] : array();
+                        $instance['property-categories']   = ! empty( $new_instance['property-categories'] ) ? $new_instance['property-categories'] : '';
+                        $instance['category-terms']        = ! empty( $new_instance['category-terms'] ) ? (array) $new_instance['category-terms'] : array();
+                        $instance['property-status']       = ! empty( $new_instance['property-status'] ) ? $new_instance['property-status'] : '';
+                        $instance['property-features']     = ! empty( $new_instance['property-features'] ) ? $new_instance['property-features'] : '';
+			$instance['checkboxes-view-limit'] = ! empty( $new_instance['checkboxes-view-limit'] ) ? $new_instance['checkboxes-view-limit'] : '';
+			$instance['price-ranges']          = ! empty( $new_instance['price-ranges'] ) ? $new_instance['price-ranges'] : '';
+			$instance['price-range-type']      = ! empty( $new_instance['price-range-type'] ) ? $new_instance['price-range-type'] : '';
+			$instance['custom-price-ranges']   = ! empty( $new_instance['custom-price-ranges'] ) ? $new_instance['custom-price-ranges'] : '';
+			$instance['price-slider-min']      = ! empty( $new_instance['price-slider-min'] ) ? $new_instance['price-slider-min'] : '';
+			$instance['price-slider-max']      = ! empty( $new_instance['price-slider-max'] ) ? $new_instance['price-slider-max'] : '';
+			$instance['area-ranges']           = ! empty( $new_instance['area-ranges'] ) ? $new_instance['area-ranges'] : '';
+			$instance['area-range-type']       = ! empty( $new_instance['area-range-type'] ) ? $new_instance['area-range-type'] : '';
+			$instance['area-unit']             = ! empty( $new_instance['area-unit'] ) ? $new_instance['area-unit'] : '';
+			$instance['custom-area-ranges']    = ! empty( $new_instance['custom-area-ranges'] ) ? $new_instance['custom-area-ranges'] : '';
+			$instance['area-slider-min']       = ! empty( $new_instance['area-slider-min'] ) ? $new_instance['area-slider-min'] : '';
+			$instance['area-slider-max']       = ! empty( $new_instance['area-slider-max'] ) ? $new_instance['area-slider-max'] : '';
+			$instance['bedroom-options']       = ! empty( $new_instance['bedroom-options'] ) ? $new_instance['bedroom-options'] : '';
+			$instance['bedrooms-max-value']    = ! empty( $new_instance['bedrooms-max-value'] ) ? $new_instance['bedrooms-max-value'] : '';
+			$instance['bathroom-options']      = ! empty( $new_instance['bathroom-options'] ) ? $new_instance['bathroom-options'] : '';
+			$instance['bathrooms-max-value']   = ! empty( $new_instance['bathrooms-max-value'] ) ? $new_instance['bathrooms-max-value'] : '';
+			$instance['garage-options']        = ! empty( $new_instance['garage-options'] ) ? $new_instance['garage-options'] : '';
+			$instance['garages-max-value']     = ! empty( $new_instance['garages-max-value'] ) ? $new_instance['garages-max-value'] : '';
+			$instance['agent-options']         = ! empty( $new_instance['agent-options'] ) ? $new_instance['agent-options'] : '';
+			$instance['agent-display-type']    = ! empty( $new_instance['agent-display-type'] ) ? $new_instance['agent-display-type'] : '';
+			$instance['agency-options']        = ! empty( $new_instance['agency-options'] ) ? $new_instance['agency-options'] : '';
+			$instance['agency-display-type']   = ! empty( $new_instance['agency-display-type'] ) ? $new_instance['agency-display-type'] : '';
+			$instance['property-id']           = ! empty( $new_instance['property-id'] ) ? $new_instance['property-id'] : '';
+			$instance['additional-fields']     = ! empty( $new_instance['additional-fields'] ) ? $new_instance['additional-fields'] : '';
+
+			return $instance;
+		}
+	}
+}
+
+if ( ! function_exists( 'register_properties_filter_widget' ) ) {
+
+	// Register Properties_Filter_Widget widget
+	function register_properties_filter_widget() {
+		register_widget( 'Properties_Filter_Widget' );
+	}
+
+	add_action( 'widgets_init', 'register_properties_filter_widget' );
+
+}


### PR DESCRIPTION
## Summary
- add widget setting to choose specific property locations for filters
- allow filter helper to include only selected locations
- introduce category filter options with selectable property categories

## Testing
- `php -l wp-content/wp-content/plugins/easy-real-estate/includes/widgets/property-filters.php`
- `php -l wp-content/wp-content/plugins/easy-real-estate/includes/functions/basic.php`


------
https://chatgpt.com/codex/tasks/task_e_689d4f00ad28832b9552e458348b1718