### PR TITLE
Reposition status buttons above keyword search

### DIFF
--- a/realhomes/assets/ultra/styles/css/custom.css
+++ b/realhomes/assets/ultra/styles/css/custom.css
@@ -1,0 +1,17 @@
+/* Custom CSS File for Buyers to Modify */
+
+/* Reposition "Alugar" and "Comprar" buttons above the keyword search field */
+.rh-ultra-search-form .rh-top-search-fields .rh-top-search-box {
+    display: flex;
+    flex-direction: column;
+}
+
+.rh-ultra-search-form .rh-status-field-wrapper,
+.rh-ultra-search-form .rh_status_field_wrapper {
+    order: 1;
+    margin-bottom: 10px;
+}
+
+.rh-ultra-search-form .rh_keyword_field_wrapper {
+    order: 2;
+}


### PR DESCRIPTION
## Summary
- Arrange search form to display rental/sale buttons above the keyword input
- Add custom CSS to stack fields vertically and prioritize status buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af874c576c832bbb3a9460eab93681