### PR TITLE
Add Housi Portfolio plugin with Elementor integration

### DIFF
--- a/housi-portfolio/README.md
+++ b/housi-portfolio/README.md
@@ -1,0 +1,14 @@
+# Housi Portfólio
+
+Plugin de portfólio baseado na funcionalidade do tema Woodmart, focado em uso com Elementor. Registra um *custom post type* "portfolio" e fornece um widget para listagem dos itens em grade.
+
+## Recursos
+- Tipo de post "portfolio" e taxonomia hierárquica "project-cat".
+- Widget Elementor **Housi Portfolio** com controles de categorias e colunas.
+- Templates padrão para arquivos e single de portfólio.
+- Estilos em `assets/css/portfolio.css` para a grade responsiva.
+
+## Uso
+1. Faça upload do diretório do plugin para `wp-content/plugins` e ative-o.
+2. Crie itens de portfólio em **Portfolios** no painel do WordPress.
+3. Insira o widget na página pelo Elementor ou acesse `/portfolio` para ver o arquivo padrão.

--- a/housi-portfolio/assets/css/portfolio.css
+++ b/housi-portfolio/assets/css/portfolio.css
@@ -1,0 +1,21 @@
+.housi-portfolio-grid {
+    display: grid;
+    gap: 30px;
+}
+
+.housi-portfolio-grid.columns-2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.housi-portfolio-grid.columns-3 {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.housi-portfolio-grid.columns-4 {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.housi-portfolio-title {
+    margin-top: 15px;
+    text-align: center;
+}

--- a/housi-portfolio/housi-portfolio.php
+++ b/housi-portfolio/housi-portfolio.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name: Housi Portfólio
+ * Description: Portfolio plugin inspired by Woodmart theme, integrated with Elementor.
+ * Version: 0.1.0
+ * Author: ChatGPT
+ * Text Domain: housi-portfolio
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'HOUSI_PORTFOLIO_VERSION', '0.1.0' );
+define( 'HOUSI_PORTFOLIO_PATH', plugin_dir_path( __FILE__ ) );
+define( 'HOUSI_PORTFOLIO_URL', plugin_dir_url( __FILE__ ) );
+
+require_once HOUSI_PORTFOLIO_PATH . 'includes/class-housi-portfolio-cpt.php';
+require_once HOUSI_PORTFOLIO_PATH . 'includes/class-housi-portfolio-elementor.php';
+
+// Register frontend styles.
+add_action( 'wp_enqueue_scripts', function() {
+    wp_register_style( 'housi-portfolio', HOUSI_PORTFOLIO_URL . 'assets/css/portfolio.css', [], HOUSI_PORTFOLIO_VERSION );
+} );
+
+// Load plugin textdomain.
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'housi-portfolio', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+} );
+
+// Flush rewrite rules on activation/deactivation.
+function housi_portfolio_activate() {
+    Housi_Portfolio_CPT::register_cpt();
+    Housi_Portfolio_CPT::register_taxonomy();
+    flush_rewrite_rules();
+}
+register_activation_hook( __FILE__, 'housi_portfolio_activate' );
+
+function housi_portfolio_deactivate() {
+    flush_rewrite_rules();
+}
+register_deactivation_hook( __FILE__, 'housi_portfolio_deactivate' );
+
+// Template loader for archive and single portfolio pages.
+add_filter( 'template_include', function( $template ) {
+    if ( is_post_type_archive( 'portfolio' ) && file_exists( HOUSI_PORTFOLIO_PATH . 'templates/archive-portfolio.php' ) ) {
+        return HOUSI_PORTFOLIO_PATH . 'templates/archive-portfolio.php';
+    }
+    if ( is_singular( 'portfolio' ) && file_exists( HOUSI_PORTFOLIO_PATH . 'templates/single-portfolio.php' ) ) {
+        return HOUSI_PORTFOLIO_PATH . 'templates/single-portfolio.php';
+    }
+    return $template;
+} );
+

--- a/housi-portfolio/includes/class-housi-portfolio-cpt.php
+++ b/housi-portfolio/includes/class-housi-portfolio-cpt.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Register portfolio post type and taxonomy.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_CPT {
+
+    public function __construct() {
+        add_action( 'init', [ __CLASS__, 'register_cpt' ] );
+        add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+    }
+
+    /**
+     * Register the portfolio custom post type.
+     */
+    public static function register_cpt() {
+        $labels = [
+            'name'               => __( 'Portfolios', 'housi-portfolio' ),
+            'singular_name'      => __( 'Portfolio', 'housi-portfolio' ),
+            'add_new'            => __( 'Add New', 'housi-portfolio' ),
+            'add_new_item'       => __( 'Add New Portfolio', 'housi-portfolio' ),
+            'edit_item'          => __( 'Edit Portfolio', 'housi-portfolio' ),
+            'new_item'           => __( 'New Portfolio', 'housi-portfolio' ),
+            'view_item'          => __( 'View Portfolio', 'housi-portfolio' ),
+            'search_items'       => __( 'Search Portfolios', 'housi-portfolio' ),
+            'not_found'          => __( 'No portfolios found', 'housi-portfolio' ),
+            'not_found_in_trash' => __( 'No portfolios found in Trash', 'housi-portfolio' ),
+        ];
+
+        $args = [
+            'labels'       => $labels,
+            'public'       => true,
+            'has_archive'  => true,
+            'show_in_rest' => true,
+            'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
+            'rewrite'      => [ 'slug' => 'portfolio' ],
+        ];
+
+        register_post_type( 'portfolio', $args );
+    }
+
+    /**
+     * Register the project-cat taxonomy.
+     */
+    public static function register_taxonomy() {
+        $labels = [
+            'name'          => __( 'Project Categories', 'housi-portfolio' ),
+            'singular_name' => __( 'Project Category', 'housi-portfolio' ),
+        ];
+
+        $args = [
+            'labels'       => $labels,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+            'rewrite'      => [ 'slug' => 'project-cat' ],
+        ];
+
+        register_taxonomy( 'project-cat', 'portfolio', $args );
+    }
+}
+
+new Housi_Portfolio_CPT();
+

--- a/housi-portfolio/includes/class-housi-portfolio-elementor.php
+++ b/housi-portfolio/includes/class-housi-portfolio-elementor.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Elementor integration for Housi Portfolio.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_Elementor {
+
+    public function __construct() {
+        add_action( 'elementor/widgets/register', [ $this, 'register_widget' ] );
+    }
+
+    /**
+     * Register the portfolio widget.
+     */
+    public function register_widget( $widgets_manager ) {
+        require_once HOUSI_PORTFOLIO_PATH . 'includes/widgets/class-housi-portfolio-widget.php';
+        $widgets_manager->register( new \Housi_Portfolio_Widget() );
+    }
+}
+
+// Only load if Elementor is active.
+if ( did_action( 'elementor/loaded' ) ) {
+    new Housi_Portfolio_Elementor();
+}
+

--- a/housi-portfolio/includes/widgets/class-housi-portfolio-widget.php
+++ b/housi-portfolio/includes/widgets/class-housi-portfolio-widget.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Elementor widget to display portfolio items.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_Widget extends \Elementor\Widget_Base {
+
+    public function get_name() {
+        return 'housi_portfolio';
+    }
+
+    public function get_title() {
+        return __( 'Housi Portfolio', 'housi-portfolio' );
+    }
+
+    public function get_icon() {
+        return 'eicon-gallery-grid';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section( 'content_section', [
+            'label' => __( 'Content', 'housi-portfolio' ),
+        ] );
+
+        $this->add_control( 'posts_per_page', [
+            'label' => __( 'Posts Per Page', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::NUMBER,
+            'default' => 6,
+        ] );
+
+        $this->add_control( 'columns', [
+            'label' => __( 'Columns', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                '2' => 2,
+                '3' => 3,
+                '4' => 4,
+            ],
+            'default' => '3',
+        ] );
+
+        $this->add_control( 'project_cat', [
+            'label' => __( 'Categories', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::SELECT2,
+            'options' => $this->get_categories_options(),
+            'multiple' => true,
+            'label_block' => true,
+        ] );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Retrieve portfolio categories for select options.
+     */
+    private function get_categories_options() {
+        $terms = get_terms( [
+            'taxonomy'   => 'project-cat',
+            'hide_empty' => false,
+        ] );
+
+        $options = [];
+        if ( ! is_wp_error( $terms ) ) {
+            foreach ( $terms as $term ) {
+                $options[ $term->slug ] = $term->name;
+            }
+        }
+
+        return $options;
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+
+        $args = [
+            'post_type'      => 'portfolio',
+            'posts_per_page' => $settings['posts_per_page'],
+        ];
+
+        if ( ! empty( $settings['project_cat'] ) ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => 'project-cat',
+                    'field'    => 'slug',
+                    'terms'    => $settings['project_cat'],
+                ],
+            ];
+        }
+
+        $query = new WP_Query( $args );
+
+        if ( $query->have_posts() ) {
+            wp_enqueue_style( 'housi-portfolio' );
+            echo '<div class="housi-portfolio-grid columns-' . esc_attr( $settings['columns'] ) . '">';
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                echo '<div class="housi-portfolio-item">';
+                if ( has_post_thumbnail() ) {
+                    echo '<div class="housi-portfolio-thumb"><a href="' . esc_url( get_permalink() ) . '">';
+                    the_post_thumbnail( 'medium' );
+                    echo '</a></div>';
+                }
+                echo '<h3 class="housi-portfolio-title"><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></h3>';
+                echo '</div>';
+            }
+            echo '</div>';
+            wp_reset_postdata();
+        }
+    }
+}
+

--- a/housi-portfolio/templates/archive-portfolio.php
+++ b/housi-portfolio/templates/archive-portfolio.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Archive template for portfolio items.
+ *
+ * @package Housi_Portfolio
+ */
+
+wp_enqueue_style( 'housi-portfolio' );
+
+get_header();
+?>
+<main class="housi-portfolio-archive">
+<?php if ( have_posts() ) : ?>
+    <div class="housi-portfolio-grid columns-3">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <div class="housi-portfolio-item">
+            <?php if ( has_post_thumbnail() ) : ?>
+                <div class="housi-portfolio-thumb"><a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'medium' ); ?></a></div>
+            <?php endif; ?>
+            <h3 class="housi-portfolio-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+        </div>
+    <?php endwhile; ?>
+    </div>
+    <?php the_posts_pagination(); ?>
+<?php else : ?>
+    <p><?php esc_html_e( 'No portfolio items found.', 'housi-portfolio' ); ?></p>
+<?php endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/housi-portfolio/templates/single-portfolio.php
+++ b/housi-portfolio/templates/single-portfolio.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Single portfolio item template.
+ *
+ * @package Housi_Portfolio
+ */
+
+wp_enqueue_style( 'housi-portfolio' );
+
+get_header();
+?>
+<main class="housi-portfolio-single">
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article id="post-<?php the_ID(); ?>" <?php post_class( 'housi-portfolio-item' ); ?>>
+        <?php if ( has_post_thumbnail() ) : ?>
+            <div class="housi-portfolio-thumb"><?php the_post_thumbnail( 'large' ); ?></div>
+        <?php endif; ?>
+        <h1 class="housi-portfolio-title"><?php the_title(); ?></h1>
+        <div class="housi-portfolio-content"><?php the_content(); ?></div>
+    </article>
+<?php endwhile; endif; ?>
+</main>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add activation hooks, textdomain loading, and template loader to Housi Portfolio plugin
- provide default archive and single templates and document plugin usage
- fix Elementor widget title rendering with esc_html

## Testing
- `find housi-portfolio -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689d65103ab0832b8701af644480dfe3