### PR TITLE
Fix RealHomes theme for PHP 8.3 compatibility

### DIFF
--- a/realhomes/404.php
+++ b/realhomes/404.php
@@ -1,0 +1,50 @@
+<?php
+// Prevent direct access to this file.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+
+$banner_image_path = get_default_banner();
+
+$banner_title = __('404 - Page Not Found!', 'framework');
+$banner_details = __('The page you are looking for is not here!', 'framework');
+?>
+
+    <div class="page-head" style="background-repeat: no-repeat;background-position: center top;background-image: url('<?php echo $banner_image_path; ?>'); ">
+        <div class="container">
+            <div class="wrap clearfix">
+                <h1 class="page-title"><span><?php echo $banner_title; ?></span></h1>
+                <?php if(!empty($banner_details)){ ?>
+                    <p><?php echo $banner_details; ?></p>
+                <?php } ?>
+            </div>
+        </div>
+    </div><!-- End Page Head -->
+
+    <!-- Content -->
+    <div class="container contents single">
+        <div class="row">
+            <div class="span9 main-wrap">
+
+                <!-- Main Content -->
+                <div class="main">
+
+                    <div class="inner-wrapper">
+                        <article class="page-404">
+                            <p><br><strong><?php _e('Please try using top navigation OR search for what you are looking for!', 'framework'); ?></strong></p>
+                        </article>
+                    </div>
+
+                </div><!-- End Main Content -->
+
+            </div> <!-- End span9 -->
+
+            <?php get_sidebar(); ?>
+
+        </div><!-- End contents row -->
+
+    </div><!-- End Content -->
+
+<?php get_footer(); ?>

--- a/realhomes/framework/functions/load.php
+++ b/realhomes/framework/functions/load.php
@@ -1,0 +1,148 @@
+<?php
+// Prevent direct access to this file.
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * This file loads other files containing various functions used in this theme
+ *
+ * @package realhomes/functions
+ */
+
+// Purchase API.
+$purchase_api = INSPIRY_FRAMEWORK . 'functions/purchase-api.php';
+if ( ! class_exists( 'ERE_Purchase_API' ) && file_exists( $purchase_api ) ) {
+        require_once $purchase_api;
+}
+
+// global data classes.
+require_once INSPIRY_FRAMEWORK . 'functions/data.php';
+
+// Basic functions.
+require_once INSPIRY_FRAMEWORK . 'functions/basic.php';
+
+// Ajax Search functions.
+require_once INSPIRY_FRAMEWORK . 'functions/ajax-search.php';
+
+// Agent Search functions.
+require_once INSPIRY_FRAMEWORK . 'functions/agent-search.php';
+
+// Agency Search functions.
+require_once INSPIRY_FRAMEWORK . 'functions/agency-search.php';
+
+// Header functions.
+require_once INSPIRY_FRAMEWORK . 'functions/header.php';
+
+// Contains Enqueue and Render functions related to Google Map
+require_once INSPIRY_FRAMEWORK . 'functions/google-map-helper.php';
+require_once INSPIRY_FRAMEWORK . 'functions/google-map.php';
+
+// Contains Enqueue and Render functions related to Open Street Map
+require_once INSPIRY_FRAMEWORK . 'functions/open-street-map.php';
+
+// Contains Enqueue and Render functions related to MapBox
+require_once INSPIRY_FRAMEWORK . 'functions/mapbox.php';
+
+// Contains WooCommerce related functions.
+require_once INSPIRY_FRAMEWORK . 'functions/woocommerce.php';
+
+// Load required styles and scripts
+require_once INSPIRY_FRAMEWORK . 'functions/design-variations-handler.php';
+
+// Pagination functions.
+require_once INSPIRY_FRAMEWORK . 'functions/pagination.php';
+
+// Price functions.
+require_once INSPIRY_FRAMEWORK . 'functions/price.php';
+
+// Real Estate functions.
+require_once INSPIRY_FRAMEWORK . 'functions/real-estate.php';
+
+// Real Estate Search Functions.
+require_once INSPIRY_FRAMEWORK . 'functions/real-estate-search.php';
+
+// Home related functions.
+require_once INSPIRY_FRAMEWORK . 'functions/home.php';
+
+// Contact related functions.
+require_once INSPIRY_FRAMEWORK . 'functions/contact.php';
+
+// Breadcrumbs functions.
+require_once INSPIRY_FRAMEWORK . 'functions/breadcrumbs.php';
+
+// Users / Members related functions.
+require_once INSPIRY_FRAMEWORK . 'functions/member.php';
+
+// Property submit and edit.
+require_once INSPIRY_FRAMEWORK . 'functions/submit-edit.php';
+
+// Favorites functions.
+require_once INSPIRY_FRAMEWORK . 'functions/favorites.php';
+
+// Property submit handler.
+require_once INSPIRY_FRAMEWORK . 'functions/property-submit-handler.php';
+
+// Property print.
+require_once INSPIRY_FRAMEWORK . 'functions/property-print.php';
+
+// User profile.
+require_once INSPIRY_FRAMEWORK . 'functions/user-profile.php';
+
+// Edit profile handler.
+require_once INSPIRY_FRAMEWORK . 'functions/edit-profile-handler.php';
+
+// Theme's custom comment.
+require_once INSPIRY_FRAMEWORK . 'functions/theme-comment.php';
+
+// Compare functions.
+require_once INSPIRY_FRAMEWORK . 'functions/compare.php';
+
+// Property custom fields functions.
+require_once INSPIRY_FRAMEWORK . 'functions/property-custom-fields.php';
+
+// Save Searches Functions.
+require_once INSPIRY_FRAMEWORK . 'functions/save-searches.php';
+
+// Memberships functions.
+require_once INSPIRY_FRAMEWORK . 'functions/membership.php';
+
+// Property Rating functions.
+require_once INSPIRY_FRAMEWORK . 'functions/comment-ratings.php';
+
+// If realhomes-vacation-rentals plugin is activated and enabled from its settings
+if ( inspiry_is_rvr_enabled() ) {
+        // Realhomes Vacation Rentals related files.
+        $rvr_search = INSPIRY_FRAMEWORK . 'functions/rvr/rvr-search.php';
+        if ( file_exists( $rvr_search ) ) {
+                require_once $rvr_search;
+        }
+        $rvr_functions = INSPIRY_FRAMEWORK . 'functions/rvr/rvr-functions.php';
+        if ( file_exists( $rvr_functions ) ) {
+                require_once $rvr_functions;
+        }
+}
+
+// Theme update functions.
+$theme_update = INSPIRY_FRAMEWORK . 'functions/theme-update.php';
+if ( class_exists( 'ERE_Subscription_API' ) && ERE_Subscription_API::status() && file_exists( $theme_update ) ) {
+        require_once $theme_update;
+}
+
+// Dashboard functions
+require_once INSPIRY_FRAMEWORK . 'functions/dashboard.php';
+require_once INSPIRY_FRAMEWORK . 'functions/dashboard-colorschemes.php';
+
+// Subscription API.
+$subscription_api = INSPIRY_FRAMEWORK . 'functions/subscription-api.php';
+if ( ! class_exists( 'ERE_Subscription_API' ) && file_exists( $subscription_api ) ) {
+        require_once $subscription_api;
+}
+
+// Color schemes file.
+require_once INSPIRY_FRAMEWORK . 'functions/colorschemes.php';
+
+if ( 'classic' !== INSPIRY_THEME_VERSION ) {
+	// Functions related to property meta custom icons.
+	require_once INSPIRY_FRAMEWORK . 'functions/property-meta-custom-icons.php';
+}


### PR DESCRIPTION
## Summary
- Guard 404 template against direct access with `ABSPATH` check
- Conditionally load Purchase API, RVR files, theme updater, and Subscription API to avoid missing-file fatals
- Clarify property custom fields comment

## Testing
- `find realhomes -name '*.php' -print0 | xargs -0 -n1 -P4 php -l`
- `php -l realhomes/framework/functions/load.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb2e001f0832bbfc2714fe30d951f