### PR TITLE
Align landing content with theme sections

### DIFF
--- a/assets/img/ai-apresentacao.svg
+++ b/assets/img/ai-apresentacao.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="320" viewBox="0 0 420 320" fill="none">
+  <defs>
+    <linearGradient id="apresentacao-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#071022" />
+      <stop offset="100%" stop-color="#101f3f" />
+    </linearGradient>
+    <radialGradient id="apresentacao-glow" cx="0.6" cy="0.2" r="0.9">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#071022" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="stage-light" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5c518" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#f5c518" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="320" rx="28" fill="url(#apresentacao-bg)" />
+  <rect width="420" height="320" rx="28" fill="url(#apresentacao-glow)" />
+  <g opacity="0.4">
+    <circle cx="78" cy="80" r="60" fill="rgba(61, 169, 252, 0.35)" />
+    <circle cx="340" cy="68" r="76" fill="rgba(245, 197, 24, 0.28)" />
+  </g>
+  <path d="M50 230h320" stroke="rgba(255, 255, 255, 0.08)" stroke-width="2" />
+  <ellipse cx="210" cy="244" rx="150" ry="34" fill="#03060f" opacity="0.55" />
+  <ellipse cx="210" cy="232" rx="120" ry="26" fill="rgba(61, 169, 252, 0.25)" opacity="0.4" />
+  <g opacity="0.65">
+    <path d="M120 240L70 120" stroke="url(#stage-light)" stroke-width="10" stroke-linecap="round" />
+    <path d="M300 240l50-120" stroke="url(#stage-light)" stroke-width="10" stroke-linecap="round" />
+  </g>
+  <g>
+    <path d="M160 160c0-24 18-42 41-42s41 18 41 42-18 42-41 42-41-18-41-42z" fill="#14274d" stroke="#2b4782" stroke-width="4" />
+    <circle cx="203" cy="122" r="30" fill="#121b36" />
+    <path d="M182 116c6-12 18-20 32-20s26 8 32 20c-8 8-20 12-32 12s-24-4-32-12z" fill="#1c2649" />
+    <circle cx="212" cy="118" r="10" fill="#3da9fc" />
+    <path d="M186 162c-6 0-10 5-10 10v18c0 5 4 9 9 9h42c10 0 20 5 26 12l16 18c4 5 11 6 16 4h1c7-3 9-12 5-18l-15-30c-10-19-30-31-52-31z" fill="#3b4f9b" />
+  </g>
+  <g opacity="0.8">
+    <rect x="60" y="60" width="120" height="70" rx="18" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(61, 169, 252, 0.4)" stroke-width="2" />
+    <rect x="76" y="78" width="88" height="12" rx="6" fill="#3da9fc" opacity="0.7" />
+    <rect x="76" y="100" width="56" height="10" rx="5" fill="#3da9fc" opacity="0.4" />
+  </g>
+  <g opacity="0.8">
+    <rect x="240" y="56" width="130" height="80" rx="20" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(245, 197, 24, 0.4)" stroke-width="2" />
+    <rect x="258" y="78" width="94" height="12" rx="6" fill="#f5c518" opacity="0.75" />
+    <rect x="258" y="100" width="70" height="10" rx="5" fill="#f5c518" opacity="0.4" />
+  </g>
+  <g opacity="0.3">
+    <circle cx="134" cy="210" r="8" fill="#3da9fc" />
+    <circle cx="282" cy="206" r="8" fill="#f5c518" />
+    <circle cx="340" cy="210" r="10" fill="#7b5bff" />
+  </g>
+  <text x="210" y="282" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">
+    Palco presencial com plateia engajada
+  </text>
+</svg>

--- a/assets/img/ai-gravacao.svg
+++ b/assets/img/ai-gravacao.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="320" viewBox="0 0 420 320" fill="none">
+  <defs>
+    <linearGradient id="gravacao-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#081224" />
+      <stop offset="100%" stop-color="#131f3e" />
+    </linearGradient>
+    <radialGradient id="gravacao-glow" cx="0.5" cy="0.2" r="0.85">
+      <stop offset="0%" stop-color="#7b5bff" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#081224" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="spotlight" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#f5c518" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#f5c518" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="320" rx="28" fill="url(#gravacao-bg)" />
+  <rect width="420" height="320" rx="28" fill="url(#gravacao-glow)" />
+  <g opacity="0.45">
+    <circle cx="90" cy="90" r="70" fill="rgba(61, 169, 252, 0.28)" />
+    <circle cx="320" cy="70" r="72" fill="rgba(245, 197, 24, 0.22)" />
+  </g>
+  <path d="M120 300h180l-38-220h-104z" fill="rgba(10, 16, 36, 0.85)" stroke="rgba(61, 169, 252, 0.25)" stroke-width="2" />
+  <path d="M178 98h64l36 202h-136z" fill="rgba(10, 16, 36, 0.75)" />
+  <rect x="138" y="102" width="36" height="204" rx="10" fill="rgba(61, 169, 252, 0.18)" />
+  <rect x="246" y="102" width="36" height="204" rx="10" fill="rgba(123, 91, 255, 0.18)" />
+  <ellipse cx="210" cy="278" rx="80" ry="20" fill="#03060f" opacity="0.55" />
+  <path d="M210 96c18 0 32-14 32-32s-14-32-32-32-32 14-32 32 14 32 32 32z" fill="#1b2747" stroke="#2b4a80" stroke-width="4" />
+  <circle cx="210" cy="56" r="18" fill="#3da9fc" />
+  <path d="M178 106v18c0 7 6 12 13 12h38c8 0 14-5 14-12v-18z" fill="#3da9fc" opacity="0.15" />
+  <g opacity="0.65">
+    <path d="M72 188 112 92" stroke="url(#spotlight)" stroke-width="10" stroke-linecap="round" />
+    <path d="M348 188 308 92" stroke="url(#spotlight)" stroke-width="10" stroke-linecap="round" />
+  </g>
+  <g>
+    <rect x="168" y="150" width="84" height="48" rx="12" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(61, 169, 252, 0.35)" stroke-width="2" />
+    <rect x="182" y="166" width="56" height="16" rx="8" fill="#3da9fc" opacity="0.75" />
+    <rect x="182" y="188" width="48" height="10" rx="5" fill="#3da9fc" opacity="0.4" />
+  </g>
+  <g opacity="0.7">
+    <path d="M90 240h36" stroke="#3da9fc" stroke-width="4" stroke-linecap="round" />
+    <path d="M294 240h36" stroke="#f5c518" stroke-width="4" stroke-linecap="round" />
+  </g>
+  <text x="210" y="308" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">
+    Estúdio iluminado para gravações impactantes
+  </text>
+</svg>

--- a/assets/img/ai-metodo.svg
+++ b/assets/img/ai-metodo.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="520" viewBox="0 0 560 520" fill="none">
+  <defs>
+    <linearGradient id="metodo-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#070c1d" />
+      <stop offset="100%" stop-color="#101c3f" />
+    </linearGradient>
+    <radialGradient id="metodo-glow" cx="0.5" cy="0.2" r="0.8">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.38" />
+      <stop offset="100%" stop-color="#070c1d" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="pillar-blue" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3da9fc" />
+      <stop offset="100%" stop-color="#1d3f8f" />
+    </linearGradient>
+    <linearGradient id="pillar-gold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f5c518" />
+      <stop offset="100%" stop-color="#a47a12" />
+    </linearGradient>
+    <linearGradient id="pillar-purple" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7b5bff" />
+      <stop offset="100%" stop-color="#3a2ca0" />
+    </linearGradient>
+  </defs>
+  <rect width="560" height="520" rx="36" fill="url(#metodo-bg)" />
+  <rect width="560" height="520" rx="36" fill="url(#metodo-glow)" />
+  <ellipse cx="280" cy="420" rx="220" ry="60" fill="#03060f" opacity="0.55" />
+  <ellipse cx="280" cy="404" rx="180" ry="40" fill="rgba(61, 169, 252, 0.22)" opacity="0.35" />
+  <g opacity="0.65">
+    <circle cx="132" cy="110" r="80" fill="rgba(61, 169, 252, 0.25)" />
+    <circle cx="434" cy="96" r="96" fill="rgba(245, 197, 24, 0.22)" />
+  </g>
+  <g opacity="0.35">
+    <path d="M280 160c58 0 108 20 140 54 6 6 6 16 0 22-28 30-80 50-140 50s-112-20-140-50c-6-6-6-16 0-22 32-34 82-54 140-54z" fill="#101d3e" />
+  </g>
+  <g>
+    <rect x="138" y="204" width="100" height="180" rx="24" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(61, 169, 252, 0.4)" stroke-width="3" />
+    <rect x="152" y="224" width="72" height="32" rx="16" fill="rgba(61, 169, 252, 0.18)" />
+    <rect x="152" y="268" width="52" height="12" rx="6" fill="#3da9fc" opacity="0.7" />
+    <rect x="152" y="286" width="68" height="12" rx="6" fill="#3da9fc" opacity="0.4" />
+    <text x="188" y="360" fill="#3da9fc" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Clareza
+    </text>
+  </g>
+  <g>
+    <rect x="230" y="156" width="100" height="232" rx="24" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(245, 197, 24, 0.4)" stroke-width="3" />
+    <rect x="244" y="178" width="72" height="32" rx="16" fill="rgba(245, 197, 24, 0.25)" />
+    <rect x="244" y="220" width="52" height="12" rx="6" fill="#f5c518" opacity="0.75" />
+    <rect x="244" y="238" width="68" height="12" rx="6" fill="#f5c518" opacity="0.45" />
+    <text x="280" y="356" fill="#f5c518" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Confiança
+    </text>
+  </g>
+  <g>
+    <rect x="322" y="232" width="100" height="152" rx="24" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(123, 91, 255, 0.4)" stroke-width="3" />
+    <rect x="336" y="252" width="72" height="32" rx="16" fill="rgba(123, 91, 255, 0.22)" />
+    <rect x="336" y="296" width="52" height="12" rx="6" fill="#7b5bff" opacity="0.7" />
+    <rect x="336" y="314" width="68" height="12" rx="6" fill="#7b5bff" opacity="0.4" />
+    <text x="372" y="360" fill="#b7a4ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Convencimento
+    </text>
+  </g>
+  <g opacity="0.3">
+    <circle cx="160" cy="370" r="14" fill="#3da9fc" />
+    <circle cx="408" cy="182" r="10" fill="#f5c518" />
+    <circle cx="464" cy="340" r="12" fill="#7b5bff" />
+  </g>
+  <text x="280" y="96" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" text-anchor="middle">
+    Método dos 3 C's
+  </text>
+  <text x="280" y="130" fill="#c5c9e6" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="400" text-anchor="middle">
+    Clareza para se fazer entender • Confiança para sustentar a mensagem • Convencimento para mover pessoas
+  </text>
+</svg>

--- a/assets/img/ai-reuniao.svg
+++ b/assets/img/ai-reuniao.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="420" height="320" viewBox="0 0 420 320" fill="none">
+  <defs>
+    <linearGradient id="reuniao-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#061224" />
+      <stop offset="100%" stop-color="#111f3f" />
+    </linearGradient>
+    <radialGradient id="reuniao-glow" cx="0.3" cy="0.1" r="1">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#061224" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="420" height="320" rx="28" fill="url(#reuniao-bg)" />
+  <rect width="420" height="320" rx="28" fill="url(#reuniao-glow)" />
+  <g opacity="0.35">
+    <circle cx="112" cy="64" r="60" fill="rgba(61, 169, 252, 0.32)" />
+    <circle cx="320" cy="82" r="74" fill="rgba(245, 197, 24, 0.28)" />
+  </g>
+  <rect x="42" y="96" width="336" height="180" rx="24" fill="rgba(10, 16, 36, 0.85)" stroke="rgba(61, 169, 252, 0.3)" stroke-width="2" />
+  <rect x="62" y="112" width="296" height="40" rx="14" fill="rgba(61, 169, 252, 0.14)" />
+  <rect x="62" y="162" width="134" height="78" rx="18" fill="rgba(10, 16, 36, 0.75)" stroke="rgba(61, 169, 252, 0.35)" stroke-width="2" />
+  <rect x="84" y="182" width="88" height="14" rx="7" fill="#3da9fc" opacity="0.75" />
+  <rect x="84" y="204" width="70" height="12" rx="6" fill="#3da9fc" opacity="0.45" />
+  <rect x="216" y="162" width="134" height="78" rx="18" fill="rgba(10, 16, 36, 0.75)" stroke="rgba(245, 197, 24, 0.35)" stroke-width="2" />
+  <rect x="236" y="182" width="94" height="14" rx="7" fill="#f5c518" opacity="0.75" />
+  <rect x="236" y="204" width="78" height="12" rx="6" fill="#f5c518" opacity="0.45" />
+  <g opacity="0.6">
+    <rect x="90" y="248" width="240" height="12" rx="6" fill="rgba(61, 169, 252, 0.28)" />
+    <rect x="90" y="266" width="180" height="10" rx="5" fill="rgba(61, 169, 252, 0.18)" />
+  </g>
+  <path d="M210 266c12 0 22 8 22 18s-10 18-22 18-22-8-22-18 10-18 22-18z" fill="#3da9fc" opacity="0.22" />
+  <text x="210" y="298" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" text-anchor="middle">
+    Reunião híbrida com dashboards ao vivo
+  </text>
+  <g opacity="0.8">
+    <circle cx="118" cy="132" r="10" fill="#3da9fc" />
+    <circle cx="146" cy="132" r="10" fill="#7b5bff" />
+    <circle cx="174" cy="132" r="10" fill="#f5c518" />
+    <rect x="206" y="124" width="140" height="16" rx="8" fill="#3da9fc" opacity="0.7" />
+    <rect x="206" y="146" width="100" height="10" rx="5" fill="#3da9fc" opacity="0.4" />
+  </g>
+</svg>

--- a/assets/img/ai-suporte.svg
+++ b/assets/img/ai-suporte.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="520" height="480" viewBox="0 0 520 480" fill="none">
+  <defs>
+    <linearGradient id="suporte-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#061224" />
+      <stop offset="100%" stop-color="#122245" />
+    </linearGradient>
+    <radialGradient id="suporte-glow" cx="0.6" cy="0.1" r="0.9">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#061224" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="520" height="480" rx="32" fill="url(#suporte-bg)" />
+  <rect width="520" height="480" rx="32" fill="url(#suporte-glow)" />
+  <g opacity="0.4">
+    <circle cx="120" cy="84" r="76" fill="rgba(61, 169, 252, 0.3)" />
+    <circle cx="380" cy="74" r="90" fill="rgba(245, 197, 24, 0.26)" />
+  </g>
+  <rect x="80" y="140" width="360" height="220" rx="28" fill="rgba(10, 16, 36, 0.85)" stroke="rgba(61, 169, 252, 0.3)" stroke-width="2.5" />
+  <rect x="108" y="166" width="156" height="96" rx="20" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(61, 169, 252, 0.4)" stroke-width="2" />
+  <rect x="128" y="188" width="116" height="14" rx="7" fill="#3da9fc" opacity="0.75" />
+  <rect x="128" y="212" width="96" height="12" rx="6" fill="#3da9fc" opacity="0.45" />
+  <rect x="256" y="166" width="156" height="96" rx="20" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(245, 197, 24, 0.4)" stroke-width="2" />
+  <rect x="276" y="188" width="116" height="14" rx="7" fill="#f5c518" opacity="0.75" />
+  <rect x="276" y="212" width="96" height="12" rx="6" fill="#f5c518" opacity="0.45" />
+  <rect x="108" y="278" width="304" height="38" rx="18" fill="rgba(61, 169, 252, 0.16)" />
+  <g>
+    <rect x="128" y="300" width="264" height="56" rx="18" fill="rgba(61, 169, 252, 0.14)" />
+    <rect x="148" y="318" width="152" height="16" rx="8" fill="#3da9fc" opacity="0.65" />
+    <rect x="312" y="318" width="62" height="16" rx="8" fill="#f5c518" opacity="0.65" />
+  </g>
+  <g opacity="0.85">
+    <circle cx="108" cy="120" r="14" fill="#3da9fc" />
+    <circle cx="144" cy="120" r="14" fill="#7b5bff" />
+    <circle cx="180" cy="120" r="14" fill="#f5c518" />
+    <rect x="218" y="108" width="180" height="20" rx="10" fill="#3da9fc" opacity="0.7" />
+    <rect x="218" y="134" width="130" height="12" rx="6" fill="#3da9fc" opacity="0.4" />
+  </g>
+  <g opacity="0.3">
+    <circle cx="132" cy="352" r="10" fill="#3da9fc" />
+    <circle cx="268" cy="360" r="12" fill="#f5c518" />
+    <circle cx="392" cy="352" r="10" fill="#7b5bff" />
+  </g>
+  <text x="260" y="398" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="22" font-weight="600" text-anchor="middle">
+    Equipe ativa, dashboards e canais 24/7
+  </text>
+  <text x="260" y="430" fill="#c5c9e6" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="16" font-weight="400" text-anchor="middle">
+    Central única com relatórios, plantões ao vivo e comunidade moderada
+  </text>
+</svg>

--- a/assets/img/ai-trilha.svg
+++ b/assets/img/ai-trilha.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="540" height="520" viewBox="0 0 540 520" fill="none">
+  <defs>
+    <linearGradient id="trilha-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#060f22" />
+      <stop offset="100%" stop-color="#101f3f" />
+    </linearGradient>
+    <radialGradient id="trilha-glow" cx="0.7" cy="0.2" r="0.9">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#060f22" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="540" height="520" rx="32" fill="url(#trilha-bg)" />
+  <rect width="540" height="520" rx="32" fill="url(#trilha-glow)" />
+  <g opacity="0.45">
+    <circle cx="110" cy="98" r="78" fill="rgba(61, 169, 252, 0.28)" />
+    <circle cx="420" cy="86" r="90" fill="rgba(245, 197, 24, 0.24)" />
+  </g>
+  <path d="M86 404c0-118 104-214 232-214 42 0 80 8 112 22" stroke="rgba(61, 169, 252, 0.5)" stroke-width="6" stroke-linecap="round" stroke-dasharray="12 18" />
+  <path d="M86 352c0-98 88-176 196-176 38 0 72 10 100 26" stroke="rgba(245, 197, 24, 0.45)" stroke-width="4" stroke-linecap="round" stroke-dasharray="10 16" />
+  <g>
+    <rect x="112" y="188" width="120" height="120" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(61, 169, 252, 0.35)" stroke-width="3" />
+    <text x="172" y="226" fill="#3da9fc" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Start
+    </text>
+    <rect x="128" y="242" width="88" height="12" rx="6" fill="#3da9fc" opacity="0.7" />
+    <rect x="128" y="262" width="72" height="10" rx="5" fill="#3da9fc" opacity="0.4" />
+  </g>
+  <g>
+    <rect x="224" y="130" width="120" height="140" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(245, 197, 24, 0.35)" stroke-width="3" />
+    <text x="284" y="174" fill="#f5c518" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Fase 1
+    </text>
+    <rect x="240" y="190" width="88" height="12" rx="6" fill="#f5c518" opacity="0.7" />
+    <rect x="240" y="210" width="72" height="10" rx="5" fill="#f5c518" opacity="0.4" />
+  </g>
+  <g>
+    <rect x="348" y="184" width="120" height="150" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(123, 91, 255, 0.35)" stroke-width="3" />
+    <text x="408" y="230" fill="#b8a6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Fase 2
+    </text>
+    <rect x="364" y="246" width="88" height="12" rx="6" fill="#7b5bff" opacity="0.65" />
+    <rect x="364" y="266" width="72" height="10" rx="5" fill="#7b5bff" opacity="0.35" />
+  </g>
+  <g>
+    <rect x="204" y="296" width="120" height="140" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(61, 169, 252, 0.35)" stroke-width="3" />
+    <text x="264" y="340" fill="#3da9fc" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Fase 3
+    </text>
+    <rect x="220" y="356" width="88" height="12" rx="6" fill="#3da9fc" opacity="0.7" />
+    <rect x="220" y="376" width="72" height="10" rx="5" fill="#3da9fc" opacity="0.4" />
+  </g>
+  <g>
+    <rect x="334" y="320" width="120" height="120" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(245, 197, 24, 0.35)" stroke-width="3" />
+    <text x="394" y="360" fill="#f5c518" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      Fase 4
+    </text>
+    <rect x="350" y="376" width="88" height="12" rx="6" fill="#f5c518" opacity="0.7" />
+    <rect x="350" y="396" width="72" height="10" rx="5" fill="#f5c518" opacity="0.4" />
+  </g>
+  <g>
+    <rect x="96" y="336" width="120" height="120" rx="26" fill="rgba(10, 16, 36, 0.82)" stroke="rgba(123, 91, 255, 0.35)" stroke-width="3" />
+    <text x="156" y="378" fill="#b8a6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="600" text-anchor="middle">
+      End
+    </text>
+    <rect x="112" y="394" width="88" height="12" rx="6" fill="#7b5bff" opacity="0.65" />
+    <rect x="112" y="414" width="72" height="10" rx="5" fill="#7b5bff" opacity="0.35" />
+  </g>
+  <path d="M172 248l54-34" stroke="#3da9fc" stroke-width="4" stroke-linecap="round" />
+  <path d="M292 218l46 26" stroke="#f5c518" stroke-width="4" stroke-linecap="round" />
+  <path d="M270 332l40 32" stroke="#7b5bff" stroke-width="4" stroke-linecap="round" />
+  <path d="M206 360l-30 32" stroke="#3da9fc" stroke-width="4" stroke-linecap="round" />
+  <text x="270" y="84" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="30" font-weight="700" text-anchor="middle">
+    Jornada do aluno
+  </text>
+  <text x="270" y="116" fill="#c5c9e6" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="16" font-weight="400" text-anchor="middle">
+    Da avaliação inicial ao plano de sustentação em trilha orientada
+  </text>
+</svg>

--- a/assets/img/hero-illustration.svg
+++ b/assets/img/hero-illustration.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="640" viewBox="0 0 880 640" fill="none">
+  <defs>
+    <linearGradient id="hero-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#070b1d" />
+      <stop offset="50%" stop-color="#0e1634" />
+      <stop offset="100%" stop-color="#101b3f" />
+    </linearGradient>
+    <radialGradient id="hero-glow" cx="0.5" cy="0.9" r="0.65">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.5" />
+      <stop offset="100%" stop-color="#070b1d" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="hero-stage" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#3da9fc" />
+      <stop offset="100%" stop-color="#2b7bd1" />
+    </linearGradient>
+    <linearGradient id="hero-dress" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3f7bff" />
+      <stop offset="100%" stop-color="#122d78" />
+    </linearGradient>
+    <linearGradient id="hero-skin" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8d7c8" />
+      <stop offset="100%" stop-color="#e6b79d" />
+    </linearGradient>
+    <radialGradient id="card-glow" cx="0.5" cy="0.5" r="0.9">
+      <stop offset="0%" stop-color="#f5c518" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#070b1d" stop-opacity="0" />
+    </radialGradient>
+    <filter id="hero-blur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="60" />
+    </filter>
+  </defs>
+  <rect width="880" height="640" rx="36" fill="url(#hero-bg)" />
+  <rect width="880" height="640" rx="36" fill="url(#hero-glow)" />
+  <g filter="url(#hero-blur)">
+    <circle cx="160" cy="140" r="90" fill="rgba(61, 169, 252, 0.32)" />
+    <circle cx="720" cy="120" r="110" fill="rgba(245, 197, 24, 0.28)" />
+    <circle cx="760" cy="420" r="130" fill="rgba(104, 74, 255, 0.24)" />
+  </g>
+  <ellipse cx="440" cy="490" rx="280" ry="70" fill="#04070f" opacity="0.5" />
+  <ellipse cx="440" cy="470" rx="230" ry="45" fill="url(#hero-stage)" opacity="0.35" />
+  <ellipse cx="440" cy="452" rx="200" ry="30" fill="rgba(61, 169, 252, 0.28)" opacity="0.45" />
+  <g opacity="0.85">
+    <rect x="214" y="140" width="180" height="110" rx="24" fill="rgba(10, 16, 36, 0.75)" stroke="rgba(61, 169, 252, 0.35)" stroke-width="2" />
+    <rect x="222" y="152" width="164" height="30" rx="12" fill="rgba(61, 169, 252, 0.14)" />
+    <rect x="222" y="192" width="72" height="12" rx="6" fill="#3da9fc" opacity="0.7" />
+    <rect x="222" y="212" width="126" height="12" rx="6" fill="#3da9fc" opacity="0.35" />
+    <rect x="486" y="110" width="220" height="130" rx="28" fill="rgba(10, 16, 36, 0.75)" stroke="rgba(245, 197, 24, 0.35)" stroke-width="2" />
+    <rect x="502" y="130" width="188" height="30" rx="14" fill="rgba(245, 197, 24, 0.18)" />
+    <rect x="502" y="172" width="88" height="14" rx="7" fill="#f5c518" opacity="0.6" />
+    <rect x="502" y="196" width="142" height="14" rx="7" fill="#f5c518" opacity="0.35" />
+  </g>
+  <g>
+    <path d="M428 254c0-23 18-41 41-41s41 18 41 41-18 41-41 41-41-18-41-41z" fill="#0f1d40" stroke="#2f3f7a" stroke-width="4" />
+    <circle cx="469" cy="220" r="38" fill="#101733" />
+    <path d="M453 210c6-12 18-20 32-20 14 0 26 8 32 20-8 8-20 13-32 13s-24-5-32-13z" fill="#1c264d" />
+    <circle cx="485" cy="214" r="12" fill="#3da9fc" />
+    <path d="M445 256c-6 0-11 5-11 11v18c0 5 4 9 9 9h46c11 0 22 5 29 14l20 25c4 5 11 6 17 4h1c7-3 10-11 7-18l-20-46c-9-20-29-33-50-33z" fill="url(#hero-dress)" />
+    <path d="M499 268c18 2 34 13 42 30l18 42" stroke="#8fb5ff" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+    <path d="M421 322c9 18 20 33 33 46 10 10 23 16 37 18l-8 72c-1 9 6 17 16 17h4c8 0 15-6 16-14l15-90" stroke="#0d1329" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <path d="M470 325 432 452" stroke="#12265a" stroke-width="12" stroke-linecap="round" />
+    <path d="M520 325 552 452" stroke="#12265a" stroke-width="12" stroke-linecap="round" />
+    <path d="M429 250c-8-22 3-47 25-55 20-7 41 1 52 18-6 4-13 6-21 6-10 0-19-3-26-9-7 11-19 18-30 20z" fill="#fcded0" />
+    <path d="M507 285c0-6 4-10 10-10 5 0 10 4 10 10s-5 10-10 10c-6 0-10-4-10-10z" fill="#f5c518" />
+  </g>
+  <g opacity="0.6">
+    <path d="M350 420h-80c-6 0-10 4-10 10v20c0 6 4 10 10 10h80c6 0 10-4 10-10v-20c0-6-4-10-10-10z" fill="rgba(61, 169, 252, 0.12)" stroke="rgba(61, 169, 252, 0.4)" stroke-width="2" />
+    <circle cx="285" cy="430" r="6" fill="#3da9fc" />
+    <circle cx="305" cy="430" r="6" fill="#3da9fc" opacity="0.7" />
+  </g>
+  <g opacity="0.65">
+    <path d="M612 404h88c6 0 10 4 10 10v24c0 6-4 10-10 10h-88c-6 0-10-4-10-10v-24c0-6 4-10 10-10z" fill="rgba(245, 197, 24, 0.12)" stroke="rgba(245, 197, 24, 0.4)" stroke-width="2" />
+    <rect x="628" y="418" width="58" height="8" rx="4" fill="#f5c518" />
+    <rect x="628" y="432" width="42" height="8" rx="4" fill="#f5c518" opacity="0.6" />
+  </g>
+  <g opacity="0.4">
+    <circle cx="272" cy="360" r="8" fill="#3da9fc" />
+    <circle cx="608" cy="176" r="6" fill="#f5c518" />
+    <circle cx="196" cy="276" r="10" fill="#3da9fc" />
+    <circle cx="672" cy="316" r="12" fill="#f5c518" />
+  </g>
+  <g opacity="0.7">
+    <path d="M412 140 388 120" stroke="#3da9fc" stroke-width="3" stroke-linecap="round" />
+    <path d="M466 124 482 100" stroke="#f5c518" stroke-width="3" stroke-linecap="round" />
+    <path d="M520 148 544 130" stroke="#3da9fc" stroke-width="3" stroke-linecap="round" />
+  </g>
+  <circle cx="430" cy="118" r="26" fill="rgba(61, 169, 252, 0.16)" />
+  <circle cx="510" cy="104" r="18" fill="rgba(245, 197, 24, 0.18)" />
+</svg>

--- a/assets/img/og-image.svg
+++ b/assets/img/og-image.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <defs>
+    <linearGradient id="og-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#060b1d" />
+      <stop offset="45%" stop-color="#0f1a38" />
+      <stop offset="100%" stop-color="#111f45" />
+    </linearGradient>
+    <radialGradient id="og-overlay" cx="0.75" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.48" />
+      <stop offset="100%" stop-color="#060b1d" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="og-stage" cx="0.5" cy="1" r="0.9">
+      <stop offset="0%" stop-color="#3da9fc" stop-opacity="0.55" />
+      <stop offset="100%" stop-color="#070b1d" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="og-dress" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#527cff" />
+      <stop offset="100%" stop-color="#1a2f7d" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="40" fill="url(#og-bg)" />
+  <rect width="1200" height="630" rx="40" fill="url(#og-overlay)" />
+  <g opacity="0.6">
+    <circle cx="180" cy="140" r="110" fill="rgba(61, 169, 252, 0.28)" />
+    <circle cx="1040" cy="120" r="140" fill="rgba(245, 197, 24, 0.24)" />
+    <circle cx="980" cy="460" r="160" fill="rgba(111, 92, 255, 0.22)" />
+  </g>
+  <ellipse cx="340" cy="470" rx="250" ry="90" fill="#03060f" opacity="0.55" />
+  <ellipse cx="348" cy="450" rx="210" ry="62" fill="url(#og-stage)" opacity="0.8" />
+  <g>
+    <path d="M268 284c0-28 22-50 50-50s50 22 50 50-22 50-50 50-50-22-50-50z" fill="#13264e" stroke="#28427a" stroke-width="5" />
+    <circle cx="328" cy="240" r="44" fill="#121a37" />
+    <path d="M306 232c8-14 23-22 40-22 17 0 32 8 40 22-9 9-24 15-40 15s-31-6-40-15z" fill="#1c2549" />
+    <circle cx="346" cy="234" r="14" fill="#3da9fc" />
+    <path d="M298 288c-8 0-14 6-14 14v24c0 7 6 12 13 12h58c13 0 25 6 33 16l26 32c4 6 12 8 18 6h1c9-4 13-14 8-23l-27-58c-12-25-36-41-63-41z" fill="url(#og-dress)" />
+    <path d="M364 302c23 2 42 16 52 36l22 48" stroke="#94b8ff" stroke-width="7" stroke-linecap="round" opacity="0.7" />
+    <path d="M288 352c12 23 26 42 42 58 13 12 28 20 46 23l-10 92c-1 11 8 20 19 20h4c10 0 18-7 19-17l18-114" stroke="#0d1429" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <path d="M330 358 280 506" stroke="#1d3570" stroke-width="14" stroke-linecap="round" />
+    <path d="M396 358 438 506" stroke="#1d3570" stroke-width="14" stroke-linecap="round" />
+    <path d="M290 282c-9-26 5-54 30-62 23-8 48 2 61 22-8 5-16 7-26 7-12 0-23-4-31-11-9 12-22 20-34 22z" fill="#fcdccf" />
+  </g>
+  <g opacity="0.85">
+    <rect x="84" y="120" width="220" height="140" rx="26" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(61, 169, 252, 0.4)" stroke-width="2.5" />
+    <rect x="104" y="146" width="180" height="30" rx="14" fill="rgba(61, 169, 252, 0.18)" />
+    <rect x="104" y="186" width="96" height="16" rx="8" fill="#3da9fc" opacity="0.6" />
+    <rect x="104" y="208" width="140" height="12" rx="6" fill="#3da9fc" opacity="0.35" />
+    <rect x="440" y="104" width="240" height="150" rx="28" fill="rgba(10, 16, 36, 0.8)" stroke="rgba(245, 197, 24, 0.4)" stroke-width="2.5" />
+    <rect x="460" y="134" width="200" height="32" rx="14" fill="rgba(245, 197, 24, 0.22)" />
+    <rect x="460" y="176" width="96" height="16" rx="8" fill="#f5c518" opacity="0.7" />
+    <rect x="460" y="200" width="150" height="12" rx="6" fill="#f5c518" opacity="0.35" />
+  </g>
+  <rect x="620" y="120" width="2" height="390" fill="rgba(255, 255, 255, 0.08)" />
+  <text x="660" y="210" fill="#f4f6ff" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="54" font-weight="700">
+    Comunicação Sem Medo
+  </text>
+  <text x="660" y="258" fill="#3da9fc" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="28" font-weight="600">
+    Método Oratória Estratégica da Dra. Cláudia Barbosa de Paiva
+  </text>
+  <text x="660" y="310" fill="#c5c9e6" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="22" font-weight="400">
+    Clareza • Confiança • Convencimento • +15 horas on-demand
+  </text>
+  <rect x="660" y="340" width="360" height="2" fill="rgba(61, 169, 252, 0.35)" />
+  <text x="660" y="380" fill="#f5c518" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="24" font-weight="600">
+    Bônus, comunidade moderada e garantia de 7 dias
+  </text>
+  <text x="660" y="426" fill="#c5c9e6" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="20" font-weight="400">
+    Aulas gravadas + mentorias ao vivo + planos de treino personalizados
+  </text>
+  <rect x="660" y="452" width="240" height="54" rx="27" fill="#3da9fc" />
+  <text x="680" y="487" fill="#05070f" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="22" font-weight="700">
+    Garanta sua vaga agora
+  </text>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,165 @@
+const ready = (callback) => {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", callback);
+  } else {
+    callback();
+  }
+};
+
+ready(() => {
+  const yearHolder = document.getElementById("current-year");
+  if (yearHolder) {
+    yearHolder.textContent = new Date().getFullYear();
+  }
+
+  const storageKey = "oe-cookie-consent";
+  const cookieBanner = document.querySelector("[data-cookie-banner]");
+  const acceptButton = document.querySelector("[data-cookie-accept]");
+  const manageButton = document.querySelector("[data-cookie-preferences]");
+  const reopenButton = document.querySelector("[data-open-cookies]");
+
+  const setVisibility = (visible) => {
+    if (!cookieBanner) return;
+    cookieBanner.style.display = visible ? "grid" : "none";
+    cookieBanner.setAttribute("aria-hidden", visible ? "false" : "true");
+    if (visible) {
+      cookieBanner.focus({ preventScroll: true });
+    }
+  };
+
+  const storedConsent = (() => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      console.warn("Não foi possível ler o consentimento salvo", error);
+      return null;
+    }
+  })();
+
+  if (!storedConsent) {
+    setTimeout(() => setVisibility(true), 800);
+  }
+
+  const persistConsent = (status) => {
+    try {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({ status, updatedAt: new Date().toISOString() }),
+      );
+    } catch (error) {
+      console.warn("Não foi possível salvar o consentimento", error);
+    }
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: "cookie_consent", consent_state: status });
+  };
+
+  acceptButton?.addEventListener("click", () => {
+    persistConsent("all");
+    setVisibility(false);
+  });
+
+  manageButton?.addEventListener("click", () => {
+    persistConsent("customize");
+    const target = manageButton.getAttribute("data-target") || "/cookies";
+    const win = window.open(target, "_blank");
+    if (win) {
+      win.opener = null;
+    }
+  });
+
+  reopenButton?.addEventListener("click", () => {
+    setVisibility(true);
+  });
+
+  const anchors = document.querySelectorAll('a[href^="#"]');
+  anchors.forEach((anchor) => {
+    anchor.addEventListener("click", (event) => {
+      const hash = anchor.getAttribute("href");
+      if (!hash || hash === "#") return;
+      const target = document.querySelector(hash);
+      if (!target) return;
+      event.preventDefault();
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      target.setAttribute("tabindex", "-1");
+      target.focus({ preventScroll: true });
+      target.removeAttribute("tabindex");
+    });
+  });
+
+  const progressBar = document.querySelector("[data-progress-bar]");
+  if (progressBar) {
+    const updateProgress = () => {
+      const doc = document.documentElement;
+      const body = document.body;
+      const scrollTop = window.scrollY || doc.scrollTop || body.scrollTop || 0;
+      const scrollHeight = Math.max(doc.scrollHeight, body.scrollHeight);
+      const viewport = window.innerHeight || doc.clientHeight || 1;
+      const max = scrollHeight - viewport;
+      const progress = max > 0 ? Math.min(Math.max(scrollTop / max, 0), 1) : 0;
+      progressBar.style.transform = `scaleX(${progress})`;
+    };
+
+    let ticking = false;
+    const requestTick = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          updateProgress();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener("scroll", requestTick, { passive: true });
+    window.addEventListener("resize", requestTick);
+    updateProgress();
+  }
+
+  const ctaBar = document.querySelector("[data-cta-bar]");
+  const heroSection = document.querySelector(".hero");
+  if (ctaBar && heroSection) {
+    const mobileQuery = window.matchMedia("(max-width: 768px)");
+    let heroOutOfView = false;
+
+    const applyCtaState = () => {
+      if (!mobileQuery.matches) {
+        ctaBar.classList.remove("is-visible");
+        return;
+      }
+      ctaBar.classList.toggle("is-visible", heroOutOfView);
+    };
+
+    if ("IntersectionObserver" in window) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.target === heroSection) {
+              heroOutOfView = !entry.isIntersecting;
+              applyCtaState();
+            }
+          });
+        },
+        { threshold: 0.15 },
+      );
+      observer.observe(heroSection);
+    } else {
+      const updateFallback = () => {
+        const rect = heroSection.getBoundingClientRect();
+        heroOutOfView = rect.bottom < 0;
+        applyCtaState();
+      };
+      window.addEventListener("scroll", updateFallback, { passive: true });
+      updateFallback();
+    }
+
+    const onQueryChange = () => applyCtaState();
+    if (typeof mobileQuery.addEventListener === "function") {
+      mobileQuery.addEventListener("change", onQueryChange);
+    } else if (typeof mobileQuery.addListener === "function") {
+      mobileQuery.addListener(onQueryChange);
+    }
+
+    applyCtaState();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3207 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Comunicação Sem Medo – Treinamento de Oratória | Oratória Estratégica
+    </title>
+    <meta
+      name="description"
+      content="Aprenda a falar em público com clareza, confiança e convencimento com o treinamento Oratória Estratégica da Dra. Cláudia Barbosa de Paiva. +15 horas de aulas, bônus exclusivos e garantia de 7 dias."
+    />
+    <link rel="canonical" href="https://oratoriaestrategica.com/csm" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Comunicação Sem Medo – Treinamento de Oratória"
+    />
+    <meta
+      property="og:description"
+      content="Metodologia 3 C's da Dra. Cláudia Barbosa de Paiva para falar com clareza, confiança e convencimento. Garanta sua vaga com 7 dias de garantia."
+    />
+    <meta property="og:url" content="https://oratoriaestrategica.com/csm" />
+    <meta property="og:image" content="/assets/img/og-image.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:site_name" content="Oratória Estratégica" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Comunicação Sem Medo – Treinamento de Oratória"
+    />
+    <meta
+      name="twitter:description"
+      content="Fale com segurança e influência em qualquer contexto com o método Oratória Estratégica."
+    />
+    <meta name="twitter:image" content="/assets/img/og-image.svg" />
+    <link
+      rel="preload"
+      as="image"
+      href="assets/img/hero-illustration.svg"
+      type="image/svg+xml"
+    />
+    <style>
+      :root {
+        color-scheme: dark light;
+        --color-background: #0a0218;
+        --color-surface: #160b2e;
+        --color-surface-alt: #1f0e3f;
+        --color-primary: #ff72d2;
+        --color-primary-strong: #d946ef;
+        --color-accent: #a855f7;
+        --color-text: #f9f5ff;
+        --color-text-muted: #d6c2f3;
+        --color-border: rgba(255, 255, 255, 0.16);
+        --container-width: min(1180px, 94vw);
+        --shadow-soft: 0 24px 64px rgba(36, 8, 72, 0.4);
+        --font-family:
+          "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+          sans-serif;
+        --radius-lg: 32px;
+        --radius-md: 20px;
+        --radius-sm: 12px;
+        --transition: 0.25s ease;
+        --gradient-page:
+          radial-gradient(
+            160% 140% at 12% -12%,
+            rgba(255, 114, 210, 0.26),
+            transparent 58%
+          ),
+          radial-gradient(
+            140% 130% at 88% 0%,
+            rgba(168, 85, 247, 0.24),
+            transparent 64%
+          ),
+          radial-gradient(
+            150% 140% at 18% 108%,
+            rgba(244, 114, 182, 0.24),
+            transparent 68%
+          ),
+          radial-gradient(
+            160% 140% at 96% 96%,
+            rgba(192, 132, 252, 0.18),
+            transparent 74%
+          ),
+          linear-gradient(
+            180deg,
+            #0a0118 0%,
+            #140530 34%,
+            #1b0a41 72%,
+            #120427 100%
+          );
+        --gradient-page-aurora:
+          radial-gradient(
+            140% 130% at 18% 18%,
+            rgba(255, 114, 210, 0.32),
+            transparent 60%
+          ),
+          radial-gradient(
+            140% 130% at 84% 18%,
+            rgba(192, 132, 252, 0.28),
+            transparent 62%
+          ),
+          radial-gradient(
+            150% 140% at 24% 92%,
+            rgba(244, 114, 182, 0.3),
+            transparent 68%
+          ),
+          radial-gradient(
+            150% 140% at 88% 92%,
+            rgba(233, 89, 161, 0.22),
+            transparent 72%
+          );
+        --gradient-hero:
+          linear-gradient(
+            180deg,
+            rgba(18, 4, 39, 0.88) 0%,
+            rgba(12, 3, 30, 0.68) 100%
+          ),
+          radial-gradient(
+            130% 90% at 12% 20%,
+            rgba(255, 114, 210, 0.38),
+            transparent 56%
+          ),
+          radial-gradient(
+            140% 90% at 82% 12%,
+            rgba(192, 132, 252, 0.28),
+            transparent 60%
+          ),
+          radial-gradient(
+            140% 140% at 46% 94%,
+            rgba(233, 89, 161, 0.32),
+            transparent 70%
+          );
+        --gradient-aurora:
+          linear-gradient(
+            180deg,
+            rgba(18, 4, 39, 0.78) 0%,
+            rgba(12, 3, 32, 0.6) 100%
+          ),
+          radial-gradient(
+            140% 120% at 22% 28%,
+            rgba(255, 114, 210, 0.28),
+            transparent 58%
+          ),
+          radial-gradient(
+            140% 120% at 80% 78%,
+            rgba(192, 132, 252, 0.26),
+            transparent 64%
+          );
+        --gradient-aurora-alt:
+          linear-gradient(
+            180deg,
+            rgba(18, 4, 39, 0.78) 0%,
+            rgba(12, 3, 32, 0.6) 100%
+          ),
+          radial-gradient(
+            140% 120% at 78% 26%,
+            rgba(192, 132, 252, 0.3),
+            transparent 60%
+          ),
+          radial-gradient(
+            140% 120% at 24% 82%,
+            rgba(244, 114, 182, 0.28),
+            transparent 66%
+          );
+        --gradient-highlight: linear-gradient(
+          135deg,
+          rgba(255, 114, 210, 0.34),
+          rgba(192, 132, 252, 0.26)
+        );
+        --ring-outline: 0 0 0 1px rgba(255, 114, 210, 0.28);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+        background: var(--gradient-page);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
+        }
+      }
+
+      body {
+        margin: 0;
+        font-family: var(--font-family);
+        color: var(--color-text);
+        background: var(--gradient-page);
+        background-attachment: fixed;
+        background-repeat: no-repeat;
+        background-size: cover;
+        position: relative;
+        z-index: 0;
+        line-height: 1.6;
+        font-size: 1rem;
+      }
+
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        z-index: -1;
+        background: var(--gradient-page-aurora);
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      img {
+        max-width: 100%;
+        display: block;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:focus-visible {
+        color: var(--color-primary);
+      }
+
+      .skip-link {
+        position: absolute;
+        left: -999px;
+        top: 16px;
+        background: var(--color-primary);
+        color: #230235;
+        padding: 0.75rem 1.5rem;
+        border-radius: var(--radius-sm);
+        font-weight: 600;
+        z-index: 1000;
+      }
+
+      .skip-link:focus {
+        left: 16px;
+      }
+
+      .reading-progress {
+        position: fixed;
+        inset-inline: 0;
+        top: 0;
+        inline-size: 100%;
+        block-size: 6px;
+        background: rgba(255, 114, 210, 0.16);
+        z-index: 980;
+        pointer-events: none;
+        overflow: hidden;
+      }
+
+      .reading-progress__bar {
+        inline-size: 100%;
+        block-size: 100%;
+        transform-origin: left center;
+        transform: scaleX(0);
+        background: linear-gradient(
+          90deg,
+          var(--color-primary),
+          var(--color-primary-strong)
+        );
+        transition: transform 0.2s ease;
+      }
+
+      .container {
+        width: var(--container-width);
+        margin: 0 auto;
+      }
+
+      header.hero {
+        padding: clamp(5rem, 12vw, 8.5rem) 0 5rem;
+        position: relative;
+        overflow: hidden;
+        background: var(--gradient-hero);
+        isolation: isolate;
+      }
+
+      .hero::before,
+      .hero::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: -1;
+      }
+
+      .hero::before {
+        background:
+          radial-gradient(
+            circle at 18% 26%,
+            rgba(255, 114, 210, 0.42),
+            transparent 56%
+          ),
+          radial-gradient(
+            circle at 80% 24%,
+            rgba(192, 132, 252, 0.3),
+            transparent 60%
+          );
+        filter: blur(0.5px);
+        opacity: 0.7;
+      }
+
+      .hero::after {
+        background:
+          radial-gradient(
+            60% 80% at 48% 92%,
+            rgba(233, 89, 161, 0.3),
+            transparent
+          ),
+          linear-gradient(
+            120deg,
+            rgba(14, 2, 32, 0.32) 0%,
+            rgba(14, 2, 32, 0) 55%
+          );
+        opacity: 0.55;
+      }
+
+      .hero__grid {
+        display: grid;
+        gap: clamp(2rem, 5vw, 4rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: center;
+      }
+
+      .hero__copy h1 {
+        font-size: clamp(2.4rem, 4.6vw, 3.6rem);
+        line-height: 1.1;
+        margin-bottom: 1rem;
+        font-weight: 700;
+      }
+
+      .hero__copy p {
+        margin-bottom: 1rem;
+        color: var(--color-text-muted);
+      }
+
+      .hero__highlights {
+        margin: 0 0 2rem;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .hero__highlights li {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: rgba(31, 14, 63, 0.8);
+        padding: 0.75rem 1rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-border);
+        font-weight: 500;
+      }
+
+      .hero__highlights li::before {
+        content: "";
+        inline-size: 12px;
+        block-size: 12px;
+        border-radius: 50%;
+        background: var(--color-primary);
+      }
+
+      .price-callout {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--color-text);
+        margin-bottom: 1.5rem;
+      }
+
+      .hero__ctas {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .section-cta {
+        margin-top: 2rem;
+      }
+
+      .section-cta--lg {
+        margin-top: 2.5rem;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.95rem 1.8rem;
+        border-radius: 999px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        border: 1px solid transparent;
+        transition:
+          transform var(--transition),
+          box-shadow var(--transition),
+          background var(--transition);
+        cursor: pointer;
+      }
+
+      .button--primary {
+        background: linear-gradient(
+          135deg,
+          var(--color-primary),
+          var(--color-primary-strong)
+        );
+        color: #22022f;
+        box-shadow: 0 14px 32px rgba(255, 114, 210, 0.4);
+      }
+
+      .button--primary:hover,
+      .button--primary:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 42px rgba(255, 114, 210, 0.5);
+      }
+
+      .button--ghost {
+        background: rgba(18, 4, 39, 0.42);
+        border: 1px solid var(--color-border);
+        color: var(--color-text);
+      }
+
+      .button--ghost:hover,
+      .button--ghost:focus-visible {
+        border-color: var(--color-primary);
+        color: var(--color-primary);
+      }
+
+      .hero__trust {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        margin-top: 2rem;
+        color: var(--color-text-muted);
+        font-size: 0.95rem;
+      }
+
+      .hero__trust span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: rgba(31, 14, 63, 0.42);
+        padding: 0.6rem 1rem;
+        border-radius: 999px;
+        border: 1px solid var(--color-border);
+      }
+
+      .hero__image {
+        position: relative;
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        isolation: isolate;
+        background:
+          radial-gradient(
+            circle at 24% 24%,
+            rgba(192, 132, 252, 0.38),
+            transparent 65%
+          ),
+          radial-gradient(
+            circle at 76% 74%,
+            rgba(255, 114, 210, 0.34),
+            transparent 58%
+          ),
+          rgba(24, 6, 52, 0.95);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .hero__image::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(14, 2, 32, 0) 40%,
+          rgba(14, 2, 32, 0.6)
+        );
+      }
+
+      .hero__image img {
+        inline-size: 100%;
+        block-size: 100%;
+        object-fit: cover;
+      }
+
+      .figure-note {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+      }
+
+      .figure-note--floating {
+        position: absolute;
+        inset-inline: 1.25rem;
+        inset-block-end: 1.25rem;
+        background: rgba(18, 4, 39, 0.58);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 999px;
+        padding: 0.5rem 1.2rem;
+        backdrop-filter: blur(10px);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .figure-note--floating::before {
+        content: "✨";
+        font-size: 0.95rem;
+      }
+
+      .section--aurora,
+      .section--aurora-alt,
+      .section--spotlight {
+        position: relative;
+        overflow: hidden;
+        isolation: isolate;
+      }
+
+      .section--aurora::before,
+      .section--aurora::after,
+      .section--aurora-alt::before,
+      .section--aurora-alt::after,
+      .section--spotlight::before,
+      .section--spotlight::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: -1;
+        transition: opacity var(--transition);
+      }
+
+      .section--aurora::before {
+        background: var(--gradient-aurora);
+        filter: blur(0.5px);
+        opacity: 0.62;
+      }
+
+      .section--aurora::after {
+        background:
+          radial-gradient(
+            90% 80% at 82% 78%,
+            rgba(192, 132, 252, 0.18),
+            transparent 70%
+          ),
+          linear-gradient(
+            180deg,
+            rgba(255, 114, 210, 0.1) 0%,
+            rgba(255, 114, 210, 0) 70%
+          );
+        opacity: 0.32;
+        mix-blend-mode: screen;
+      }
+
+      .section--aurora-alt::before {
+        background: var(--gradient-aurora-alt);
+        filter: blur(0.5px);
+        opacity: 0.62;
+      }
+
+      .section--aurora-alt::after {
+        background:
+          radial-gradient(
+            90% 85% at 18% 24%,
+            rgba(255, 114, 210, 0.18),
+            transparent 70%
+          ),
+          linear-gradient(
+            180deg,
+            rgba(192, 132, 252, 0.1) 0%,
+            rgba(192, 132, 252, 0) 70%
+          );
+        opacity: 0.32;
+        mix-blend-mode: screen;
+      }
+
+      .section--spotlight::before {
+        background:
+          linear-gradient(
+            180deg,
+            rgba(18, 4, 39, 0.8) 0%,
+            rgba(12, 3, 32, 0.6) 100%
+          ),
+          radial-gradient(
+            120% 110% at 24% 30%,
+            rgba(192, 132, 252, 0.3),
+            transparent 60%
+          ),
+          radial-gradient(
+            120% 110% at 78% 72%,
+            rgba(255, 114, 210, 0.26),
+            transparent 62%
+          );
+        opacity: 0.68;
+      }
+
+      .section--spotlight::after {
+        background: linear-gradient(
+          120deg,
+          rgba(14, 2, 32, 0.45),
+          rgba(14, 2, 32, 0)
+        );
+        opacity: 0.28;
+        mix-blend-mode: screen;
+      }
+
+      .section-layout {
+        display: grid;
+        gap: clamp(2rem, 6vw, 4.5rem);
+        align-items: center;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      @media (min-width: 960px) {
+        .section-layout {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .section-layout__content {
+        display: grid;
+        gap: 1.5rem;
+        align-content: start;
+      }
+
+      .theme-block {
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+      }
+
+      .theme-block--split {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: start;
+      }
+
+      .theme-block__intro > :is(h2, h3) + .section-intro {
+        margin-top: 1rem;
+      }
+
+      .theme-stats {
+        display: grid;
+        gap: 0.75rem;
+        margin: 1.5rem 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .theme-stats li {
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
+        padding: 0.75rem 1rem;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: var(--radius-sm);
+      }
+
+      .theme-stats strong {
+        color: var(--color-primary);
+      }
+
+      .benefits-grid {
+        display: grid;
+        gap: clamp(1.25rem, 2.5vw, 2rem);
+        margin-top: clamp(1.75rem, 3vw, 2.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .benefit-card {
+        padding: clamp(1.25rem, 2.5vw, 2rem);
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: linear-gradient(
+          145deg,
+          rgba(168, 85, 247, 0.16),
+          rgba(10, 1, 24, 0.4)
+        );
+        box-shadow: var(--shadow-soft);
+      }
+
+      .benefit-card h3 {
+        font-size: clamp(1.1rem, 2vw, 1.35rem);
+        margin-bottom: 0.75rem;
+      }
+
+      .benefit-card ul {
+        margin: 1rem 0 0;
+        padding-left: 1.25rem;
+        color: var(--color-text-muted);
+      }
+
+      .service-grid {
+        display: grid;
+        gap: clamp(1.25rem, 2.5vw, 2rem);
+        margin-top: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .service-card {
+        padding: clamp(1.25rem, 2.5vw, 2rem);
+        border-radius: var(--radius-md);
+        background: rgba(18, 4, 39, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        backdrop-filter: blur(16px);
+      }
+
+      .service-card strong {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 3rem;
+        height: 3rem;
+        margin-bottom: 1rem;
+        border-radius: 999px;
+        background: rgba(255, 114, 210, 0.18);
+        color: var(--color-primary);
+        font-size: 1rem;
+        font-weight: 600;
+      }
+
+      .service-card h3 {
+        font-size: clamp(1.15rem, 2vw, 1.4rem);
+        margin-bottom: 0.5rem;
+      }
+
+      .service-card ul {
+        margin: 0.75rem 0 0;
+        padding-left: 1.25rem;
+        color: var(--color-text-muted);
+      }
+
+      .section-visual {
+        background: rgba(24, 6, 52, 0.48);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 4vw, 2rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-soft);
+        max-inline-size: min(100%, 420px);
+        margin: 0 auto;
+      }
+
+      .section-visual img {
+        border-radius: var(--radius-md);
+        inline-size: 100%;
+        block-size: auto;
+        background: rgba(18, 4, 39, 0.35);
+      }
+
+      .section-layout--reverse .section-visual {
+        order: 0;
+      }
+
+      .section-layout--reverse .section-layout__content {
+        order: 1;
+      }
+
+      @media (max-width: 959px) {
+        .section-layout--reverse .section-visual {
+          order: 1;
+        }
+
+        .section-layout--reverse .section-layout__content {
+          order: 0;
+        }
+      }
+
+      .gallery-grid {
+        display: grid;
+        gap: clamp(1.5rem, 4vw, 2.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        margin-top: clamp(2rem, 4vw, 3rem);
+      }
+
+      .gallery-card {
+        display: grid;
+        gap: 1rem;
+        background: rgba(24, 6, 52, 0.5);
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        box-shadow: 0 18px 44px rgba(36, 12, 72, 0.45);
+      }
+
+      .gallery-card img {
+        border-radius: var(--radius-sm);
+        inline-size: 100%;
+        block-size: auto;
+      }
+
+      .gallery-card figcaption {
+        font-size: 0.9rem;
+        color: var(--color-text-muted);
+      }
+
+      .final-cta {
+        display: grid;
+        gap: 1.5rem;
+        text-align: center;
+        max-width: 720px;
+        margin: 0 auto;
+      }
+
+      .final-cta__actions {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      section {
+        padding: clamp(3.5rem, 7vw, 5.5rem) 0;
+      }
+
+      h2 {
+        font-size: clamp(2rem, 3.8vw, 2.8rem);
+        line-height: 1.2;
+        margin-bottom: 1rem;
+      }
+
+      h3 {
+        font-size: clamp(1.4rem, 3vw, 1.8rem);
+        margin-bottom: 0.5rem;
+      }
+
+      .section-intro {
+        max-width: 58ch;
+        color: var(--color-text-muted);
+      }
+
+      .logos-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        align-items: center;
+        margin-top: 2rem;
+      }
+
+      .logos-grid span {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 1.1rem 1.4rem;
+        border-radius: var(--radius-sm);
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        font-size: 0.85rem;
+      }
+
+      .disclaimer {
+        font-size: 0.8rem;
+        color: var(--color-text-muted);
+        margin-top: 1.5rem;
+      }
+
+      .testimonials-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        margin-top: 2.5rem;
+      }
+
+      .testimonial-card {
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: 1.8rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
+        transition: transform var(--transition);
+      }
+
+      .testimonial-card:hover {
+        transform: translateY(-4px);
+      }
+
+      .testimonial-card blockquote {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--color-text);
+      }
+
+      .testimonial-card cite {
+        font-style: normal;
+        font-size: 0.9rem;
+        color: var(--color-text-muted);
+      }
+
+      .audience-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        margin-top: 2.5rem;
+      }
+
+      .audience-card {
+        background: rgba(24, 6, 52, 0.48);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: 1.8rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .audience-card h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .audience-card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .method-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        margin-top: 2.5rem;
+      }
+
+      .method-card {
+        background: rgba(24, 6, 52, 0.52);
+        border-radius: var(--radius-md);
+        padding: 1.8rem;
+        border: 1px solid var(--color-border);
+        position: relative;
+      }
+
+      .method-card::before {
+        content: attr(data-label);
+        position: absolute;
+        top: -14px;
+        left: 1.6rem;
+        background: var(--color-background);
+        padding: 0.25rem 0.75rem;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        border-radius: 999px;
+        border: 1px solid var(--color-border);
+        color: var(--color-text-muted);
+      }
+
+      .method-card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .modules-grid {
+        margin-top: 3rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .module-card {
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: 1.8rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+      }
+
+      .module-card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .resources-grid {
+        margin-top: 3rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .resource-card {
+        background: rgba(24, 6, 52, 0.5);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border);
+        padding: 1.8rem;
+        display: grid;
+        gap: 0.8rem;
+      }
+
+      .resource-card strong {
+        font-size: 1.2rem;
+      }
+
+      .resource-card p {
+        margin: 0;
+        color: var(--color-text-muted);
+      }
+
+      .resource-card ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .journey {
+        margin-top: 3rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .journey__highlight {
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: 1.5rem 1.8rem;
+        display: grid;
+        gap: 0.6rem;
+      }
+
+      .journey__steps {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 1.2rem;
+      }
+
+      .journey__steps li {
+        display: grid;
+        gap: 0.3rem;
+        padding-left: 2.6rem;
+        position: relative;
+      }
+
+      .journey__steps li::before {
+        content: attr(data-step);
+        position: absolute;
+        inset-inline-start: 0;
+        inset-block-start: 0.2rem;
+        inline-size: 2rem;
+        block-size: 2rem;
+        border-radius: 999px;
+        display: grid;
+        place-items: center;
+        background: rgba(255, 114, 210, 0.26);
+        border: 1px solid rgba(255, 114, 210, 0.5);
+        color: var(--color-primary);
+        font-weight: 700;
+      }
+
+      .journey__steps p {
+        margin: 0;
+        color: var(--color-text-muted);
+      }
+
+      .journey__steps strong {
+        font-size: 1.05rem;
+      }
+
+      .comparison {
+        margin-top: 3rem;
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .comparison__item {
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-border);
+        padding: 1.8rem;
+        background: rgba(18, 4, 39, 0.4);
+        display: grid;
+        gap: 0.8rem;
+      }
+
+      .comparison__item h3 {
+        margin: 0;
+        font-size: 1.3rem;
+      }
+
+      .comparison__item ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .bonus-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        margin-top: 2.5rem;
+      }
+
+      .bonus-card {
+        background: linear-gradient(
+          140deg,
+          rgba(192, 132, 252, 0.2),
+          rgba(24, 6, 52, 0.95)
+        );
+        border-radius: var(--radius-md);
+        border: 1px solid rgba(255, 114, 210, 0.26);
+        padding: 1.8rem;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .bonus-card strong {
+        display: block;
+        font-size: 1.05rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .bonus-card span {
+        font-size: 0.9rem;
+        color: var(--color-text-muted);
+      }
+
+      .investment {
+        margin-top: 3rem;
+        background: rgba(24, 6, 52, 0.6);
+        border-radius: var(--radius-lg);
+        padding: clamp(2.5rem, 5vw, 3.5rem);
+        border: 1px solid var(--color-border);
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        align-items: center;
+      }
+
+      .price-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .price-anchor {
+        font-size: 1rem;
+        color: var(--color-text-muted);
+        text-decoration: line-through;
+      }
+
+      .price-highlight {
+        font-size: clamp(2rem, 5vw, 2.6rem);
+        font-weight: 700;
+      }
+
+      .price-installment {
+        font-size: 1.1rem;
+        color: var(--color-text-muted);
+      }
+
+      .guarantee-card {
+        margin-top: 2.5rem;
+        background: linear-gradient(
+          135deg,
+          rgba(245, 197, 24, 0.16),
+          rgba(24, 6, 52, 0.9)
+        );
+        border-radius: var(--radius-md);
+        padding: 2rem;
+        border: 1px solid rgba(245, 197, 24, 0.4);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .media-logos {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        margin-top: 1.5rem;
+      }
+
+      .media-logos span {
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        padding: 0.9rem 1.1rem;
+        font-size: 0.85rem;
+        text-align: center;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      .press-links {
+        margin-top: 1.5rem;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.8rem;
+        color: var(--color-text-muted);
+      }
+
+      .press-links a {
+        color: inherit;
+        text-decoration: underline;
+      }
+
+      .faq-grid {
+        margin-top: 2.5rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      details {
+        background: rgba(18, 4, 39, 0.4);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        padding: 1.2rem 1.4rem;
+      }
+
+      details > summary {
+        font-weight: 600;
+        cursor: pointer;
+        list-style: none;
+      }
+
+      details[open] {
+        border-color: var(--color-primary);
+        box-shadow: 0 0 0 1px rgba(192, 132, 252, 0.28);
+      }
+
+      details > summary::-webkit-details-marker {
+        display: none;
+      }
+
+      details > summary::after {
+        content: "+";
+        float: right;
+        transition: transform var(--transition);
+      }
+
+      details[open] > summary::after {
+        transform: rotate(45deg);
+      }
+
+      details p {
+        margin: 0.75rem 0 0;
+        color: var(--color-text-muted);
+      }
+
+      .contact-grid {
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: start;
+      }
+
+      form {
+        display: grid;
+        gap: 1.1rem;
+      }
+
+      label {
+        display: grid;
+        gap: 0.4rem;
+        font-weight: 600;
+      }
+
+      input,
+      textarea {
+        background: rgba(18, 4, 39, 0.35);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        padding: 0.85rem 1rem;
+        color: var(--color-text);
+        font-size: 1rem;
+        transition:
+          border-color var(--transition),
+          box-shadow var(--transition);
+      }
+
+      input:focus,
+      textarea:focus {
+        outline: none;
+        border-color: var(--color-primary);
+        box-shadow: 0 0 0 3px rgba(255, 114, 210, 0.26);
+      }
+
+      .consent {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.6rem;
+        font-size: 0.85rem;
+        color: var(--color-text-muted);
+      }
+
+      .consent input {
+        inline-size: 1.1rem;
+        block-size: 1.1rem;
+        margin-top: 0.2rem;
+      }
+
+      .whatsapp-card {
+        background: rgba(24, 6, 52, 0.65);
+        border: 1px solid rgba(255, 114, 210, 0.32);
+        border-radius: var(--radius-md);
+        padding: 1.5rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .whatsapp-card a {
+        background: linear-gradient(135deg, #3ac766, #2a9f4b);
+        color: #041106;
+        padding: 0.85rem 1.4rem;
+        border-radius: 999px;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+      }
+
+      .whatsapp-card a::before {
+        content: "\f232";
+        font-family:
+          "Font Awesome 5 Free", "Font Awesome 6 Free", Arial, sans-serif;
+        font-weight: 900;
+      }
+
+      footer {
+        padding: 3rem 0;
+        background: rgba(18, 4, 39, 0.9);
+        border-top: 1px solid var(--color-border);
+      }
+
+      footer nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        font-size: 0.9rem;
+      }
+
+      footer nav a {
+        color: var(--color-text-muted);
+        text-decoration: underline;
+      }
+
+      footer p {
+        color: var(--color-text-muted);
+        font-size: 0.85rem;
+        margin: 1.2rem 0 0;
+      }
+
+      .cta-bar {
+        position: fixed;
+        inset-inline: clamp(1rem, 4vw, 2rem);
+        bottom: 1.2rem;
+        background: rgba(18, 4, 39, 0.92);
+        border-radius: 999px;
+        border: 1px solid rgba(255, 114, 210, 0.32);
+        padding: 0.75rem 1.1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        box-shadow: 0 18px 44px rgba(18, 4, 39, 0.5);
+        z-index: 900;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(120%);
+        transition:
+          transform var(--transition),
+          opacity var(--transition),
+          box-shadow var(--transition);
+      }
+
+      .cta-bar span {
+        font-size: 0.95rem;
+        color: var(--color-text-muted);
+      }
+
+      .cta-bar .button {
+        padding: 0.75rem 1.4rem;
+      }
+
+      .cta-bar.is-visible {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+      }
+
+      .cta-bar.is-visible .button {
+        box-shadow: 0 16px 40px rgba(255, 114, 210, 0.45);
+      }
+
+      @media (min-width: 769px) {
+        .cta-bar {
+          display: none;
+        }
+      }
+
+      @media (max-width: 768px) {
+        header.hero {
+          padding-top: 4.5rem;
+        }
+      }
+
+      .cookie-banner {
+        position: fixed;
+        inset-inline: clamp(1rem, 5vw, 2rem);
+        bottom: clamp(1rem, 8vw, 2rem);
+        background: rgba(18, 4, 39, 0.96);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: 1.5rem;
+        display: none;
+        gap: 1rem;
+        max-width: 480px;
+        z-index: 950;
+        box-shadow: var(--shadow-soft);
+      }
+
+      .cookie-banner p {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--color-text-muted);
+      }
+
+      .cookie-actions {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+      }
+
+      .cookie-banner button {
+        flex: 1;
+        min-width: 140px;
+        border-radius: 999px;
+        border: none;
+        padding: 0.7rem 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      .cookie-banner button.accept {
+        background: linear-gradient(
+          135deg,
+          var(--color-primary),
+          var(--color-primary-strong)
+        );
+        color: #230235;
+      }
+
+      .cookie-banner button.manage {
+        background: rgba(24, 6, 52, 0.8);
+        color: var(--color-text);
+        border: 1px solid var(--color-border);
+      }
+
+      .section--dev-notes {
+        background: rgba(24, 6, 52, 0.88);
+        border-top: 1px dashed rgba(255, 114, 210, 0.4);
+      }
+
+      .dev-notes {
+        display: grid;
+        gap: 2rem;
+      }
+
+      @media (min-width: 960px) {
+        .dev-notes {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .dev-notes__group {
+        background: rgba(18, 4, 39, 0.7);
+        border: 1px dashed rgba(192, 132, 252, 0.35);
+        border-radius: var(--radius-md);
+        padding: clamp(1.5rem, 4vw, 2rem);
+        display: grid;
+        gap: 1rem;
+        box-shadow: 0 18px 44px rgba(18, 4, 39, 0.4);
+      }
+
+      .dev-notes__group h3 {
+        margin: 0;
+        font-size: clamp(1.2rem, 2.4vw, 1.5rem);
+      }
+
+      .dev-notes__list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.8rem;
+      }
+
+      .dev-notes__list li {
+        position: relative;
+        padding-left: 1.75rem;
+        color: var(--color-text-muted);
+      }
+
+      .dev-notes__list li::before {
+        content: "✔";
+        position: absolute;
+        left: 0;
+        top: 0.1rem;
+        font-size: 0.95rem;
+        color: var(--color-primary);
+      }
+
+      .dev-notes__fields {
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .dev-notes__field {
+        display: grid;
+        gap: 0.4rem;
+        background: rgba(24, 6, 52, 0.8);
+        border-radius: var(--radius-sm);
+        padding: 1rem 1.1rem;
+        border: 1px solid rgba(255, 114, 210, 0.26);
+      }
+
+      .dev-notes__field dt {
+        font-weight: 600;
+      }
+
+      .dev-notes__field dd {
+        margin: 0;
+        color: var(--color-text-muted);
+      }
+
+      .dev-notes__annotation {
+        margin-top: 2rem;
+        font-size: 0.85rem;
+        color: var(--color-text-muted);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+      }
+
+      .dev-notes__annotation code {
+        font-family: "Source Code Pro", "Fira Code", monospace;
+        font-size: 0.8rem;
+        background: rgba(18, 4, 39, 0.8);
+        padding: 0.2rem 0.4rem;
+        border-radius: 4px;
+        border: 1px solid rgba(192, 132, 252, 0.28);
+      }
+
+      .dev-notes__code {
+        margin-top: 0.5rem;
+        padding: 1rem 1.25rem;
+        border-radius: var(--radius-sm);
+        background: rgba(9, 3, 21, 0.85);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        color: var(--color-text);
+        overflow-x: auto;
+        font-family:
+          "Fira Code", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
+          Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.95rem;
+        line-height: 1.6;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: rgba(18, 4, 39, 0.65);
+        border-radius: 999px;
+        padding: 0.4rem 0.9rem;
+        font-size: 0.85rem;
+        color: var(--color-text-muted);
+        border: 1px solid var(--color-border);
+      }
+
+      @media (max-width: 600px) {
+        .hero__highlights li {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        footer nav {
+          flex-direction: column;
+          gap: 0.8rem;
+        }
+      }
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Course",
+        "name": "Oratória Estratégica – Comunicação Sem Medo",
+        "description": "Curso completo de oratória com metodologia 3 C's, aulas on-line, encontros ao vivo e materiais bônus para profissionais, líderes e empreendedores.",
+        "provider": {
+          "@type": "Person",
+          "name": "Dra. Cláudia Barbosa de Paiva",
+          "sameAs": [
+            "https://www.instagram.com/dra.claudiabarbosadepaiva",
+            "https://www.linkedin.com/in/claudiabarbosadepaiva"
+          ]
+        },
+        "hasCourseInstance": {
+          "@type": "CourseInstance",
+          "name": "Turma 2025 do Oratória Estratégica",
+          "courseMode": ["online", "assíncrono", "ao vivo"],
+          "startDate": "2025-01-15",
+          "endDate": "2025-12-31",
+          "location": {
+            "@type": "VirtualLocation",
+            "url": "https://oratoriaestrategica.com/csm"
+          },
+          "instructor": {
+            "@type": "Person",
+            "name": "Dra. Cláudia Barbosa de Paiva"
+          }
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Oratória Estratégica – Comunicação Sem Medo",
+        "description": "Treinamento on-line com +15 horas de conteúdo, método 3 C's e bônus exclusivos para falar em público com clareza, confiança e convencimento.",
+        "brand": {
+          "@type": "Brand",
+          "name": "Oratória Estratégica"
+        },
+        "image": [
+          "https://oratoriaestrategica.com/csm/assets/img/og-image.svg",
+          "https://oratoriaestrategica.com/csm/assets/img/ai-apresentacao.svg",
+          "https://oratoriaestrategica.com/csm/assets/img/ai-reuniao.svg",
+          "https://oratoriaestrategica.com/csm/assets/img/ai-gravacao.svg"
+        ],
+        "sku": "OE-CSM-2025",
+        "offers": {
+          "@type": "Offer",
+          "price": "347.00",
+          "priceCurrency": "BRL",
+          "priceValidUntil": "2025-12-31",
+          "availability": "https://schema.org/InStock",
+          "url": "https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica",
+          "itemCondition": "https://schema.org/NewCondition",
+          "seller": {
+            "@type": "Organization",
+            "name": "Dra. Cláudia Barbosa de Paiva"
+          }
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Oratória Estratégica",
+        "url": "https://oratoriaestrategica.com",
+        "logo": "https://oratoriaestrategica.com/csm/assets/img/og-image.svg",
+        "sameAs": [
+          "https://www.instagram.com/dra.claudiabarbosadepaiva",
+          "https://www.linkedin.com/in/claudiabarbosadepaiva",
+          "https://www.youtube.com/@oratoriaestrategica"
+        ],
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "telephone": "+55-11-0000-0000",
+          "areaServed": "BR",
+          "availableLanguage": ["Portuguese"]
+        }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Quando terei acesso ao conteúdo?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "O acesso é liberado imediatamente após a confirmação do pagamento. Você recebe seu login por e-mail e pode assistir às aulas quando e onde quiser."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Por quanto tempo posso acessar o treinamento?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "O acesso fica disponível por 12 meses a partir da data da compra. Durante esse período você pode rever as aulas e participar das atualizações."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "A garantia realmente é de 7 dias?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Sim. Você pode consumir o conteúdo por 7 dias e, se entender que o treinamento não é para você, basta solicitar o cancelamento dentro do prazo para receber 100% do seu investimento de volta."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Os bônus têm custo adicional?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Não. Todos os bônus descritos na página estão incluídos no valor promocional informado e são liberados junto com o acesso principal."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Para quem é o Oratória Estratégica?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "O treinamento é indicado para profissionais, líderes e empreendedores que desejam superar o medo de falar em público, eliminar vícios de linguagem e aumentar o poder de persuasão em apresentações, reuniões ou negociações."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Quanto tempo devo dedicar por semana?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Recomendamos reservar cerca de 90 minutos por semana para assistir às aulas, praticar com os exercícios e participar das lives ou assistir às gravações no seu melhor horário."
+            }
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <div class="reading-progress" aria-hidden="true">
+      <span class="reading-progress__bar" data-progress-bar></span>
+    </div>
+    <a class="skip-link" href="#conteudo">Pular para o conteúdo principal</a>
+    <header class="hero" id="inicio">
+      <div class="container hero__grid">
+        <div class="hero__copy">
+          <span class="badge" aria-label="Garantia de 7 dias"
+            >Garantia 7 dias • risco zero</span
+          >
+          <h1>
+            Fale com segurança e influência — em reuniões, no palco e no vídeo.
+          </h1>
+          <p>
+            Transforme sua comunicação com o método dos 3 C's da Dra. Cláudia
+            Barbosa de Paiva: clareza para ser entendido, confiança para se
+            posicionar com firmeza e convencimento para engajar qualquer
+            audiência.
+          </p>
+          <ul class="hero__highlights" role="list">
+            <li>
+              <strong>+15 horas</strong> de treinamento on-line e materiais
+              táticos sob demanda.
+            </li>
+            <li>
+              <strong>Mentorias ao vivo</strong> com feedback individualizado e
+              plano de treino.
+            </li>
+            <li>
+              <strong>Comunidade de prática</strong> para networking seguro e
+              intencional.
+            </li>
+          </ul>
+          <p class="price-callout">
+            De R$ 1.638 por <strong>12× de R$ 36,40</strong> ou
+            <strong>R$ 347 à vista</strong> (economize R$ 1.291).
+          </p>
+          <div class="hero__ctas">
+            <a
+              class="button button--primary"
+              href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+              target="_blank"
+              rel="noopener"
+              aria-label="Comece agora o treinamento Oratória Estratégica"
+            >
+              Comece agora
+            </a>
+            <a class="button button--ghost" href="#metodo"
+              >Quero aprender os 3 C's</a
+            >
+          </div>
+          <div class="hero__trust" aria-label="Indicadores de confiança">
+            <span>+5.000 alunos formados (dados de 2025)</span>
+            <span>+3 milhões de seguidores nas redes</span>
+            <span>Conteúdo certificado pela EMERJ e AMAERJ</span>
+          </div>
+        </div>
+        <figure class="hero__image">
+          <img
+            src="assets/img/hero-illustration.svg"
+            width="880"
+            height="640"
+            loading="eager"
+            decoding="async"
+            alt="Ilustração gerada por inteligência artificial com uma oradora apresentando-se em um palco futurista"
+          />
+          <figcaption class="figure-note figure-note--floating">
+            Arte generativa em IA destacando presença de palco e conexão com o
+            público.
+          </figcaption>
+        </figure>
+      </div>
+    </header>
+
+    <main id="conteudo">
+      <section
+        class="section--aurora"
+        aria-labelledby="sobre-title"
+        id="sobre"
+        data-theme-slot="about"
+      >
+        <div class="container">
+          <div class="theme-block theme-block--split">
+            <div class="theme-block__intro">
+              <h2 id="sobre-title">
+                Tradição acadêmica com entrega prática imediata
+              </h2>
+              <p class="section-intro">
+                A Oratória Estratégica nasceu da vivência da Dra. Cláudia
+                Barbosa de Paiva em tribunais, salas de aula e grandes palcos.
+                Unimos pesquisa científica, metodologia própria e acompanhamento
+                ao vivo para acelerar a evolução de profissionais que precisam
+                ser respeitados quando falam.
+              </p>
+              <ul class="theme-stats">
+                <li>
+                  <strong>+5.000</strong>
+                  alunos formados com acompanhamento individual (dados 2025).
+                </li>
+                <li>
+                  <strong>+3 milhões</strong> de seguidores consumindo conteúdos
+                  semanais sobre clareza, confiança e convencimento.
+                </li>
+                <li>
+                  <strong>12 meses</strong> de acesso com lives quinzenais,
+                  comunidade moderada e atualização contínua.
+                </li>
+              </ul>
+              <div class="hero__ctas section-cta">
+                <a class="button button--primary" href="#programa">
+                  Ver programa completo
+                </a>
+                <a class="button button--ghost" href="#contato">
+                  Conversar com a equipe
+                </a>
+              </div>
+            </div>
+            <div class="theme-block__intro">
+              <h3>Quem conduz o método</h3>
+              <p class="section-intro">
+                Dra. Cláudia é doutora em Comunicação, bicampeã brasileira de
+                oratória, professora convidada da EMERJ e consultora em
+                programas de liderança corporativa. Já treinou times jurídicos,
+                financeiros, executivos de tecnologia e empreendedores em busca
+                de presença influente.
+              </p>
+              <ul class="hero__highlights" role="list">
+                <li>
+                  Juíza-chefe em campeonatos de oratória e debate acadêmico.
+                </li>
+                <li>
+                  Palestrante TEDx e presença confirmada em The Noite, Pânico,
+                  Os Sócios e Primocast.
+                </li>
+                <li>
+                  Artigos e entrevistas em veículos como IstoÉ (26/09/2022) e R7
+                  (14/12/2022).
+                </li>
+              </ul>
+              <div class="media-logos" role="list">
+                <span role="listitem">TEDx</span>
+                <span role="listitem">The Noite</span>
+                <span role="listitem">Pânico</span>
+                <span role="listitem">Os Sócios</span>
+                <span role="listitem">Primocast</span>
+                <span role="listitem">IstoÉ</span>
+                <span role="listitem">R7</span>
+                <span role="listitem">AMAERJ</span>
+              </div>
+              <ul class="press-links">
+                <li>
+                  <a
+                    href="https://www.istoedinheiro.com.br/"
+                    target="_blank"
+                    rel="noopener"
+                    >Matéria na IstoÉ – 26/09/2022</a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="https://recordtv.r7.com/"
+                    target="_blank"
+                    rel="noopener"
+                    >Entrevista no portal R7 – 14/12/2022</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="logos-grid" role="list" aria-label="Segmentos atendidos">
+            <span role="listitem">Tribunais</span>
+            <span role="listitem">OAB</span>
+            <span role="listitem">Setor Financeiro</span>
+            <span role="listitem">Saúde</span>
+            <span role="listitem">Educação</span>
+            <span role="listitem">Startups</span>
+          </div>
+          <p class="disclaimer">
+            Algumas marcas representam ex-alunos e projetos com autorização
+            prévia. Cada marca pertence aos respectivos detentores.
+          </p>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="beneficios-title"
+        id="beneficios"
+        data-theme-slot="benefits"
+      >
+        <div class="container">
+          <div class="theme-block">
+            <div class="theme-block__intro">
+              <h2 id="beneficios-title">
+                Benefícios imediatos que o método entrega
+              </h2>
+              <p class="section-intro">
+                Cada aula, exercício e encontro ao vivo foi desenhado para que
+                você sinta evolução real já nas primeiras semanas. A trilha
+                conecta fundamentos científicos de comunicação com desafios
+                práticos aplicados ao seu contexto.
+              </p>
+            </div>
+            <div class="benefits-grid" role="list">
+              <article class="benefit-card" role="listitem">
+                <h3>Clareza para liderar conversas</h3>
+                <p>
+                  Estruture argumentos, roteiros e apresentações com início,
+                  meio e fim que prendem a atenção sem rodeios.
+                </p>
+                <ul>
+                  <li>Modelos de discurso para reuniões, aulas e pitches.</li>
+                  <li>Checklist para eliminar vícios de linguagem.</li>
+                  <li>
+                    Storytelling adaptado ao mundo jurídico e corporativo.
+                  </li>
+                </ul>
+              </article>
+              <article class="benefit-card" role="listitem">
+                <h3>Confiança para qualquer palco</h3>
+                <p>
+                  Ganhe presença executiva controlando ansiedade, linguagem
+                  corporal e uso da voz com protocolos rápidos.
+                </p>
+                <ul>
+                  <li>Rotinas de aquecimento vocal e corporal.</li>
+                  <li>Âncoras mentais para reuniões decisivas.</li>
+                  <li>Feedback individualizado nas lives quinzenais.</li>
+                </ul>
+              </article>
+              <article class="benefit-card" role="listitem">
+                <h3>Convencimento ético e consistente</h3>
+                <p>
+                  Aprenda a guiar decisões com técnicas de persuasão validadas
+                  sem soar agressivo ou artificial.
+                </p>
+                <ul>
+                  <li>
+                    10 gatilhos mentais aplicados ao contexto profissional.
+                  </li>
+                  <li>
+                    Scripts de negociação e follow-up com ajustes por setor.
+                  </li>
+                  <li>
+                    Simulações gravadas para revisar e otimizar discursos.
+                  </li>
+                </ul>
+              </article>
+              <article class="benefit-card" role="listitem">
+                <h3>Suporte contínuo para manter resultados</h3>
+                <p>
+                  Transforme o aprendizado em hábito com recursos e comunidade
+                  disponíveis 12 meses por assinatura.
+                </p>
+                <ul>
+                  <li>Painel de evolução semanal com métricas individuais.</li>
+                  <li>Comunidade moderada 24/7 para networking estratégico.</li>
+                  <li>Biblioteca viva de roteiros, slides e mapas mentais.</li>
+                </ul>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="servicos-title"
+        id="servicos"
+        data-theme-slot="services"
+      >
+        <div class="container">
+          <div class="theme-block">
+            <div class="theme-block__intro">
+              <h2 id="servicos-title">Como aplicamos a Oratória Estratégica</h2>
+              <p class="section-intro">
+                O tema atual da Estratégica Oratória dispõe de blocos
+                específicos para destacar soluções. Organizamos o conteúdo
+                criado para o projeto Codex em quatro ofertas que cabem
+                perfeitamente nesses espaços.
+              </p>
+            </div>
+            <div class="service-grid" role="list">
+              <article class="service-card" role="listitem">
+                <strong>01</strong>
+                <h3>Treinamento Comunicação Sem Medo</h3>
+                <p>
+                  Programa completo com +15h de conteúdo on-line, lives
+                  quinzenais e comunidade moderada por 12 meses.
+                </p>
+                <ul>
+                  <li>Metodologia 3 C’s aplicada em trilha Start → End.</li>
+                  <li>
+                    Bônus: lives extras, mapas mentais e oratória de impacto.
+                  </li>
+                  <li>Checkout com garantia de 7 dias e suporte dedicado.</li>
+                </ul>
+              </article>
+              <article class="service-card" role="listitem">
+                <strong>02</strong>
+                <h3>Mentoria Executiva Personalizada</h3>
+                <p>
+                  Sessões individuais ou em pequenos grupos para líderes e
+                  porta-vozes que precisam de ajustes finos para eventos
+                  estratégicos.
+                </p>
+                <ul>
+                  <li>Diagnóstico de presença, voz e linguagem corporal.</li>
+                  <li>Roteiro personalizado para apresentações críticas.</li>
+                  <li>
+                    Simulações com gravação e feedback técnico da Dra. Cláudia.
+                  </li>
+                </ul>
+              </article>
+              <article class="service-card" role="listitem">
+                <strong>03</strong>
+                <h3>Workshops e Palestras In-Company</h3>
+                <p>
+                  Experiências imersivas para equipes que precisam alinhar
+                  comunicação, cultura e performance em pouco tempo.
+                </p>
+                <ul>
+                  <li>Formatos presenciais ou on-line com dinâmica prática.</li>
+                  <li>
+                    Conteúdo adaptado a setores jurídico, financeiro e tech.
+                  </li>
+                  <li>Material de apoio e plano de continuidade pós-evento.</li>
+                </ul>
+              </article>
+              <article class="service-card" role="listitem">
+                <strong>04</strong>
+                <h3>Experiências para lançamentos digitais</h3>
+                <p>
+                  Pacote de consultoria para criadores e infoprodutores que
+                  buscam aumentar conversão em webinars, vídeos e lançamentos.
+                </p>
+                <ul>
+                  <li>
+                    Roteiros de vídeo, scripts de vendas e sequências de lives.
+                  </li>
+                  <li>
+                    Setup recomendado de iluminação, áudio e postura em câmera.
+                  </li>
+                  <li>
+                    Suporte para Q&amp;A ao vivo e gestão de objeções em tempo
+                    real.
+                  </li>
+                </ul>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="depoimentos-title"
+        id="resultados"
+      >
+        <div class="container">
+          <h2 id="depoimentos-title">Resultados reais de alunos</h2>
+          <p class="section-intro">
+            Veja como profissionais de diferentes áreas destravaram a
+            comunicação, assumiram o protagonismo em apresentações e fecharam
+            novas oportunidades após aplicar o método dos 3 C's.
+          </p>
+          <div class="testimonials-grid" role="list">
+            <article class="testimonial-card" role="listitem">
+              <blockquote>
+                “Eu evitava reuniões. Depois de 30 dias aplicando os exercícios
+                de clareza, conduzi a apresentação da diretoria e fui convidada
+                para liderar o projeto.”
+              </blockquote>
+              <cite>Maria Fernanda – Gerente de Operações</cite>
+            </article>
+            <article class="testimonial-card" role="listitem">
+              <blockquote>
+                “As técnicas de confiança me deram o controle da ansiedade. Hoje
+                consigo gravar vídeos semanais para o meu escritório e
+                conquistei mais clientes.”
+              </blockquote>
+              <cite>Rafael Souza – Advogado empresarial</cite>
+            </article>
+            <article class="testimonial-card" role="listitem">
+              <blockquote>
+                “O módulo de convencimento mudou meu processo comercial. A
+                conversão nas reuniões subiu 42% em dois meses.”
+              </blockquote>
+              <cite>Juliana Ramos – Empreendedora SaaS</cite>
+            </article>
+            <article class="testimonial-card" role="listitem">
+              <blockquote>
+                “Eu tinha pavor de falar em público. Hoje dou aulas na
+                pós-graduação e sou referência na minha área.”
+              </blockquote>
+              <cite>Dr. Paulo Lima – Médico especialista</cite>
+            </article>
+          </div>
+          <p class="disclaimer">
+            Os depoimentos foram autorizados pelos participantes. Resultados
+            individuais podem variar conforme dedicação e aplicação prática.
+          </p>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="audience-title"
+        id="para-quem"
+        data-theme-slot="audiences"
+      >
+        <div class="container">
+          <h2 id="audience-title">
+            Para quem o Oratória Estratégica foi criado
+          </h2>
+          <p class="section-intro">
+            Mapear o perfil certo garante maior aplicação prática. Os módulos e
+            bônus foram desenhados para atender às rotinas mais exigentes sem
+            abrir mão da profundidade acadêmica.
+          </p>
+          <div class="audience-grid" role="list">
+            <article class="audience-card" role="listitem">
+              <h3>Profissionais em ascensão</h3>
+              <p>
+                Ideal para quem participa de reuniões estratégicas e precisa
+                comunicar ideias com confiança.
+              </p>
+              <ul>
+                <li>Apresente relatórios e projetos com objetividade.</li>
+                <li>Construa autoridade diante da liderança.</li>
+                <li>Receba feedback personalizado para evoluir rápido.</li>
+              </ul>
+            </article>
+            <article class="audience-card" role="listitem">
+              <h3>Empreendedores e times de vendas</h3>
+              <p>
+                Aplique argumentos de convencimento ético para fechar negócios
+                sem pressão indevida.
+              </p>
+              <ul>
+                <li>Estruture pitches memoráveis em minutos.</li>
+                <li>Domine follow-ups com storytelling persuasivo.</li>
+                <li>Transforme objeções em alavancas de credibilidade.</li>
+              </ul>
+            </article>
+            <article class="audience-card" role="listitem">
+              <h3>Líderes e porta-vozes</h3>
+              <p>
+                Desenvolva presença executiva e conduza discursos que mobilizam
+                equipes em momentos críticos.
+              </p>
+              <ul>
+                <li>Treine pronunciamentos internos e externos.</li>
+                <li>Adote protocolos para entrevistas e mídia.</li>
+                <li>Gerencie emoções mantendo clareza e empatia.</li>
+              </ul>
+            </article>
+            <article class="audience-card" role="listitem">
+              <h3>Acadêmicos e concurseiros</h3>
+              <p>
+                Aperfeiçoe aulas, bancas e sustentações orais com suporte
+                científico e exercícios guiados.
+              </p>
+              <ul>
+                <li>Estruture defesas e teses passo a passo.</li>
+                <li>Melhore dicção e projeção para ambientes formais.</li>
+                <li>
+                  Utilize mapas mentais exclusivos para consolidar conteúdos.
+                </li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="metodo-title"
+        id="metodo"
+      >
+        <div class="container">
+          <div class="section-layout">
+            <div class="section-layout__content">
+              <h2 id="metodo-title">
+                O método 3 C's: clareza, confiança e convencimento
+              </h2>
+              <p class="section-intro">
+                A metodologia proprietária da Dra. Cláudia Barbosa de Paiva
+                integra ciência da comunicação, neurociência e treino prático
+                para gerar mudança imediata e sustentável.
+              </p>
+              <div class="method-grid">
+                <article class="method-card" data-label="C1 – Clareza">
+                  <h3>Clareza</h3>
+                  <p>
+                    Aprenda a estruturar ideias com objetividade e storytelling
+                    estratégico.
+                  </p>
+                  <ul>
+                    <li>
+                      Diagnóstico de vícios de linguagem e plano de correção.
+                    </li>
+                    <li>
+                      Modelos de roteiro para falas curtas, aulas e pitches.
+                    </li>
+                    <li>Vocalização, dicção e uso intencional das pausas.</li>
+                  </ul>
+                </article>
+                <article class="method-card" data-label="C2 – Confiança">
+                  <h3>Confiança</h3>
+                  <p>
+                    Domine técnicas corporais e mentais para controlar o
+                    nervosismo.
+                  </p>
+                  <ul>
+                    <li>
+                      Protocolos rápidos para reduzir ansiedade em minutos.
+                    </li>
+                    <li>Gestão da linguagem corporal e da respiração.</li>
+                    <li>Feedback individual em sessões ao vivo.</li>
+                  </ul>
+                </article>
+                <article class="method-card" data-label="C3 – Convencimento">
+                  <h3>Convencimento</h3>
+                  <p>
+                    Gere adesão imediata em reuniões, vendas e apresentações de
+                    impacto.
+                  </p>
+                  <ul>
+                    <li>
+                      10 técnicas de persuasão ética baseadas em evidências.
+                    </li>
+                    <li>Mapas mentais para argumentos de alta conversão.</li>
+                    <li>
+                      Simulações com roteiros prontos para diferentes cenários.
+                    </li>
+                  </ul>
+                </article>
+              </div>
+              <div class="hero__ctas section-cta section-cta--lg">
+                <a
+                  class="button button--primary"
+                  href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+                  target="_blank"
+                  rel="noopener"
+                  >Garanta sua vaga</a
+                >
+                <a class="button button--ghost" href="#oferta"
+                  >Ver investimento</a
+                >
+              </div>
+            </div>
+            <figure class="section-visual">
+              <img
+                src="assets/img/ai-metodo.svg"
+                width="560"
+                height="520"
+                loading="lazy"
+                decoding="async"
+                alt="Cena criada por IA mostrando três pilares luminosos com ícones de clareza, confiança e convencimento"
+              />
+              <figcaption class="figure-note">
+                Visual gerado com IA para facilitar a replicação da identidade
+                do método 3 C's em peças futuras.
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="experiencia-title"
+        id="experiencia"
+      >
+        <div class="container">
+          <h2 id="experiencia-title">
+            Visualize sua presença em diferentes arenas
+          </h2>
+          <p class="section-intro">
+            As artes abaixo foram criadas com inteligência artificial para que a
+            equipe possa replicar rapidamente o visual da campanha em anúncios,
+            apresentações e materiais de apoio.
+          </p>
+          <div class="gallery-grid" role="list">
+            <figure class="gallery-card" role="listitem">
+              <img
+                src="assets/img/ai-apresentacao.svg"
+                width="420"
+                height="320"
+                loading="lazy"
+                decoding="async"
+                alt="Representação gerada por IA de uma oradora destacada por luzes holográficas diante de uma plateia"
+              />
+              <figcaption>
+                Imagem gerada por IA de palco presencial com camadas de luz e
+                público atento – ideal para reforçar a conquista de autoridade e
+                aplausos imediatos.
+              </figcaption>
+            </figure>
+            <figure class="gallery-card" role="listitem">
+              <img
+                src="assets/img/ai-reuniao.svg"
+                width="420"
+                height="320"
+                loading="lazy"
+                decoding="async"
+                alt="Imagem em IA simulando reunião híbrida com telas flutuantes e métricas em destaque"
+              />
+              <figcaption>
+                Visual em IA de reunião híbrida com dashboards colaborativos,
+                perfeito para enfatizar apresentações de resultados e
+                negociações estratégicas.
+              </figcaption>
+            </figure>
+            <figure class="gallery-card" role="listitem">
+              <img
+                src="assets/img/ai-gravacao.svg"
+                width="420"
+                height="320"
+                loading="lazy"
+                decoding="async"
+                alt="Estúdio moderno renderizado por IA com câmera, iluminação e apresentadora confiante"
+              />
+              <figcaption>
+                Cena criada por IA de estúdio de gravação com clima
+                cinematográfico para conteúdos em vídeo, lançamentos e aulas ao
+                vivo.
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="programa-title"
+        id="programa"
+      >
+        <div class="container">
+          <h2 id="programa-title">
+            O que você recebe ao entrar no Oratória Estratégica
+          </h2>
+          <p class="section-intro">
+            Acesso imediato a mais de 15 horas de conteúdo organizado em trilha
+            estratégica – do diagnóstico ao palco – com materiais complementares
+            e desafios guiados.
+          </p>
+          <div class="section-layout section-layout--reverse">
+            <figure class="section-visual">
+              <img
+                src="assets/img/ai-trilha.svg"
+                width="540"
+                height="520"
+                loading="lazy"
+                decoding="async"
+                alt="Mapa gerado por IA com cartões conectados representando a trilha Start, Fases 1 a 4 e End"
+              />
+              <figcaption class="figure-note">
+                Visualização em IA da jornada completa para facilitar o
+                alinhamento entre copy e design nas próximas campanhas.
+              </figcaption>
+            </figure>
+            <div class="section-layout__content">
+              <div class="modules-grid">
+                <article class="module-card">
+                  <h3>Start</h3>
+                  <p>Mapeie sua linha de base e defina metas mensuráveis.</p>
+                  <ul>
+                    <li>Avaliação de estilo comunicacional.</li>
+                    <li>Checklist de clareza e dicção.</li>
+                    <li>Plano de 21 dias para destravar a fala.</li>
+                  </ul>
+                </article>
+                <article class="module-card">
+                  <h3>Fase 1 – Clareza</h3>
+                  <p>Estruture argumentos e roteiros eficientes.</p>
+                  <ul>
+                    <li>Matriz de mensagens e storytelling.</li>
+                    <li>Modelos de slides minimalistas.</li>
+                    <li>Treino guiado de voz, ritmo e pausas.</li>
+                  </ul>
+                </article>
+                <article class="module-card">
+                  <h3>Fase 2 – Confiança</h3>
+                  <p>Construa presença usando voz, corpo e mente.</p>
+                  <ul>
+                    <li>Técnicas para controlar ansiedade e tremores.</li>
+                    <li>Âncoras corporais e olhar estratégico.</li>
+                    <li>Simulações com feedback gravado.</li>
+                  </ul>
+                </article>
+                <article class="module-card">
+                  <h3>Fase 3 – Convencimento</h3>
+                  <p>Comunique com persuasão em vendas, liderança e mídia.</p>
+                  <ul>
+                    <li>10 gatilhos de persuasão ética e exemplos práticos.</li>
+                    <li>Scripts para reuniões, pitches e entrevistas.</li>
+                    <li>Dinâmicas para conduzir Q&amp;A desafiador.</li>
+                  </ul>
+                </article>
+                <article class="module-card">
+                  <h3>Fase 4 – Performance</h3>
+                  <p>Performances ao vivo e no vídeo com alta retenção.</p>
+                  <ul>
+                    <li>Setup para vídeo, iluminação e áudio.</li>
+                    <li>Protocolos de aquecimento vocal e físico.</li>
+                    <li>Planilhas de acompanhamento de evolução.</li>
+                  </ul>
+                </article>
+                <article class="module-card">
+                  <h3>End – Sustentação</h3>
+                  <p>Construa um plano contínuo para manter a evolução.</p>
+                  <ul>
+                    <li>Revisão com feedback final personalizado.</li>
+                    <li>Agenda de lives mensais e clube de prática.</li>
+                    <li>Certificado reconhecido por instituições parceiras.</li>
+                  </ul>
+                </article>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="resources-title"
+        id="recursos"
+      >
+        <div class="container">
+          <div class="section-layout">
+            <div class="section-layout__content">
+              <h2 id="resources-title">
+                Ferramentas e suporte para manter sua evolução
+              </h2>
+              <p class="section-intro">
+                Além dos módulos gravados, você conta com acompanhamento
+                contínuo, materiais vivos e uma comunidade ativa para
+                transformar estudo em prática semanal.
+              </p>
+              <div class="resources-grid" role="list">
+                <article class="resource-card" role="listitem">
+                  <strong>Painel de evolução semanal</strong>
+                  <p>
+                    Monitore o quanto avançou em clareza, confiança e
+                    convencimento a cada etapa do método.
+                  </p>
+                  <ul>
+                    <li>Checklist de preparação antes de cada apresentação.</li>
+                    <li>
+                      Relatórios automáticos com seus pontos fortes e ajustes.
+                    </li>
+                    <li>
+                      Alertas para revisar aulas-chave antes de eventos reais.
+                    </li>
+                  </ul>
+                </article>
+                <article class="resource-card" role="listitem">
+                  <strong>Plantão tira-dúvidas ao vivo</strong>
+                  <p>
+                    Sessões quinzenais com a equipe da Dra. Cláudia para lapidar
+                    argumentos e postura.
+                  </p>
+                  <ul>
+                    <li>
+                      Envio prévio de perguntas e vídeos para feedback técnico.
+                    </li>
+                    <li>
+                      Protocolos de respiração e mindset aplicados em tempo
+                      real.
+                    </li>
+                    <li>
+                      Replay liberado em até 48 horas para rever quando quiser.
+                    </li>
+                  </ul>
+                </article>
+                <article class="resource-card" role="listitem">
+                  <strong>Biblioteca de roteiros e slides</strong>
+                  <p>
+                    Modelos editáveis para reuniões, aulas, sustentações orais e
+                    vendas consultivas.
+                  </p>
+                  <ul>
+                    <li>Templates em Google Slides, PowerPoint e PDF.</li>
+                    <li>
+                      Roteiros de storytelling com tempo sugerido de fala.
+                    </li>
+                    <li>Checklist visual para cada tipo de apresentação.</li>
+                  </ul>
+                </article>
+                <article class="resource-card" role="listitem">
+                  <strong>Comunidade moderada 24/7</strong>
+                  <p>
+                    Espaço exclusivo para networking, desafios mensais e troca
+                    de oportunidades profissionais.
+                  </p>
+                  <ul>
+                    <li>Desafios com feedback coletivo e ranking saudável.</li>
+                    <li>Canal de parcerias para palestras, eventos e lives.</li>
+                    <li>
+                      Equipe de suporte garantindo ambiente seguro e produtivo.
+                    </li>
+                  </ul>
+                </article>
+              </div>
+              <div class="hero__ctas section-cta">
+                <a
+                  class="button button--primary"
+                  href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+                  target="_blank"
+                  rel="noopener"
+                  >Acessar tudo agora</a
+                >
+                <a class="button button--ghost" href="#bonus"
+                  >Ver bônus inclusos</a
+                >
+              </div>
+              <p class="disclaimer">
+                Planilhas, templates e comunidade ficam disponíveis durante todo
+                o período de acesso ativo ao treinamento (12 meses).
+              </p>
+            </div>
+            <figure class="section-visual">
+              <img
+                src="assets/img/ai-suporte.svg"
+                width="520"
+                height="480"
+                loading="lazy"
+                decoding="async"
+                alt="Equipe de suporte retratada em arte gerada por IA com dashboards, chat e ícones de atendimento"
+              />
+              <figcaption class="figure-note">
+                Representação em IA do ecossistema de suporte contínuo para
+                facilitar a produção de banners e e-mails alinhados ao visual da
+                LP.
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="jornada-title"
+        id="jornada"
+      >
+        <div class="container">
+          <h2 id="jornada-title">Como funciona sua jornada após a matrícula</h2>
+          <p class="section-intro">
+            Da confirmação do pagamento aos primeiros resultados, você segue um
+            roteiro claro para manter o ritmo de prática e a consistência na
+            comunicação.
+          </p>
+          <div class="journey">
+            <div class="journey__highlight">
+              <strong>Diagnóstico imediato</strong>
+              <p>
+                No primeiro acesso você realiza o teste de clareza e confiança e
+                recebe um plano de treino personalizado.
+              </p>
+            </div>
+            <ol class="journey__steps">
+              <li data-step="01">
+                <strong>Onboarding guiado (Dia 1)</strong>
+                <p>
+                  Vídeo de boas-vindas da Dra. Cláudia, checklist de
+                  configuração e orientação para aproveitar as lives.
+                </p>
+              </li>
+              <li data-step="02">
+                <strong>Imersão nos módulos nucleares (Dias 2 a 14)</strong>
+                <p>
+                  Sequência recomendada de aulas, exercícios em áudio e
+                  exercícios de câmera com feedback da comunidade.
+                </p>
+              </li>
+              <li data-step="03">
+                <strong>Aplicação em cenários reais (Dias 15 a 30)</strong>
+                <p>
+                  Implementação assistida em reuniões, pitches ou aulas, com
+                  roteiros prontos e avaliação dos mentores.
+                </p>
+              </li>
+              <li data-step="04">
+                <strong>Plano de sustentação (Dia 31+)</strong>
+                <p>
+                  Rotina mensal de revisão, lives temáticas e novos desafios
+                  para consolidar autoridade e presença.
+                </p>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="comparativo-title"
+        id="comparativo"
+      >
+        <div class="container">
+          <h2 id="comparativo-title">O que muda na sua comunicação</h2>
+          <p class="section-intro">
+            Transforme insegurança em desempenho consistente. Veja os principais
+            avanços relatados pelos alunos após 30 dias de treino dedicado.
+          </p>
+          <div class="comparison" role="list">
+            <article class="comparison__item" role="listitem">
+              <h3>Antes</h3>
+              <ul>
+                <li>Ideias desconectadas e apresentações improvisadas.</li>
+                <li>Ansiedade elevada minutos antes de falar.</li>
+                <li>
+                  Baixo engajamento do público e pouca geração de negócios.
+                </li>
+              </ul>
+            </article>
+            <article class="comparison__item" role="listitem">
+              <h3>Depois</h3>
+              <ul>
+                <li>Mensagens estruturadas com clareza e storytelling.</li>
+                <li>Protocolos para entrar no palco com tranquilidade.</li>
+                <li>
+                  Interações estratégicas que ampliam oportunidades e
+                  conversões.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <p class="disclaimer">
+            Resultados reais dependem da dedicação individual e da aplicação dos
+            exercícios propostos durante o programa.
+          </p>
+          <div class="hero__ctas section-cta">
+            <a
+              class="button button--primary"
+              href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+              target="_blank"
+              rel="noopener"
+              >Quero destravar minha comunicação</a
+            >
+            <a class="button button--ghost" href="#contato"
+              >Falar com um especialista</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="bonus-title"
+        id="bonus"
+      >
+        <div class="container">
+          <h2 id="bonus-title">
+            Bônus exclusivos para acelerar seus resultados
+          </h2>
+          <p class="section-intro">
+            Somados, os bônus valem R$ 1.291 – e você recebe tudo incluso na
+            matrícula promocional.
+          </p>
+          <div class="bonus-grid">
+            <article class="bonus-card">
+              <strong>9 Lives + 9 Mapas Mentais de Treino</strong>
+              <span
+                >Calendário de encontros ao vivo com gravações e mapas prontos
+                para aplicar em diferentes contextos.</span
+              >
+              <span><em>Valor de referência:</em> R$ 497</span>
+            </article>
+            <article class="bonus-card">
+              <strong>Guia de Gatilhos Mentais Éticos</strong>
+              <span
+                >Manual com frameworks para ganhar atenção, construir autoridade
+                e gerar ações imediatas.</span
+              >
+              <span><em>Valor de referência:</em> R$ 397</span>
+            </article>
+            <article class="bonus-card">
+              <strong>Oratória de Impacto para Carreira e Negócios</strong>
+              <span
+                >Casos reais com roteiros de apresentações, defesa de teses e
+                reuniões comerciais.</span
+              >
+              <span><em>Valor de referência:</em> R$ 397</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora"
+        aria-labelledby="oferta-title"
+        id="oferta"
+      >
+        <div class="container">
+          <h2 id="oferta-title">Garanta sua vaga com desconto de R$ 1.291</h2>
+          <p class="section-intro">
+            Oferta válida por tempo limitado ou enquanto durarem as vagas da
+            turma atual.
+          </p>
+          <div class="investment">
+            <div class="price-stack" aria-label="Informações de investimento">
+              <span class="price-anchor">Valor original: R$ 1.638</span>
+              <span class="price-highlight">R$ 347 à vista</span>
+              <span class="price-installment"
+                >ou 12× de R$ 36,40 no cartão</span
+              >
+              <p class="section-intro">
+                Economize R$ 1.291 garantindo todos os módulos e bônus descritos
+                nesta página.
+              </p>
+            </div>
+            <div class="price-stack" aria-label="Chamada para ação">
+              <p>
+                Escolha a melhor condição e finalize sua matrícula com segurança
+                pelo checkout oficial.
+              </p>
+              <a
+                class="button button--primary"
+                href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+                target="_blank"
+                rel="noopener"
+              >
+                Comece agora
+              </a>
+              <p class="section-intro">
+                Pagamento processado com criptografia e confirmação instantânea
+                por e-mail.
+              </p>
+            </div>
+          </div>
+          <div class="guarantee-card" id="garantia">
+            <h3>Garantia incondicional de 7 dias</h3>
+            <p>
+              Teste o treinamento completo, participe das lives e acesse os
+              bônus. Se em até 7 dias você entender que o Oratória Estratégica
+              não é para você, é só enviar um e-mail para nossa equipe que
+              devolvemos 100% do investimento.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section--aurora" aria-labelledby="faq-title" id="faq">
+        <div class="container">
+          <h2 id="faq-title">Perguntas frequentes</h2>
+          <div class="faq-grid">
+            <details>
+              <summary>Quando terei acesso ao conteúdo?</summary>
+              <p>
+                Assim que o pagamento é aprovado, você recebe um e-mail com
+                login e senha para acessar a plataforma. Tudo fica disponível em
+                um único lugar, no desktop ou no mobile.
+              </p>
+            </details>
+            <details>
+              <summary>Por quanto tempo posso acessar o treinamento?</summary>
+              <p>
+                O acesso é válido por 12 meses completos, com possibilidade de
+                renovação. Durante esse período você participa das lives e
+                recebe atualizações sem custo adicional.
+              </p>
+            </details>
+            <details>
+              <summary>Os bônus custam algo a mais?</summary>
+              <p>
+                Não. Os três bônus detalhados nesta página são liberados
+                imediatamente, sem cobranças extras, desde que você garanta a
+                matrícula promocional.
+              </p>
+            </details>
+            <details>
+              <summary>E se eu não gostar?</summary>
+              <p>
+                Você tem 7 dias para assistir às aulas, participar da comunidade
+                e testar os materiais. Caso não queira continuar, basta
+                solicitar o cancelamento dentro do prazo e devolvemos 100% do
+                valor investido.
+              </p>
+            </details>
+            <details>
+              <summary>Preciso ter experiência prévia?</summary>
+              <p>
+                Não. O método foi desenhado para iniciantes e para quem já fala
+                em público, com trilhas específicas para diferentes contextos
+                profissionais.
+              </p>
+            </details>
+            <details>
+              <summary>Como funciona o suporte?</summary>
+              <p>
+                Você pode enviar dúvidas pela plataforma, participar das lives
+                tira-dúvidas e falar com a equipe pelo WhatsApp oficial das 9h
+                às 19h (horário de Brasília).
+              </p>
+            </details>
+            <details>
+              <summary>Quanto tempo devo dedicar por semana?</summary>
+              <p>
+                Recomendamos reservar ao menos 90 minutos semanais para assistir
+                às aulas e praticar com os exercícios guiados. Nas semanas com
+                lives, você pode participar ao vivo ou assistir às gravações no
+                seu ritmo.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--spotlight"
+        aria-labelledby="convite-title"
+        id="convite-final"
+      >
+        <div class="container">
+          <div class="final-cta">
+            <h2 id="convite-title">
+              Pronto para dominar sua oratória estratégica?
+            </h2>
+            <p class="section-intro">
+              Reúna método validado, acompanhamento ao vivo e materiais
+              inteligentes em uma experiência única, com garantia de 7 dias e
+              suporte dedicado para cada passo da jornada.
+            </p>
+            <div class="final-cta__actions">
+              <a
+                class="button button--primary"
+                href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+                target="_blank"
+                rel="noopener"
+                >Comece agora</a
+              >
+              <a class="button button--ghost" href="#contato"
+                >Quero falar com um especialista</a
+              >
+            </div>
+            <small class="disclaimer">
+              Acesso imediato, bônus liberados na matrícula e cancelamento sem
+              burocracia dentro do prazo legal de 7 dias.
+            </small>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--aurora-alt"
+        aria-labelledby="contato-title"
+        id="contato"
+      >
+        <div class="container contact-grid">
+          <div>
+            <h2 id="contato-title">Fale com a equipe e tire suas dúvidas</h2>
+            <p class="section-intro">
+              Estamos prontos para ajudar você a aproveitar todo o potencial da
+              sua comunicação.
+            </p>
+            <div class="whatsapp-card">
+              <p>Prefere conversar agora? Clique e fale com um especialista.</p>
+              <a
+                href="https://wa.me/5500000000000?text=Quero%20saber%20mais%20sobre%20o%20treinamento%20Orat%C3%B3ria%20Estrat%C3%A9gica&utm_source=lp&utm_medium=whatsapp&utm_campaign=oratoria-estrategica"
+                target="_blank"
+                rel="noopener"
+                aria-label="Abrir conversa no WhatsApp com a equipe Oratória Estratégica"
+              >
+                Fale com a equipe
+              </a>
+              <small class="disclaimer"
+                >Atualize o número oficial e personalize os parâmetros UTM de
+                acordo com a campanha ativa.</small
+              >
+            </div>
+          </div>
+          <div>
+            <form
+              action="https://oratoriaestrategica.com/api/leads"
+              method="post"
+              aria-describedby="form-disclaimer"
+            >
+              <label for="nome">
+                Nome completo
+                <input
+                  id="nome"
+                  name="nome"
+                  type="text"
+                  autocomplete="name"
+                  placeholder="Seu nome"
+                  required
+                />
+              </label>
+              <label for="email">
+                E-mail
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autocomplete="email"
+                  placeholder="seuemail@dominio.com"
+                  required
+                />
+              </label>
+              <label for="telefone">
+                Telefone
+                <input
+                  id="telefone"
+                  name="telefone"
+                  type="tel"
+                  inputmode="tel"
+                  autocomplete="tel"
+                  placeholder="(11) 90000-0000"
+                  required
+                />
+              </label>
+              <input type="hidden" name="utm_source" value="landing-page" />
+              <input type="hidden" name="utm_medium" value="form" />
+              <input
+                type="hidden"
+                name="utm_campaign"
+                value="oratoria-estrategica"
+              />
+              <label class="consent">
+                <input
+                  id="consentimento"
+                  name="consentimento"
+                  type="checkbox"
+                  value="true"
+                  required
+                />
+                <span>
+                  Autorizo o contato da Oratória Estratégica e concordo com a
+                  <a
+                    href="/politica-de-privacidade"
+                    target="_blank"
+                    rel="noopener"
+                    >Política de Privacidade</a
+                  >.
+                </span>
+              </label>
+              <button class="button button--primary" type="submit">
+                Quero receber o plano personalizado
+              </button>
+              <small class="disclaimer" id="form-disclaimer"
+                >Utilizamos seus dados apenas para contato relacionado ao
+                treinamento. Você pode solicitar remoção a qualquer
+                momento.</small
+              >
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="section--spotlight section--dev-notes"
+        id="publicacao"
+        data-dev-note
+        aria-labelledby="publicacao-title"
+      >
+        <div class="container">
+          <h2 id="publicacao-title">
+            Checklist de publicação &amp; campos a preencher
+          </h2>
+          <p class="section-intro">
+            Esta seção é um guia interno para a equipe de lançamento. Oculte-a
+            ou remova-a na versão final voltada ao público.
+          </p>
+          <div
+            class="dev-notes"
+            role="note"
+            aria-label="Orientações antes de publicar"
+          >
+            <article class="dev-notes__group">
+              <h3>Checklist de publicação</h3>
+              <ul class="dev-notes__list">
+                <li>Preço unificado em hero, oferta, FAQ e anúncios.</li>
+                <li>UTMs revisadas em todos os botões e WhatsApp.</li>
+                <li>
+                  Pixels e GA4 testados (ViewContent, Lead, InitiateCheckout,
+                  Purchase).
+                </li>
+                <li>
+                  Formulário com consentimento LGPD e resposta automática ativa.
+                </li>
+                <li>
+                  Central de cookies traduzida e funcionando em todos os
+                  devices.
+                </li>
+                <li>Provas sociais documentadas com autorização atualizada.</li>
+              </ul>
+            </article>
+            <article class="dev-notes__group">
+              <h3>Campos a preencher</h3>
+              <dl class="dev-notes__fields">
+                <div class="dev-notes__field">
+                  <dt>Preço final (à vista e parcelado)</dt>
+                  <dd>Atualizar com as condições aprovadas pelo financeiro.</dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>Headline aprovada</dt>
+                  <dd>Inserir a versão final validada pelo time de copy.</dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>Lista de logos autorizados</dt>
+                  <dd>
+                    Substituir placeholders por marcas com autorização formal.
+                  </dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>Depoimentos aprovados</dt>
+                  <dd>
+                    Atualizar com nome, cargo e data fornecidos pelo jurídico.
+                  </dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>Política de privacidade / Termos</dt>
+                  <dd>Informar URLs definitivos antes da publicação.</dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>WhatsApp oficial com parâmetros UTM</dt>
+                  <dd>Confirmar número da operação e tokens de campanha.</dd>
+                </div>
+                <div class="dev-notes__field">
+                  <dt>Paleta e tipografia da marca</dt>
+                  <dd>
+                    Registrar código de cores e fontes aprovadas no brandbook.
+                  </dd>
+                </div>
+              </dl>
+            </article>
+            <article class="dev-notes__group">
+              <h3>Referências para adaptação ao tema atual</h3>
+              <p>
+                Utilize os materiais abaixo para alinhar a copy criada no
+                projeto Codex com os slots disponíveis no template da
+                Estratégica Oratória.
+              </p>
+              <h4>Mapa mental da landing page</h4>
+              <pre class="dev-notes__code"><code>mindmap
+  root((LP Oratória Estratégica))
+    Hero &amp; CTA inicial
+      Headline transformação
+      Subheadline + selo 7 dias
+      CTA primário e secundário
+    Sobre &amp; Autoridade
+      Bio Dra. Cláudia
+      Estatísticas atualizadas
+      Logos de mídia e segmentos
+    Benefícios &amp; Perfis
+      Benefícios imediatos
+      Perfis atendidos
+      Provas sociais
+    Ofertas &amp; Programa
+      Método 3 C&#39;s
+      Trilha de módulos
+      Bônus estratégicos
+      Oferta &amp; garantia
+    Conversão final
+      FAQ
+      CTA final
+      Formulário &amp; WhatsApp</code></pre>
+              <h4>Organograma de navegação</h4>
+              <pre
+                class="dev-notes__code"
+              ><code>Home Hero → Sobre/Autoridade → Benefícios → Serviços → Resultados → Método 3 C&#39;s → Programa → Bônus → Oferta &amp; Garantia → Perfis → Recursos &amp; Suporte → Galeria IA → FAQ → CTA Final → Contato</code></pre>
+              <h4>Prompt sugerido para o Codex</h4>
+              <pre
+                class="dev-notes__code"
+              ><code>Você receberá o conteúdo estruturado da landing page Oratória Estratégica (hero, método 3 C&#39;s, módulos, bônus, oferta, garantia, provas sociais e FAQ). Sua tarefa é adaptar esse conteúdo para o tema ativo em https://www.estrategicaoratoria.com.br/, respeitando os seguintes slots: Sobre, Benefícios, Serviços, Resultados, Método, Programa, Bônus, Oferta, Garantia, FAQ e Contato.
+
+Para cada bloco do tema:
+1. Resuma o conteúdo existente mantendo a mesma promessa, dados e CTAs.
+2. Ajuste o tom de voz ao padrão já aplicado no Home Hero do tema.
+3. Informe onde inserir elementos visuais (imagens IA, ícones, logos) criados no projeto Codex.
+4. Garanta consistência nos preços: R$ 347 à vista ou 12× de R$ 36,40.
+5. Replique as UTMs padrão nos botões (utm_source, utm_medium, utm_campaign).
+
+Entregue o texto final em ordem de implementação, pronto para copiar e colar em cada seção do tema.</code></pre>
+            </article>
+          </div>
+          <p class="dev-notes__annotation">
+            ✅ Após validar cada item, exclua esta seção ou defina o atributo
+            <code>data-dev-note</code> como <code>hidden</code> para ocultá-la
+            no ambiente público.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <nav aria-label="Links institucionais">
+          <a href="/politica-de-privacidade">Política de Privacidade</a>
+          <a href="/termos-de-uso">Termos de Uso</a>
+          <a href="/cookies">Preferências de Cookies</a>
+        </nav>
+        <p>
+          © <span id="current-year"></span> Oratória Estratégica. Todos os
+          direitos reservados. CNPJ 00.000.000/0000-00.
+        </p>
+        <p>
+          Oratória Estratégica é uma marca liderada pela Dra. Cláudia Barbosa de
+          Paiva. Resultados podem variar conforme dedicação individual.
+        </p>
+        <button
+          class="button button--ghost"
+          type="button"
+          data-open-cookies
+          aria-label="Revisar preferências de cookies"
+        >
+          Ajustar preferências de cookies
+        </button>
+      </div>
+    </footer>
+
+    <div
+      class="cta-bar"
+      data-cta-bar
+      role="region"
+      aria-label="Chamada para iniciar matrícula"
+    >
+      <span>Pronto para falar com confiança?</span>
+      <a
+        class="button button--primary"
+        href="https://checkout.oratoriaestrategica.com/?utm_source=lp&utm_medium=cta&utm_campaign=oratoria-estrategica"
+        target="_blank"
+        rel="noopener"
+        >Comece agora</a
+      >
+    </div>
+
+    <div
+      class="cookie-banner"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cookie-title"
+      aria-describedby="cookie-description"
+      data-cookie-banner
+      tabindex="-1"
+    >
+      <div>
+        <h3 id="cookie-title">Nós respeitamos sua privacidade</h3>
+        <p id="cookie-description">
+          Utilizamos cookies para personalizar conteúdo, analisar o tráfego e
+          mensurar campanhas. Escolha continuar navegando com todos os cookies
+          ou ajuste suas preferências.
+        </p>
+        <div class="cookie-actions">
+          <button class="manage" type="button" data-cookie-preferences>
+            Gerenciar preferências
+          </button>
+          <button class="accept" type="button" data-cookie-accept>
+            Aceitar todos
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Structure the post-hero content into theme-friendly blocks for about, benefits and services so the Codex copy maps directly to the Estratégica Oratória template.
- Extend the stylesheet with layout utilities and card styles that keep the new sections visually aligned with the existing neon gradient system.
- Document a ready-to-use mindmap, navigation organogram and Codex prompt inside the internal checklist to guide future adaptations.

## Testing
- `npx --yes prettier --write index.html assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c9e2c4ae90832b8a16ddda48a5938e