### PR TITLE
Add Chrome extension to invite Facebook post likers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# FB Post Like Inviter
+
+This Chrome extension helps page owners invite everyone who liked a Facebook post to like the page.
+
+## Usage
+
+1. Load the extension in Chrome using developer mode.
+2. Navigate to a Facebook post and open the list of people who liked it.
+3. Click the extension's toolbar icon to send invites to all visible users who have not yet been invited.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,6 @@
+chrome.action.onClicked.addListener((tab) => {
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    files: ['invite.js']
+  });
+});

--- a/invite.js
+++ b/invite.js
@@ -1,0 +1,12 @@
+(() => {
+  const buttons = Array.from(document.querySelectorAll('div[aria-label="Invite"]'));
+  document.querySelectorAll('button').forEach(btn => {
+    if (/invite/i.test(btn.textContent) && !buttons.includes(btn)) {
+      buttons.push(btn);
+    }
+  });
+  buttons.forEach(btn => {
+    btn.click();
+  });
+  console.log(`Invited ${buttons.length} users.`);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "FB Post Like Inviter",
+  "version": "1.0",
+  "description": "Invite users who liked a Facebook post to like the page.",
+  "permissions": ["activeTab", "scripting"],
+  "host_permissions": ["https://*.facebook.com/*"],
+  "action": {
+    "default_title": "Invite post likers"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add manifest v3 for extension
- add background script to inject invite script
- add content script to click "Invite" buttons on Facebook post likers
- add README with usage instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af77204458832ba44bc4c1a00695c1