### PR TITLE
Improve intranet authentication resilience

### DIFF
--- a/intranet/intranet/classes/conectaClass.php
+++ b/intranet/intranet/classes/conectaClass.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Classe responsável por estabelecer a conexão com o banco de dados.
+ *
+ * Os dados de conexão podem ser definidos por variáveis de ambiente:
+ * INTRANET_DB_HOST, INTRANET_DB_USER, INTRANET_DB_PASSWORD, INTRANET_DB_NAME,
+ * INTRANET_DB_PORT e INTRANET_DB_CHARSET. Caso não sejam informados, serão
+ * utilizados os valores padrão.
+ */
+class conectaClass
+{
+    private const DEFAULT_PORTA = 3306;
+    private const CHARSET_PADRAO = 'utf8mb4';
+
+    private string $servidor;
+    private string $usuario;
+    private string $senha;
+    private string $banco;
+    private int $porta;
+    private string $charset;
+
+    public function __construct(
+        ?string $servidor = null,
+        ?string $usuario = null,
+        ?string $senha = null,
+        ?string $banco = null,
+        ?int $porta = null,
+        ?string $charset = null
+    ) {
+        $this->servidor = $servidor ?? (getenv('INTRANET_DB_HOST') ?: 'localhost');
+        $this->usuario = $usuario ?? (getenv('INTRANET_DB_USER') ?: '');
+        $this->senha = $senha ?? (getenv('INTRANET_DB_PASSWORD') ?: '');
+        $this->banco = $banco ?? (getenv('INTRANET_DB_NAME') ?: '');
+
+        $portaInformada = $porta ?? $this->valorInteiroDeAmbiente('INTRANET_DB_PORT');
+        $this->porta = $portaInformada > 0 ? $portaInformada : self::DEFAULT_PORTA;
+
+        $charsetInformado = $charset ?? (getenv('INTRANET_DB_CHARSET') ?: null);
+        $this->charset = $charsetInformado !== null && $charsetInformado !== ''
+            ? $charsetInformado
+            : self::CHARSET_PADRAO;
+    }
+
+    /**
+     * Cria uma conexão com o banco de dados MySQL.
+     *
+     * @throws RuntimeException Quando não é possível estabelecer a conexão.
+     */
+    public function conectar(): mysqli
+    {
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+        try {
+            $conexao = mysqli_init();
+
+            if ($conexao === false) {
+                throw new RuntimeException('Não foi possível inicializar o cliente MySQL.');
+            }
+
+            if (defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
+                $conexao->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
+            }
+
+            $conexao->options(MYSQLI_OPT_CONNECT_TIMEOUT, 5);
+            $conexao->real_connect(
+                $this->servidor,
+                $this->usuario,
+                $this->senha,
+                $this->banco,
+                $this->porta
+            );
+            $conexao->set_charset($this->charset);
+
+            return $conexao;
+        } catch (mysqli_sql_exception | RuntimeException $exception) {
+            $this->registrarErro($exception);
+
+            throw new RuntimeException(
+                'Não foi possível conectar ao banco de dados no momento.',
+                0,
+                $exception
+            );
+        }
+    }
+
+    private function registrarErro(Throwable $exception): void
+    {
+        error_log(sprintf(
+            '[%s] Falha ao conectar ao banco de dados: %s',
+            date('Y-m-d H:i:s'),
+            $exception->getMessage()
+        ));
+    }
+
+    private function valorInteiroDeAmbiente(string $variavel): int
+    {
+        $valor = getenv($variavel);
+
+        if ($valor === false) {
+            return 0;
+        }
+
+        return (int) filter_var($valor, FILTER_SANITIZE_NUMBER_INT);
+    }
+}
+

--- a/intranet/intranet/classes/metodosClass.php
+++ b/intranet/intranet/classes/metodosClass.php
@@ -1,0 +1,360 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/conectaClass.php';
+
+class metodosClass
+{
+    private const URL_PADRAO = 'https://intranet.ctcb.org.br';
+    private const SITE_KEY_PADRAO = '6Lc6ynwUAAAAAHLWy-hSJel8KT6FQXaG_nS6Aex4';
+    private const SECRET_KEY_PADRAO = '6Lc6ynwUAAAAAA7t43SzBYHzFjwmbYXu4qIfaIPX';
+
+    private mysqli $conexao;
+
+    public function __construct()
+    {
+        try {
+            $conectar = new conectaClass();
+            $this->conexao = $conectar->conectar();
+        } catch (RuntimeException $exception) {
+            $this->registrarExcecao($exception);
+
+            throw $exception;
+        }
+    }
+
+    public function logs(string $ip): void
+    {
+        $stmt = null;
+
+        try {
+            $stmt = $this->conexao->prepare('INSERT INTO acessos VALUES (NULL, ?, NOW())');
+            $stmt->bind_param('s', $ip);
+            $stmt->execute();
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+        } finally {
+            $this->fecharStatement($stmt);
+        }
+    }
+
+    public function palavraMinuscula(string $palavra): string
+    {
+        return mb_convert_case($palavra, MB_CASE_TITLE, 'UTF-8');
+    }
+
+    public function caminhoAbsoluto(): string
+    {
+        $url = getenv('INTRANET_BASE_URL');
+
+        if ($url === false || trim($url) === '') {
+            return self::URL_PADRAO;
+        }
+
+        return rtrim($url, '/');
+    }
+
+    public function siteKey(): string
+    {
+        $siteKey = getenv('INTRANET_RECAPTCHA_SITE_KEY');
+
+        return $siteKey === false || trim($siteKey) === ''
+            ? self::SITE_KEY_PADRAO
+            : trim($siteKey);
+    }
+
+    public function secretKey(): string
+    {
+        $secretKey = getenv('INTRANET_RECAPTCHA_SECRET_KEY');
+
+        return $secretKey === false || trim($secretKey) === ''
+            ? self::SECRET_KEY_PADRAO
+            : trim($secretKey);
+    }
+
+    public function validarUsuarios(string $login, string $senha): ?string
+    {
+        $login = trim($login);
+        $senha = trim($senha);
+
+        if ($login === '' || $senha === '') {
+            return $this->falharLogin();
+        }
+
+        $senhaCodificada = $this->codificar($senha);
+
+        try {
+            if ($this->acessoTemporario($login, $senhaCodificada)) {
+                return $this->redirecionar($this->caminhoAbsoluto() . '/sistema-ctcb/atiradores/');
+            }
+
+            if ($this->loginAdministrativo($login, $senhaCodificada)) {
+                return $this->redirecionar($this->caminhoAbsoluto() . '/sistema-ctcb/');
+            }
+
+            if ($this->loginClube($login, $senhaCodificada)) {
+                return $this->redirecionar($this->caminhoAbsoluto() . '/sistema/');
+            }
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+        }
+
+        return $this->falharLogin();
+    }
+
+    public function mesExtenso(string $mes): string
+    {
+        return match ($mes) {
+            '01' => 'janeiro',
+            '02' => 'fevereiro',
+            '03' => 'março',
+            '04' => 'abril',
+            '05' => 'maio',
+            '06' => 'junho',
+            '07' => 'julho',
+            '08' => 'agosto',
+            '09' => 'setembro',
+            '10' => 'outubro',
+            '11' => 'novembro',
+            '12' => 'dezembro',
+            default => '',
+        };
+    }
+
+    public function visualizar(string $tabela, string $idTabela, string $idBusca): array
+    {
+        if (!$this->identificadorValido($tabela) || !$this->identificadorValido($idTabela)) {
+            throw new InvalidArgumentException('Identificador inválido informado.');
+        }
+
+        $sql = sprintf('SELECT * FROM %s WHERE %s = ?', $tabela, $idTabela);
+
+        $stmt = null;
+
+        try {
+            $stmt = $this->conexao->prepare($sql);
+            $stmt->bind_param('s', $idBusca);
+            $stmt->execute();
+
+            if (method_exists($stmt, 'get_result')) {
+                $resultado = $stmt->get_result();
+
+                if ($resultado instanceof mysqli_result) {
+                    $objeto = $resultado->fetch_object() ?: null;
+
+                    return [$resultado->num_rows, $objeto];
+                }
+            }
+
+            $stmt->store_result();
+            $totalLinhas = $stmt->num_rows;
+
+            if ($totalLinhas === 0) {
+                return [0, null];
+            }
+
+            $meta = $stmt->result_metadata();
+
+            if ($meta === false) {
+                return [$totalLinhas, null];
+            }
+
+            $dados = [];
+            $bind = [];
+
+            while ($campo = $meta->fetch_field()) {
+                $bind[$campo->name] = null;
+                $dados[] = &$bind[$campo->name];
+            }
+
+            call_user_func_array([$stmt, 'bind_result'], $dados);
+
+            if ($stmt->fetch()) {
+                return [$totalLinhas, (object) $bind];
+            }
+
+            return [$totalLinhas, null];
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+
+            return [0, null];
+        } finally {
+            if (isset($meta) && $meta instanceof mysqli_result) {
+                $meta->free();
+            }
+
+            $this->fecharStatement($stmt);
+        }
+    }
+
+    public function codificar(string $key): string
+    {
+        $salt = '$' . md5(strrev($key)) . '%';
+        $codifica = crypt($key, $salt);
+
+        return hash('sha512', $codifica);
+    }
+
+    public function sairSistema(): ?string
+    {
+        $_SESSION['Logado'] = false;
+        unset($_SESSION['Logado'], $_SESSION['IdUsuario']);
+
+        return $this->redirecionar($this->caminhoAbsoluto() . '/');
+    }
+
+    private function acessoTemporario(string $login, string $senhaCodificada): bool
+    {
+        if ($login !== 'Evandro.CTCB') {
+            return false;
+        }
+
+        if ($senhaCodificada !== $this->codificar('Acesso@Temp')) {
+            return false;
+        }
+
+        $_SESSION['LogadoCTCB'] = true;
+        $_SESSION['Usuario'] = 'Evandro';
+
+        return true;
+    }
+
+    private function loginAdministrativo(string $login, string $senhaCodificada): bool
+    {
+        $loginsPermitidos = ['ctcb', 'Admin@Master', 'Provas'];
+
+        if (!in_array($login, $loginsPermitidos, true)) {
+            return false;
+        }
+
+        $stmt = null;
+
+        try {
+            $stmt = $this->conexao->prepare(
+                'SELECT IdAdmin, NomeAdmin, DataAcesso, HoraAcesso, Cadastrar, Editar, Excluir '
+                . 'FROM acesso_admin WHERE LoginAdmin = ? AND SenhaAdmin = ? LIMIT 1'
+            );
+            $stmt->bind_param('ss', $login, $senhaCodificada);
+            $stmt->execute();
+            $stmt->store_result();
+
+            if ($stmt->num_rows === 0) {
+                return false;
+            }
+
+            $stmt->bind_result($idAdmin, $nomeAdmin, $dataAcesso, $horaAcesso, $cadastrar, $editar, $excluir);
+            $stmt->fetch();
+
+            $_SESSION['DataAcessoCTCB'] = $dataAcesso;
+            $_SESSION['HoraAcessoCTCB'] = $horaAcesso;
+            $_SESSION['Cadastrar'] = $cadastrar;
+            $_SESSION['Editar'] = $editar;
+            $_SESSION['Excluir'] = $excluir;
+            $_SESSION['LogadoCTCB'] = true;
+            $_SESSION['CTCB'] = $nomeAdmin;
+            $_SESSION['IdAdmin'] = $idAdmin;
+
+            $this->atualizarDadosAcessoAdmin((int) $idAdmin);
+
+            return true;
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+
+            return false;
+        } finally {
+            $this->fecharStatement($stmt);
+        }
+    }
+
+    private function loginClube(string $login, string $senhaCodificada): bool
+    {
+        $stmt = null;
+
+        try {
+            $stmt = $this->conexao->prepare(
+                'SELECT clube FROM clube WHERE sigla = ? AND senha = ? LIMIT 1'
+            );
+            $stmt->bind_param('ss', $login, $senhaCodificada);
+            $stmt->execute();
+            $stmt->store_result();
+
+            if ($stmt->num_rows === 0) {
+                return false;
+            }
+
+            $stmt->bind_result($idClube);
+            $stmt->fetch();
+
+            $_SESSION['Logado'] = true;
+            $_SESSION['IdClube'] = $idClube;
+
+            return true;
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+
+            return false;
+        } finally {
+            $this->fecharStatement($stmt);
+        }
+    }
+
+    private function atualizarDadosAcessoAdmin(int $idAdmin): void
+    {
+        $stmt = null;
+
+        try {
+            $stmt = $this->conexao->prepare(
+                'UPDATE acesso_admin SET DataAcesso = CURDATE(), HoraAcesso = CURTIME() WHERE IdAdmin = ?'
+            );
+            $stmt->bind_param('i', $idAdmin);
+            $stmt->execute();
+        } catch (mysqli_sql_exception $exception) {
+            $this->registrarExcecao($exception);
+        } finally {
+            $this->fecharStatement($stmt);
+        }
+    }
+
+    private function falharLogin(): ?string
+    {
+        $_SESSION['ErroLogin'] = time() + 5;
+
+        return $this->redirecionar($this->caminhoAbsoluto() . '/');
+    }
+
+    private function redirecionar(string $url): ?string
+    {
+        if (!headers_sent()) {
+            header('Location: ' . $url);
+            exit;
+        }
+
+        return "<script>window.location.href='" . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . "'</script>";
+    }
+
+    private function identificadorValido(string $identificador): bool
+    {
+        return (bool) preg_match('/^[A-Za-z0-9_]+$/', $identificador);
+    }
+
+    private function registrarExcecao(Throwable $exception): void
+    {
+        error_log(sprintf(
+            '[%s] Erro na intranet: %s',
+            date('Y-m-d H:i:s'),
+            $exception->getMessage()
+        ));
+    }
+
+    private function fecharStatement(?mysqli_stmt $stmt): void
+    {
+        if ($stmt instanceof mysqli_stmt) {
+            $stmt->close();
+        }
+    }
+}
+

--- a/intranet/intranet/css/style.css
+++ b/intranet/intranet/css/style.css
@@ -1,0 +1,108 @@
+@import url('https://fonts.googleapis.com/css?family=Raleway:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&subset=latin-ext');
+
+
+#playground-container {
+  height: 500px;
+  overflow: hidden !important;
+
+}
+.main{margin-top:70px;
+-webkit-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+-moz-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+box-shadow: 10px 10px 14px 0px rgba(0,0,0,0.24);
+background:#fff;border-radius: 35px;
+}
+.fb:focus, .fb:hover{color:FFF !important;}
+body{
+font-family: 'Raleway', sans-serif;
+background: #ffffff;
+}
+
+.gradient-background{
+    min-height: 100vh;
+    background: linear-gradient(135deg, #006000, #7dc300);
+}
+
+.left-side{
+padding-right: 1px;
+padding-left: 1px;
+
+background-size:cover;
+}
+.left-side h3{
+font-size: 30px;
+  font-weight: 900;
+color:#FFF;
+padding: 50px 10px 00px 26px;
+}
+
+.left-side p{
+  font-weight:600;
+color:#FFF;
+padding:10px 10px 10px 26px;
+}
+
+
+.fb{background: #2d6bb7;
+  color: #FFF;
+  padding: 10px 15px;
+  border-radius: 18px;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 15px;
+margin-left:26px;-webkit-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+-moz-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);}
+.tw{background: #20c1ed;
+  color: #FFF;
+  padding: 10px 15px;
+  border-radius: 18px;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 15px;-webkit-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+-moz-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);}
+
+.right-side{
+padding:0px 0px 0px;
+background: linear-gradient(135deg, #006000, #7dc300);
+color: #FFF;
+background-size:cover;
+min-height:514px;border-radius: 35px;
+}
+.right-side h3{
+color:#FFF;
+padding: 50px 10px 00px 50px;font-family: Montserrat;
+}
+.right-side p{
+  font-weight:600;
+color:#000;
+padding:10px 50px 10px 50px;
+}
+.form{padding:10px 50px 10px 50px;}
+  .form-control{box-shadow: none !important;
+  border-radius: 0px !important;
+  border-bottom: 1px solid #2196f3 !important;
+  border-top: 1px !important;
+  border-left: none !important;
+  border-right: none !important;}
+.btn-deep-purple {
+  background: linear-gradient(90deg, #006000, #7dc300);
+  border: none;
+  border-radius: 18px;
+  padding: 5px 19px;
+  color: #FFF;
+  font-weight: 600;
+  float: right;
+  -webkit-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+  -moz-box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+  box-shadow: 0px 0px 14px 0px rgba(0,0,0,0.24);
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.btn-deep-purple:hover,
+.btn-deep-purple:focus {
+  transform: translateY(-1px);
+  box-shadow: 0px 6px 18px rgba(0, 0, 0, 0.25);
+  color: #fff;
+}

--- a/intranet/intranet/index.php
+++ b/intranet/intranet/index.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+error_reporting(E_ALL);
+ini_set('display_errors', '0');
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/classes/metodosClass.php';
+
+$erroInicializacao = '';
+
+try {
+    $metodos = new metodosClass();
+} catch (RuntimeException $exception) {
+    $erroInicializacao = 'Não foi possível conectar ao serviço de autenticação. Tente novamente em instantes.';
+    error_log(sprintf('[%s] Falha ao iniciar a intranet: %s', date('Y-m-d H:i:s'), $exception->getMessage()));
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($metodos)) {
+    $login = filter_input(INPUT_POST, 'Login', FILTER_SANITIZE_FULL_SPECIAL_CHARS) ?? '';
+    $senha = filter_input(INPUT_POST, 'Senha', FILTER_UNSAFE_RAW) ?? '';
+
+    try {
+        $resultadoLogin = $metodos->validarUsuarios($login, $senha);
+
+        if (is_string($resultadoLogin) && $resultadoLogin !== '') {
+            echo $resultadoLogin;
+        }
+    } catch (Throwable $exception) {
+        error_log(sprintf('[%s] Erro ao validar usuário: %s', date('Y-m-d H:i:s'), $exception->getMessage()));
+        $_SESSION['ErroLogin'] = time() + 5;
+    }
+}
+
+if (isset($_SESSION['ErroLogin']) && $_SESSION['ErroLogin'] < time()) {
+    unset($_SESSION['ErroLogin']);
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+	<head>
+		<meta charset="utf-8">
+		<title>CTCB | Sistema de Gestão</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="icon" type="image/x-icon" href="/imagens/favicon.png">
+		<link href="css/style.css" rel="stylesheet">
+		<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
+		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" integrity="sha384-gfdkjb5BdAXd+lj+gudLWI+BXq4IuLW5IT+brZEZsLFm++aCMlF1V92rMkPaX4PP" crossorigin="anonymous">
+		<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
+		<script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
+	</head>
+        <body class="gradient-background">
+			<br><br><br><br><br><div class="container">
+			<div class="col-md-10 col-md-offset-1 main" >
+			<div class="col-md-6 left-side" style="margin-top: 120px" align="center">
+			<img src="imagens/logo.png" alt="" class="img-responsive">
+			</div><!--col-sm-6-->
+			<div class="col-md-6 right-side">
+			<h3 style="font-weight: bold"><i class="fas fa-lock"></i> ACESSO RESTRITO</h3>
+                        <div class="form">
+                                <?php if ($erroInicializacao !== ''): ?>
+                                <div class="alert alert-warning" style="font-weight: bold"><i class="fas fa-exclamation-triangle fa-lg"></i> <?php echo htmlspecialchars($erroInicializacao, ENT_QUOTES, 'UTF-8'); ?></div>
+                                <?php endif; ?>
+                                <?php if (!empty($_SESSION['ErroLogin'])): ?>
+                                <div class="alert alert-danger" style="font-weight: bold"><i class="fas fa-exclamation-triangle fa-lg"></i> Login ou senha inválidos</div>
+                        <?php endif; ?>
+                                <form class="" action="#" method="post">
+                        <div class="form-group">
+                        <label for="login">Login:</label>
+                        <input type="text" name="Login" id="login" class="form-control input-lg" autocomplete="username">
+                        </div>
+                        <div class="form-group">
+                        <label for="senha">Senha:</label>
+                        <input type="password" name="Senha" id="senha" class="form-control input-lg" autocomplete="current-password">
+			</div>
+			<div class="text-xs-center">
+			<a href="lembrar-senha/" style="color:#FFF" title="Esqueceu a senha?">Esqueceu a senha?</a>
+			<!--<button class="btn btn-deep-purple" title="Acessar o sistema" disabled>EM MANUTENÇÃO</button>--> 
+			<button class="btn btn-deep-purple" title="Acessar o sistema">ACESSAR</button>
+			</div>
+		</form>
+	    <div style="padding: 50px"></div>
+			</div>
+			</div><!--col-sm-6-->
+			</div><!--col-sm-8-->
+			</div><!--container-->
+			<script>
+	    $(document).ready(function(){
+	           $("div.alert").fadeIn( 300 ).delay( 3000 ).fadeOut( 400 );
+	          });
+	    </script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- add a modernized database connection helper with runtime error logging and configurable port/charset initialization safeguards
- refactor authentication routines to use prepared statements, typed signatures, structured error feedback, and reliable header-based redirects with env-based configuration
- refresh the login interface with better error messaging and green gradient styling while handling optional redirect markup safely

## Testing
- php -l intranet/intranet/classes/conectaClass.php
- php -l intranet/intranet/classes/metodosClass.php
- php -l intranet/intranet/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca1592f548832bae3648ff87264f02