### PR TITLE
Add Housi Portfolio plugin with Elementor integration

### DIFF
--- a/housi-portfolio/README.md
+++ b/housi-portfolio/README.md
@@ -1,0 +1,17 @@
+# Housi Portfólio
+
+Plugin de portfólio baseado na funcionalidade do tema Woodmart, focado em uso com Elementor. Registra um *custom post type* "portfolio" e fornece um widget para listagem dos itens em grade.
+
+## Recursos
+- Tipo de post "portfolio" e taxonomia hierárquica "project-cat".
+- Widget Elementor **Housi Portfolio** com controles de categorias e colunas.
+- Templates padrão para arquivos e single de portfólio.
+- Estilos e scripts em `assets/css/portfolio.css` e `assets/js/portfolio.js` para grade responsiva com filtros de categorias.
+- Template específico para páginas de categorias (`taxonomy-project-cat.php`) com filtros e grade idênticos ao arquivo principal.
+- Os títulos dos projetos aparecem abaixo das imagens destacadas.
+- Layout do single apresenta a imagem destacada ao lado das descrições.
+
+## Uso
+1. Faça upload do diretório do plugin para `wp-content/plugins` e ative-o.
+2. Crie itens de portfólio em **Portfolios** no painel do WordPress.
+3. Insira o widget na página pelo Elementor ou acesse `/portfolio` para ver o arquivo padrão.

--- a/housi-portfolio/assets/css/portfolio.css
+++ b/housi-portfolio/assets/css/portfolio.css
@@ -1,0 +1,84 @@
+.housi-portfolio-filters {
+    text-align: center;
+    margin-bottom: 25px;
+}
+
+.housi-portfolio-filters button {
+    background: none;
+    border: none;
+    padding: 6px 15px;
+    margin: 0 5px 10px;
+    cursor: pointer;
+    color: #333;
+    border-bottom: 2px solid transparent;
+    transition: border-color 0.3s;
+}
+
+.housi-portfolio-filters button.active,
+.housi-portfolio-filters button:hover {
+    border-color: #333;
+}
+
+.housi-portfolio-grid {
+    display: grid;
+    gap: 30px;
+}
+
+.housi-portfolio-grid.columns-2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.housi-portfolio-grid.columns-3 {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.housi-portfolio-grid.columns-4 {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.housi-portfolio-item {
+    overflow: hidden;
+    text-align: center;
+}
+
+.housi-portfolio-thumb img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.housi-portfolio-title {
+    margin: 10px 0 0;
+    font-size: 16px;
+    text-align: left;
+}
+
+.housi-portfolio-single .housi-portfolio-container {
+    display: flex;
+    gap: 30px;
+    max-width: 1200px;
+    margin: 40px auto;
+}
+
+.housi-portfolio-media {
+    flex: 1;
+}
+
+.housi-portfolio-media img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.housi-portfolio-details {
+    flex: 1;
+}
+
+.housi-portfolio-details .housi-portfolio-title {
+    text-align: left;
+    margin-bottom: 20px;
+}
+
+.housi-portfolio-content {
+    line-height: 1.6;
+}

--- a/housi-portfolio/assets/js/portfolio.js
+++ b/housi-portfolio/assets/js/portfolio.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+    var filters = document.querySelectorAll('.housi-portfolio-filters button');
+    var items = document.querySelectorAll('.housi-portfolio-item');
+
+    filters.forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var term = this.getAttribute('data-term');
+            filters.forEach(function(b){ b.classList.remove('active'); });
+            this.classList.add('active');
+
+            items.forEach(function(item) {
+                if (term === 'all' || item.classList.contains('term-' + term)) {
+                    item.style.display = '';
+                } else {
+                    item.style.display = 'none';
+                }
+            });
+        });
+    });
+});

--- a/housi-portfolio/housi-portfolio.php
+++ b/housi-portfolio/housi-portfolio.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Plugin Name: Housi Portfólio
+ * Description: Portfolio plugin inspired by Woodmart theme, integrated with Elementor.
+ * Version: 0.1.0
+ * Author: ChatGPT
+ * Text Domain: housi-portfolio
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'HOUSI_PORTFOLIO_VERSION', '0.1.0' );
+define( 'HOUSI_PORTFOLIO_PATH', plugin_dir_path( __FILE__ ) );
+define( 'HOUSI_PORTFOLIO_URL', plugin_dir_url( __FILE__ ) );
+
+require_once HOUSI_PORTFOLIO_PATH . 'includes/class-housi-portfolio-cpt.php';
+require_once HOUSI_PORTFOLIO_PATH . 'includes/class-housi-portfolio-elementor.php';
+
+// Register frontend assets.
+add_action( 'wp_enqueue_scripts', function() {
+    wp_register_style( 'housi-portfolio', HOUSI_PORTFOLIO_URL . 'assets/css/portfolio.css', [], HOUSI_PORTFOLIO_VERSION );
+    wp_register_script( 'housi-portfolio', HOUSI_PORTFOLIO_URL . 'assets/js/portfolio.js', [], HOUSI_PORTFOLIO_VERSION, true );
+} );
+
+// Load plugin textdomain.
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'housi-portfolio', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+} );
+
+// Flush rewrite rules on activation/deactivation.
+function housi_portfolio_activate() {
+    Housi_Portfolio_CPT::register_cpt();
+    Housi_Portfolio_CPT::register_taxonomy();
+    flush_rewrite_rules();
+}
+register_activation_hook( __FILE__, 'housi_portfolio_activate' );
+
+function housi_portfolio_deactivate() {
+    flush_rewrite_rules();
+}
+register_deactivation_hook( __FILE__, 'housi_portfolio_deactivate' );
+
+// Template loader for archive and single portfolio pages.
+add_filter( 'template_include', function( $template ) {
+    if ( is_post_type_archive( 'portfolio' ) && file_exists( HOUSI_PORTFOLIO_PATH . 'templates/archive-portfolio.php' ) ) {
+        return HOUSI_PORTFOLIO_PATH . 'templates/archive-portfolio.php';
+    }
+    if ( is_singular( 'portfolio' ) && file_exists( HOUSI_PORTFOLIO_PATH . 'templates/single-portfolio.php' ) ) {
+        return HOUSI_PORTFOLIO_PATH . 'templates/single-portfolio.php';
+    }
+    if ( is_tax( 'project-cat' ) && file_exists( HOUSI_PORTFOLIO_PATH . 'templates/taxonomy-project-cat.php' ) ) {
+        return HOUSI_PORTFOLIO_PATH . 'templates/taxonomy-project-cat.php';
+    }
+    return $template;
+} );
+

--- a/housi-portfolio/includes/class-housi-portfolio-cpt.php
+++ b/housi-portfolio/includes/class-housi-portfolio-cpt.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Register portfolio post type and taxonomy.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_CPT {
+
+    public function __construct() {
+        add_action( 'init', [ __CLASS__, 'register_cpt' ] );
+        add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+    }
+
+    /**
+     * Register the portfolio custom post type.
+     */
+    public static function register_cpt() {
+        $labels = [
+            'name'               => __( 'Portfolios', 'housi-portfolio' ),
+            'singular_name'      => __( 'Portfolio', 'housi-portfolio' ),
+            'add_new'            => __( 'Add New', 'housi-portfolio' ),
+            'add_new_item'       => __( 'Add New Portfolio', 'housi-portfolio' ),
+            'edit_item'          => __( 'Edit Portfolio', 'housi-portfolio' ),
+            'new_item'           => __( 'New Portfolio', 'housi-portfolio' ),
+            'view_item'          => __( 'View Portfolio', 'housi-portfolio' ),
+            'search_items'       => __( 'Search Portfolios', 'housi-portfolio' ),
+            'not_found'          => __( 'No portfolios found', 'housi-portfolio' ),
+            'not_found_in_trash' => __( 'No portfolios found in Trash', 'housi-portfolio' ),
+        ];
+
+        $args = [
+            'labels'       => $labels,
+            'public'       => true,
+            'has_archive'  => true,
+            'show_in_rest' => true,
+            'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
+            'rewrite'      => [ 'slug' => 'portfolio' ],
+        ];
+
+        register_post_type( 'portfolio', $args );
+    }
+
+    /**
+     * Register the project-cat taxonomy.
+     */
+    public static function register_taxonomy() {
+        $labels = [
+            'name'          => __( 'Project Categories', 'housi-portfolio' ),
+            'singular_name' => __( 'Project Category', 'housi-portfolio' ),
+        ];
+
+        $args = [
+            'labels'       => $labels,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+            'rewrite'      => [ 'slug' => 'project-cat' ],
+        ];
+
+        register_taxonomy( 'project-cat', 'portfolio', $args );
+    }
+}
+
+new Housi_Portfolio_CPT();
+

--- a/housi-portfolio/includes/class-housi-portfolio-elementor.php
+++ b/housi-portfolio/includes/class-housi-portfolio-elementor.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Elementor integration for Housi Portfolio.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_Elementor {
+
+    public function __construct() {
+        add_action( 'elementor/widgets/register', [ $this, 'register_widget' ] );
+    }
+
+    /**
+     * Register the portfolio widget.
+     */
+    public function register_widget( $widgets_manager ) {
+        require_once HOUSI_PORTFOLIO_PATH . 'includes/widgets/class-housi-portfolio-widget.php';
+        $widgets_manager->register( new \Housi_Portfolio_Widget() );
+    }
+}
+
+// Only load if Elementor is active.
+if ( did_action( 'elementor/loaded' ) ) {
+    new Housi_Portfolio_Elementor();
+}
+

--- a/housi-portfolio/includes/widgets/class-housi-portfolio-widget.php
+++ b/housi-portfolio/includes/widgets/class-housi-portfolio-widget.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Elementor widget to display portfolio items.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Housi_Portfolio_Widget extends \Elementor\Widget_Base {
+
+    public function get_name() {
+        return 'housi_portfolio';
+    }
+
+    public function get_title() {
+        return __( 'Housi Portfolio', 'housi-portfolio' );
+    }
+
+    public function get_icon() {
+        return 'eicon-gallery-grid';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section( 'content_section', [
+            'label' => __( 'Content', 'housi-portfolio' ),
+        ] );
+
+        $this->add_control( 'posts_per_page', [
+            'label' => __( 'Posts Per Page', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::NUMBER,
+            'default' => 6,
+        ] );
+
+        $this->add_control( 'columns', [
+            'label' => __( 'Columns', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::SELECT,
+            'options' => [
+                '2' => 2,
+                '3' => 3,
+                '4' => 4,
+            ],
+            'default' => '3',
+        ] );
+
+        $this->add_control( 'project_cat', [
+            'label' => __( 'Categories', 'housi-portfolio' ),
+            'type' => \Elementor\Controls_Manager::SELECT2,
+            'options' => $this->get_categories_options(),
+            'multiple' => true,
+            'label_block' => true,
+        ] );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Retrieve portfolio categories for select options.
+     */
+    private function get_categories_options() {
+        $terms = get_terms( [
+            'taxonomy'   => 'project-cat',
+            'hide_empty' => false,
+        ] );
+
+        $options = [];
+        if ( ! is_wp_error( $terms ) ) {
+            foreach ( $terms as $term ) {
+                $options[ $term->slug ] = $term->name;
+            }
+        }
+
+        return $options;
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+
+        $args = [
+            'post_type'      => 'portfolio',
+            'posts_per_page' => $settings['posts_per_page'],
+        ];
+
+        if ( ! empty( $settings['project_cat'] ) ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => 'project-cat',
+                    'field'    => 'slug',
+                    'terms'    => $settings['project_cat'],
+                ],
+            ];
+        }
+
+        $query = new WP_Query( $args );
+
+        if ( $query->have_posts() ) {
+            wp_enqueue_style( 'housi-portfolio' );
+            wp_enqueue_script( 'housi-portfolio' );
+
+            $filter_terms = empty( $settings['project_cat'] ) ? get_terms( [
+                'taxonomy'   => 'project-cat',
+                'hide_empty' => true,
+            ] ) : get_terms( [
+                'taxonomy'   => 'project-cat',
+                'hide_empty' => true,
+                'slug'       => $settings['project_cat'],
+            ] );
+
+            if ( ! is_wp_error( $filter_terms ) && ! empty( $filter_terms ) ) {
+                echo '<div class="housi-portfolio-filters">';
+                echo '<button class="active" data-term="all">' . esc_html__( 'Mostrar Todos', 'housi-portfolio' ) . '</button>';
+                foreach ( $filter_terms as $term ) {
+                    echo '<button data-term="' . esc_attr( $term->slug ) . '">' . esc_html( $term->name ) . '</button>';
+                }
+                echo '</div>';
+            }
+
+            echo '<div class="housi-portfolio-grid columns-' . esc_attr( $settings['columns'] ) . '">';
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                $terms        = get_the_terms( get_the_ID(), 'project-cat' );
+                $term_classes = '';
+                if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+                    foreach ( $terms as $term ) {
+                        $term_classes .= ' term-' . $term->slug;
+                    }
+                }
+                echo '<div class="housi-portfolio-item' . esc_attr( $term_classes ) . '">';
+                if ( has_post_thumbnail() ) {
+                    echo '<div class="housi-portfolio-thumb"><a href="' . esc_url( get_permalink() ) . '">';
+                    the_post_thumbnail( 'large' );
+                    echo '</a></div>';
+                    echo '<h3 class="housi-portfolio-title"><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></h3>';
+                } else {
+                    echo '<h3 class="housi-portfolio-title"><a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a></h3>';
+                }
+                echo '</div>';
+            }
+            echo '</div>';
+            wp_reset_postdata();
+        }
+    }
+}
+

--- a/housi-portfolio/templates/archive-portfolio.php
+++ b/housi-portfolio/templates/archive-portfolio.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Archive template for portfolio items.
+ *
+ * @package Housi_Portfolio
+ */
+
+wp_enqueue_style( 'housi-portfolio' );
+wp_enqueue_script( 'housi-portfolio' );
+
+get_header();
+?>
+<main class="housi-portfolio-archive">
+<?php if ( have_posts() ) : ?>
+    <?php
+    $terms = get_terms( [
+        'taxonomy'   => 'project-cat',
+        'hide_empty' => true,
+    ] );
+    if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) : ?>
+        <div class="housi-portfolio-filters">
+            <button class="active" data-term="all"><?php esc_html_e( 'Mostrar Todos', 'housi-portfolio' ); ?></button>
+            <?php foreach ( $terms as $term ) : ?>
+                <button data-term="<?php echo esc_attr( $term->slug ); ?>"><?php echo esc_html( $term->name ); ?></button>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <div class="housi-portfolio-grid columns-3">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <?php
+        $post_terms   = get_the_terms( get_the_ID(), 'project-cat' );
+        $term_classes = '';
+        if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+            foreach ( $post_terms as $t ) {
+                $term_classes .= ' term-' . $t->slug;
+            }
+        }
+        ?>
+        <div class="housi-portfolio-item<?php echo esc_attr( $term_classes ); ?>">
+            <?php if ( has_post_thumbnail() ) : ?>
+                <div class="housi-portfolio-thumb"><a href="<?php the_permalink(); ?>">
+                    <?php the_post_thumbnail( 'large' ); ?>
+                </a></div>
+                <h3 class="housi-portfolio-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+            <?php else : ?>
+                <h3 class="housi-portfolio-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+            <?php endif; ?>
+        </div>
+    <?php endwhile; ?>
+    </div>
+    <?php the_posts_pagination(); ?>
+<?php else : ?>
+    <p><?php esc_html_e( 'No portfolio items found.', 'housi-portfolio' ); ?></p>
+<?php endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/housi-portfolio/templates/single-portfolio.php
+++ b/housi-portfolio/templates/single-portfolio.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Single portfolio item template.
+ *
+ * @package Housi_Portfolio
+ */
+
+wp_enqueue_style( 'housi-portfolio' );
+
+get_header();
+?>
+<main class="housi-portfolio-single">
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article id="post-<?php the_ID(); ?>" <?php post_class( 'housi-portfolio-item' ); ?>>
+        <div class="housi-portfolio-container">
+            <?php if ( has_post_thumbnail() ) : ?>
+                <div class="housi-portfolio-media"><?php the_post_thumbnail( 'large' ); ?></div>
+            <?php endif; ?>
+            <div class="housi-portfolio-details">
+                <h1 class="housi-portfolio-title"><?php the_title(); ?></h1>
+                <div class="housi-portfolio-content"><?php the_content(); ?></div>
+            </div>
+        </div>
+    </article>
+    <?php endwhile; endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/housi-portfolio/templates/taxonomy-project-cat.php
+++ b/housi-portfolio/templates/taxonomy-project-cat.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Taxonomy archive template for project categories.
+ *
+ * @package Housi_Portfolio
+ */
+
+wp_enqueue_style( 'housi-portfolio' );
+wp_enqueue_script( 'housi-portfolio' );
+
+get_header();
+?>
+<main class="housi-portfolio-archive">
+<?php if ( have_posts() ) : ?>
+    <?php
+    $current_term = get_queried_object();
+    $terms        = get_terms( [
+        'taxonomy'   => 'project-cat',
+        'hide_empty' => true,
+    ] );
+    if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) : ?>
+        <div class="housi-portfolio-filters">
+            <button data-term="all"<?php if ( ! $current_term ) { echo ' class="active"'; } ?>><?php esc_html_e( 'Mostrar Todos', 'housi-portfolio' ); ?></button>
+            <?php foreach ( $terms as $term ) : ?>
+                <button data-term="<?php echo esc_attr( $term->slug ); ?>"<?php if ( $current_term && $current_term->slug === $term->slug ) { echo ' class="active"'; } ?>><?php echo esc_html( $term->name ); ?></button>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <div class="housi-portfolio-grid columns-3">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <?php
+        $post_terms   = get_the_terms( get_the_ID(), 'project-cat' );
+        $term_classes = '';
+        if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+            foreach ( $post_terms as $t ) {
+                $term_classes .= ' term-' . $t->slug;
+            }
+        }
+        ?>
+        <div class="housi-portfolio-item<?php echo esc_attr( $term_classes ); ?>">
+            <?php if ( has_post_thumbnail() ) : ?>
+                <div class="housi-portfolio-thumb"><a href="<?php the_permalink(); ?>">
+                    <?php the_post_thumbnail( 'large' ); ?>
+                </a></div>
+                <h3 class="housi-portfolio-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+            <?php else : ?>
+                <h3 class="housi-portfolio-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+            <?php endif; ?>
+        </div>
+    <?php endwhile; ?>
+    </div>
+    <?php the_posts_pagination(); ?>
+<?php else : ?>
+    <p><?php esc_html_e( 'No portfolio items found.', 'housi-portfolio' ); ?></p>
+<?php endif; ?>
+</main>
+<?php get_footer(); ?>
+


### PR DESCRIPTION
## Summary
- remove overlay from portfolio tiles and print titles below thumbnails
- center thumbnail titles with simplified CSS grid styles
- document that project titles now render under their featured images
- left-align portfolio titles and remove forced uppercase styling

## Testing
- `find housi-portfolio -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689d65103ab0832b8701af644480dfe3