### PR TITLE
feat: add Addon Ahousi search plugin

### DIFF
--- a/addon-ahousi/addon-ahousi.php
+++ b/addon-ahousi/addon-ahousi.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Plugin Name: Addon Ahousi
+ * Description: Instant search plugin providing autocomplete and quick results.
+ * Version: 0.1.0
+ * Author: ChatGPT
+ * License: GPL2
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Addon_Ahousi {
+    public function __construct() {
+        add_action('init', [ $this, 'register_shortcodes' ]);
+        add_action('wp_enqueue_scripts', [ $this, 'register_assets' ]);
+        add_action('rest_api_init', [ $this, 'register_routes' ]);
+    }
+
+    public function register_shortcodes() {
+        add_shortcode('addon_ahousi_search', [ $this, 'render_search' ]);
+    }
+
+    public function render_search() {
+        ob_start();
+        ?>
+        <div class="ahousi-search">
+            <div class="ahousi-search__field">
+                <span class="ahousi-search__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.471 6.471 0 001.48-5.34C15.22 5.01 12.21 2 8.61 2S2 5.01 2 8.39s3.01 6.39 6.39 6.39a6.471 6.471 0 005.34-1.48l.27.28v.79l4.99 4.98L20.49 19l-4.99-4.99zm-6.89 0C6.01 14 4 11.99 4 9.39S6.01 4.78 8.61 4.78s4.61 2.01 4.61 4.61-2.01 4.61-4.61 4.61z"/>
+                    </svg>
+                </span>
+                <input type="text" class="ahousi-search__input" placeholder="Buscar..." aria-label="Buscar" />
+            </div>
+            <ul class="ahousi-search__suggestions" role="listbox"></ul>
+            <div class="ahousi-search__results"></div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    public function register_assets() {
+        if (!is_admin()) {
+            wp_enqueue_style('addon-ahousi-style', plugin_dir_url(__FILE__) . 'assets/addon-ahousi.css', [], '0.1.0');
+            wp_enqueue_script('addon-ahousi-script', plugin_dir_url(__FILE__) . 'assets/addon-ahousi.js', [ 'wp-util' ], '0.1.0', true);
+        }
+    }
+
+    public function register_routes() {
+        register_rest_route('addon-ahousi/v1', '/query', [
+            'methods' => 'GET',
+            'callback' => [ $this, 'handle_query' ],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('addon-ahousi/v1', '/suggest', [
+            'methods' => 'GET',
+            'callback' => [ $this, 'handle_suggest' ],
+            'permission_callback' => '__return_true',
+        ]);
+    }
+
+    public function handle_query(\WP_REST_Request $request) {
+        $term = sanitize_text_field($request->get_param('q'));
+        $page = max(1, (int) $request->get_param('page'));
+        $post_types = $request->get_param('post_type');
+        $post_types = $post_types ? array_map('sanitize_key', (array) $post_types) : [ 'post', 'page' ];
+
+        $query = new \WP_Query([
+            's' => $term,
+            'post_type' => $post_types,
+            'posts_per_page' => 20,
+            'paged' => $page,
+        ]);
+
+        $items = [];
+        foreach ($query->posts as $post) {
+            $items[] = [
+                'title' => get_the_title($post),
+                'url' => get_permalink($post),
+                'snippet' => wp_html_excerpt($post->post_content, 120, '...'),
+                'type' => $post->post_type,
+                'category' => ( $cat = get_the_category($post->ID) ) ? $cat[0]->name : '',
+            ];
+        }
+
+        return rest_ensure_response([
+            'items' => $items,
+            'total' => (int) $query->found_posts,
+        ]);
+    }
+
+    public function handle_suggest(\WP_REST_Request $request) {
+        $term = sanitize_text_field($request->get_param('q'));
+        $query = new \WP_Query([
+            's' => $term,
+            'posts_per_page' => 8,
+            'post_type' => [ 'post', 'page' ],
+        ]);
+
+        $items = [];
+        foreach ($query->posts as $post) {
+            $items[] = [
+                'title' => get_the_title($post),
+                'url' => get_permalink($post),
+            ];
+        }
+
+        return rest_ensure_response([ 'items' => $items ]);
+    }
+}
+
+new Addon_Ahousi();

--- a/addon-ahousi/assets/addon-ahousi.css
+++ b/addon-ahousi/assets/addon-ahousi.css
@@ -1,0 +1,83 @@
+.ahousi-search {
+    position: relative;
+    max-width: 620px;
+    margin: 0 auto;
+}
+
+.ahousi-search__field {
+    position: relative;
+    display: flex;
+    align-items: center;
+    border: 1px solid #ccc;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    transition: box-shadow .2s;
+}
+
+.ahousi-search__field:focus-within {
+    box-shadow: 0 0 0 2px #ffea00, 0 2px 6px rgba(0,0,0,0.08);
+}
+
+.ahousi-search__icon {
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #777;
+    pointer-events: none;
+}
+
+.ahousi-search__input {
+    width: 100%;
+    padding: 0.75rem 1rem 0.75rem 2.5rem;
+    border: none;
+    background: transparent;
+    box-sizing: border-box;
+    font-size: 1rem;
+}
+
+.ahousi-search__input:focus {
+    outline: none;
+}
+
+.ahousi-search__suggestions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    z-index: 100;
+    overflow: hidden;
+}
+
+.ahousi-search__suggestions li {
+    padding: 0.625rem 1rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.ahousi-search__suggestions li:hover,
+.ahousi-search__suggestions li[aria-selected="true"] {
+    background: #f5f5f5;
+}
+
+.ahousi-search__results {
+    margin-top: 1rem;
+}
+
+.ahousi-search__results-item {
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #eee;
+}
+
+.ahousi-search__results-item mark {
+    background: #ffeb3b;
+}

--- a/addon-ahousi/assets/addon-ahousi.js
+++ b/addon-ahousi/assets/addon-ahousi.js
@@ -1,0 +1,70 @@
+(function(){
+    function debounce(fn, delay){
+        var timer;return function(){clearTimeout(timer);var args=arguments;timer=setTimeout(function(){fn.apply(null,args);},delay);};
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        var root = document.querySelector('.ahousi-search');
+        if(!root) return;
+        var input = root.querySelector('.ahousi-search__input');
+        var sugg = root.querySelector('.ahousi-search__suggestions');
+        var results = root.querySelector('.ahousi-search__results');
+        var selected = -1;
+
+        var fetchSuggest = debounce(function(term){
+            if(!term){sugg.innerHTML='';return;}
+            fetch('/wp-json/addon-ahousi/v1/suggest?q='+encodeURIComponent(term))
+                .then(function(r){return r.json();})
+                .then(function(data){
+                    var html='';
+                    var re=new RegExp('('+term.replace(/[-/\\^$*+?.()|[\]{}]/g,'\\$&')+')','ig');
+                    data.items.forEach(function(item){
+                        var title=item.title.replace(re,'<mark>$1</mark>');
+                        html+='<li role="option" data-url="'+item.url+'">'+title+'</li>';
+                    });
+                    sugg.innerHTML=html;
+                    selected=-1;
+                });
+        },250);
+
+        input.addEventListener('input', function(){
+            fetchSuggest(this.value);
+        });
+
+        input.addEventListener('keydown', function(e){
+            var items=sugg.querySelectorAll('li');
+            if(e.key==='ArrowDown'){selected=Math.min(selected+1,items.length-1);update();e.preventDefault();}
+            if(e.key==='ArrowUp'){selected=Math.max(selected-1,-1);update();e.preventDefault();}
+            if(e.key==='Enter'){
+                if(selected>-1 && items[selected]){window.location=items[selected].dataset.url;} else {performSearch(this.value);} e.preventDefault();
+            }
+            if(e.key==='Escape'){sugg.innerHTML='';}
+            function update(){items.forEach(function(li,i){li.setAttribute('aria-selected',i===selected);});}
+        });
+
+        sugg.addEventListener('click', function(e){
+            var li=e.target.closest('li');
+            if(li){window.location=li.dataset.url;}
+        });
+
+        document.addEventListener('click', function(e){
+            if(!root.contains(e.target)) sugg.innerHTML='';
+        });
+
+        function performSearch(term){
+            fetch('/wp-json/addon-ahousi/v1/query?q='+encodeURIComponent(term))
+                .then(function(r){return r.json();})
+                .then(function(data){
+                    var html='';
+                    data.items.forEach(function(item){
+                        var re=new RegExp('('+term.replace(/[-/\\^$*+?.()|[\]{}]/g,'\\$&')+')','ig');
+                        var title=item.title.replace(re,'<mark>$1</mark>');
+                        var snippet=item.snippet.replace(re,'<mark>$1</mark>');
+                        html+='<div class="ahousi-search__results-item">'+
+                            '<a href="'+item.url+'">'+title+'</a><p>'+snippet+'</p></div>';
+                    });
+                    results.innerHTML=html;
+                });
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- add Addon Ahousi plugin with REST search and suggest endpoints
- provide shortcode with pill-style search UI, assets and highlight
- refine UI to mirror Lopes search with icon, focus ring and styled suggestions

## Testing
- `php -l addon-ahousi/addon-ahousi.php`
- `node --check addon-ahousi/assets/addon-ahousi.js`


------
https://chatgpt.com/codex/tasks/task_e_68af15ad5988832b8affd504b5daf032