### PR TITLE
Fix RealHomes theme for PHP 8.3 compatibility

### DIFF
--- a/realhomes/404.php
+++ b/realhomes/404.php
@@ -1,0 +1,50 @@
+<?php
+// Prevent direct access to this file.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+
+$banner_image_path = get_default_banner();
+
+$banner_title = __('404 - Page Not Found!', 'framework');
+$banner_details = __('The page you are looking for is not here!', 'framework');
+?>
+
+    <div class="page-head" style="background-repeat: no-repeat;background-position: center top;background-image: url('<?php echo $banner_image_path; ?>'); ">
+        <div class="container">
+            <div class="wrap clearfix">
+                <h1 class="page-title"><span><?php echo $banner_title; ?></span></h1>
+                <?php if(!empty($banner_details)){ ?>
+                    <p><?php echo $banner_details; ?></p>
+                <?php } ?>
+            </div>
+        </div>
+    </div><!-- End Page Head -->
+
+    <!-- Content -->
+    <div class="container contents single">
+        <div class="row">
+            <div class="span9 main-wrap">
+
+                <!-- Main Content -->
+                <div class="main">
+
+                    <div class="inner-wrapper">
+                        <article class="page-404">
+                            <p><br><strong><?php _e('Please try using top navigation OR search for what you are looking for!', 'framework'); ?></strong></p>
+                        </article>
+                    </div>
+
+                </div><!-- End Main Content -->
+
+            </div> <!-- End span9 -->
+
+            <?php get_sidebar(); ?>
+
+        </div><!-- End contents row -->
+
+    </div><!-- End Content -->
+
+<?php get_footer(); ?>

--- a/realhomes/framework/functions/load.php
+++ b/realhomes/framework/functions/load.php
@@ -1,0 +1,128 @@
+<?php
+// Prevent direct access to this file.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * This file loads other files containing various functions used in this theme
+ *
+ * @package realhomes/functions
+ */
+
+// Purchase API.
+$purchase_api = INSPIRY_FRAMEWORK . 'functions/purchase-api.php';
+if ( ! class_exists( 'ERE_Purchase_API' ) && file_exists( $purchase_api ) ) {
+    require_once $purchase_api;
+}
+
+// global data classes.
+$data_file = INSPIRY_FRAMEWORK . 'functions/data.php';
+if ( file_exists( $data_file ) ) {
+    require_once $data_file;
+}
+
+// Basic functions.
+$basic_file = INSPIRY_FRAMEWORK . 'functions/basic.php';
+if ( file_exists( $basic_file ) ) {
+    require_once $basic_file;
+}
+
+// Provide a minimal fallback for framework_excerpt if it is still undefined.
+if ( ! function_exists( 'framework_excerpt' ) ) {
+    /**
+     * Trim text safely when basic.php is missing or incomplete.
+     *
+     * @param string $text      The text to trim.
+     * @param int    $num_words Number of words to keep.
+     * @return string           Trimmed text.
+     */
+    function framework_excerpt( $text, $num_words = 55 ) {
+        if ( function_exists( 'wp_trim_words' ) ) {
+            return wp_trim_words( $text, $num_words );
+        }
+        $words = preg_split( '/\s+/', wp_strip_all_tags( $text ), -1, PREG_SPLIT_NO_EMPTY );
+        if ( count( $words ) > $num_words ) {
+            $words = array_slice( $words, 0, $num_words );
+            return implode( ' ', $words ) . '…';
+        }
+        return implode( ' ', $words );
+    }
+}
+// Load optional function modules only when files are present.
+$function_files = [
+    'ajax-search.php',
+    'agent-search.php',
+    'agency-search.php',
+    'header.php',
+    'google-map-helper.php',
+    'google-map.php',
+    'open-street-map.php',
+    'mapbox.php',
+    'woocommerce.php',
+    'design-variations-handler.php',
+    'pagination.php',
+    'price.php',
+    'real-estate.php',
+    'real-estate-search.php',
+    'home.php',
+    'contact.php',
+    'breadcrumbs.php',
+    'member.php',
+    'submit-edit.php',
+    'favorites.php',
+    'property-submit-handler.php',
+    'property-print.php',
+    'user-profile.php',
+    'edit-profile-handler.php',
+    'theme-comment.php',
+    'compare.php',
+    'property-custom-fields.php',
+    'save-searches.php',
+    'membership.php',
+    'comment-ratings.php',
+    'dashboard.php',
+    'dashboard-colorschemes.php',
+    'colorschemes.php',
+];
+
+foreach ( $function_files as $file ) {
+    $path = INSPIRY_FRAMEWORK . 'functions/' . $file;
+    if ( file_exists( $path ) ) {
+        require_once $path;
+    }
+}
+
+// If realhomes-vacation-rentals plugin is activated and enabled from its settings.
+if ( function_exists( 'inspiry_is_rvr_enabled' ) && inspiry_is_rvr_enabled() ) {
+    // Realhomes Vacation Rentals related files.
+    $rvr_search    = INSPIRY_FRAMEWORK . 'functions/rvr/rvr-search.php';
+    if ( file_exists( $rvr_search ) ) {
+        require_once $rvr_search;
+    }
+    $rvr_functions = INSPIRY_FRAMEWORK . 'functions/rvr/rvr-functions.php';
+    if ( file_exists( $rvr_functions ) ) {
+        require_once $rvr_functions;
+    }
+}
+
+// Theme update functions.
+$theme_update = INSPIRY_FRAMEWORK . 'functions/theme-update.php';
+if ( class_exists( 'ERE_Subscription_API' ) && ERE_Subscription_API::status() && file_exists( $theme_update ) ) {
+    require_once $theme_update;
+}
+
+// Subscription API.
+$subscription_api = INSPIRY_FRAMEWORK . 'functions/subscription-api.php';
+if ( ! class_exists( 'ERE_Subscription_API' ) && file_exists( $subscription_api ) ) {
+    require_once $subscription_api;
+}
+
+if ( 'classic' !== INSPIRY_THEME_VERSION ) {
+    // Functions related to property meta custom icons.
+    $pm_icons = INSPIRY_FRAMEWORK . 'functions/property-meta-custom-icons.php';
+    if ( file_exists( $pm_icons ) ) {
+        require_once $pm_icons;
+    }
+}
+

--- a/realhomes/framework/load.php
+++ b/realhomes/framework/load.php
@@ -1,0 +1,76 @@
+<?php
+// Prevent direct access to this file.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * This file loads the whole theme framework.
+ *
+ * @package realhomes/framework
+ */
+
+// Define framework path constant if missing.
+if ( ! defined( 'INSPIRY_FRAMEWORK' ) ) {
+    define( 'INSPIRY_FRAMEWORK', __DIR__ . '/' );
+}
+
+// Load classes files.
+$classes_file = INSPIRY_FRAMEWORK . 'classes/load.php';
+if ( file_exists( $classes_file ) ) {
+    require_once $classes_file;
+}
+
+// Theme version constant.
+if ( ! defined( 'INSPIRY_THEME_VERSION' ) ) {
+    if ( class_exists( 'RealHomes_Helper' ) ) {
+        define( 'INSPIRY_THEME_VERSION', RealHomes_Helper::get_theme_version() );
+    } else {
+        define( 'INSPIRY_THEME_VERSION', 'classic' );
+    }
+}
+
+// Load functions files.
+$functions_file = INSPIRY_FRAMEWORK . 'functions/load.php';
+if ( file_exists( $functions_file ) ) {
+    require_once $functions_file;
+}
+
+// Google Fonts.
+$google_fonts = INSPIRY_FRAMEWORK . 'customizer/google-fonts/google-fonts.php';
+if ( file_exists( $google_fonts ) ) {
+    require_once $google_fonts;
+}
+
+// Customizer.
+$customizer = INSPIRY_FRAMEWORK . 'customizer/customizer.php';
+if ( file_exists( $customizer ) ) {
+    require_once $customizer;
+}
+
+// RealHomes Admin.
+$rh_admin = INSPIRY_FRAMEWORK . 'include/admin/class-rh-admin.php';
+if ( file_exists( $rh_admin ) ) {
+    require_once $rh_admin;
+}
+
+// RealHomes Admin functions.
+$rh_admin_functions = INSPIRY_FRAMEWORK . 'include/admin/admin-functions.php';
+if ( file_exists( $rh_admin_functions ) ) {
+    require_once $rh_admin_functions;
+}
+
+// Theme meta boxes.
+$meta_boxes = [
+    'include/meta-boxes/post-meta-box.php',
+    'include/meta-boxes/home-page-meta-box.php',
+    'include/meta-boxes/meta-boxes.php',
+];
+
+foreach ( $meta_boxes as $meta_box ) {
+    $path = INSPIRY_FRAMEWORK . $meta_box;
+    if ( file_exists( $path ) ) {
+        require_once $path;
+    }
+}
+

--- a/realhomes/functions.php
+++ b/realhomes/functions.php
@@ -1,0 +1,28 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Fallback check for WooCommerce activation.
+ *
+ * Provides a lightweight implementation when the WooCommerce helper file is
+ * missing, avoiding fatal errors during theme setup.
+ *
+ * @return bool True if WooCommerce is detected, false otherwise.
+ */
+if ( ! function_exists( 'realhomes_is_woocommerce_activated' ) ) {
+    function realhomes_is_woocommerce_activated() {
+        return class_exists( 'WooCommerce' );
+    }
+}
+
+// Define framework path constant for reuse and load the theme framework.
+if ( ! defined( 'INSPIRY_FRAMEWORK' ) ) {
+    define( 'INSPIRY_FRAMEWORK', get_template_directory() . '/framework/' );
+}
+
+$framework = INSPIRY_FRAMEWORK . 'load.php';
+if ( file_exists( $framework ) ) {
+    require_once $framework;
+}


### PR DESCRIPTION
## Summary
- Guard 404 template against direct access with `ABSPATH` check
- Conditionally load function modules like Ajax Search and dashboard so missing files no longer trigger fatals
- Load Purchase API, RVR files, theme updater, Subscription API, data classes, basic functions, property meta custom icons, and WooCommerce helper only when present
- Safely check for Vacation Rentals plugin before loading its helpers to avoid undefined function errors
- Protect framework loader by verifying Google Fonts, Customizer, admin helpers, and meta box files exist before including them
- Provide fallbacks for `realhomes_is_woocommerce_activated` and `framework_excerpt` so theme setup and slider templates don't fail when helpers are absent
- Load the theme framework from `functions.php` and define `INSPIRY_FRAMEWORK` path constant before loading to avoid undefined constant errors

## Testing
- `find realhomes -name '*.php' -print0 | xargs -0 -n1 -P4 php -l`
- `php -l realhomes/framework/load.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb2e001f0832bbfc2714fe30d951f