### PR TITLE
Refine Glicenutre landing page to match ShadePro style

### DIFF
--- a/glicenutre.html
+++ b/glicenutre.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Glicenutre – Landing Page</title>
+  <!-- ShadePro theme styles (remote) -->
+  <link rel="stylesheet" href="https://compre.nutreessencia.com.br/wp-content/themes/shadepro/assets/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://compre.nutreessencia.com.br/wp-content/themes/shadepro/assets/css/core.css" />
+  <link rel="stylesheet" href="https://compre.nutreessencia.com.br/wp-content/themes/shadepro/style.css" />
+  <style>
+    body { font-family: 'Circular Std', sans-serif; }
+    .hero-section {
+      background-color: #03d0ad;
+      color: #fff;
+      padding: 100px 0;
+    }
+    .hero-section .btn-primary {
+      background-color: #473bf0;
+      border-color: #473bf0;
+    }
+    .benefits li { margin-bottom: 10px; }
+    footer { background-color: #161c2d; color:#fff; }
+  </style>
+</head>
+<body>
+  <!-- Hero Section -->
+  <section class="hero-section text-center">
+    <div class="container">
+      <h1 class="display-4 fw-bold">Glicenutre</h1>
+      <p class="lead mb-4">Seu aliado no bem-estar e controle glicêmico!</p>
+      <a href="#comprar" class="btn btn-primary btn-lg">QUERO MEU GLICENUTRE AGORA!</a>
+    </div>
+  </section>
+
+  <!-- Benefits -->
+  <section id="beneficios" class="py-5 bg-light">
+    <div class="container">
+      <h2 class="text-center mb-4">Benefícios</h2>
+      <ul class="benefits list-unstyled lead">
+        <li><i class="fas fa-check text-success me-2"></i>Ajuda a diminuir a necessidade de insulina e a variação glicêmica.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Traz sensação de saciedade e auxilia no controle do peso.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Fornece nutrientes necessários para uma vida mais saudável.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Colabora com a manutenção de níveis saudáveis de glicose.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Promove mais energia e disposição ao longo do dia.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Contribui para a saúde da visão e redução de desconfortos como formigamentos.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Fórmula com ingredientes que favorecem o bem-estar cardiovascular.</li>
+        <li><i class="fas fa-check text-success me-2"></i>Auxilia na redução do fluxo urinário.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- Description -->
+  <section id="descricao" class="py-5">
+    <div class="container">
+      <h2 class="text-center mb-4">Descrição do Produto</h2>
+      <p class="lead">Glicenutre com sua fórmula avançada, é ideal para quem busca mais equilíbrio no dia a dia, especialmente no apoio à estabilidade da glicemia, energia, bem-estar e vitalidade. Sua composição tem ingredientes reconhecidos por suas propriedades funcionais, como Vitamina B1, Vitamina B2, Vitamina B3, Vitamina B5, Vitamina B6, Vitamina B7, Vitamina B12, cromo, vitaminas essenciais e outros compostos que atuam em sinergia com o organismo.</p>
+      <p class="lead"><strong>Para que serve o cromo?</strong> Auxilia na ação da insulina, no metabolismo de nutrientes, no controle da glicemia, no ganho de massa muscular e na redução de gordura corporal.</p>
+    </div>
+  </section>
+
+  <!-- How to buy -->
+  <section id="como-comprar" class="py-5 bg-light">
+    <div class="container">
+      <h2 class="text-center mb-4">Como Comprar</h2>
+      <ol class="lead">
+        <li>Escolha seu Kit: Selecione quantos frascos e quanto mais unidades, mais descontos para você.</li>
+        <li>Compre pelo 0800/WhatsApp.</li>
+        <li>Aguarde a Entrega: Receba o seu pedido totalmente discreto e no conforto de seu lar.</li>
+      </ol>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="text-center py-3">
+    <p class="mb-0">&copy; 2024 Glicenutre. Todos os direitos reservados.</p>
+  </footer>
+
+  <!-- JS dependencies -->
+  <script src="https://compre.nutreessencia.com.br/wp-content/themes/shadepro/assets/js/bootstrap.bundle.min.js"></script>
+  <script src="https://compre.nutreessencia.com.br/wp-content/themes/shadepro/assets/js/fontawesome.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link ShadePro theme CSS from Nutreessencia site to mirror Nutrisource look
- style hero, benefits, description and purchase steps with theme colors and icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d1dec330832b84d0286e7ed7b494