### PR TITLE
Expose final Guell HTML inside dedicated folder

### DIFF
--- a/inst/newsletter/README.md
+++ b/inst/newsletter/README.md
@@ -1,0 +1,90 @@
+# Newsletter Guell Almeida — Pacote Final
+
+Este diretório agora contém a newsletter concluída com imagens reais hospedadas on-line, pronta para ser importada em plataformas como SFMC, Mailchimp ou Braze. O HTML está limpo, responsivo (largura fixa de 600&nbsp;px), com UTMs padronizadas e CTAs de WhatsApp funcionais.
+
+## Como usar
+
+1. Abra [`guell-newsletter.html`](final/guell-newsletter.html) (dentro da pasta [`final/`](final)) e personalize os campos operacionais restantes (`{{link_versao_web}}`, `{{link_descadastro}}` e `{{email_guell}}`). Caso já tenha o e-mail oficial, substitua o placeholder diretamente.
+2. Se preferir usar outros criativos, troque as URLs das imagens pelos seus próprios arquivos hospedados (veja a tabela abaixo com os tamanhos e fontes atuais).
+3. Faça o QA em inbox preview/spam checker, valide os links e parta para o disparo utilizando os assuntos e preheaders sugeridos.
+
+> **Observação:** todas as URLs já possuem o modelo de UTM `?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content={{bloco}}`. Ajuste apenas se a nomenclatura da campanha mudar.
+
+## Imagens aplicadas (pode substituir se desejar)
+
+| Bloco | Dimensão sugerida | URL utilizada | Fonte |
+|-------|-------------------|---------------|-------|
+| Logo | 160&nbsp;px de largura (máx. 600&nbsp;px) | `https://guellalmeida.com.br/images/logo.png` | Site oficial |
+| Faixa topo | 600×82 (entregue @2x) | `https://dummyimage.com/1200x164/25d366/ffffff&text=Agende+sua+consultoria+on-line+gr%C3%A1tis` | DummyImage (texto customizável) |
+| Hero | 600×400 | `https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1200` | Pexels — Fauxels |
+| Serviços — Mídia Social | 600×180 | `https://guellalmeida.com.br/images/portfolio/post1.jpg` | Site oficial |
+| Serviços — Logotipos | 600×180 | `https://guellalmeida.com.br/images/portfolio/logotipo2.jpg` | Site oficial |
+| Serviços — Marketing Digital | 600×180 | `https://images.pexels.com/photos/6476584/pexels-photo-6476584.jpeg?auto=compress&cs=tinysrgb&w=1200` | Pexels — Mikael Blomkvist |
+| Serviços — Site Responsivo | 600×180 | `https://guellalmeida.com.br/images/portfolio/site2.jpg` | Site oficial |
+| Serviços — Consultoria | 600×180 | `https://guellalmeida.com.br/images/portfolio/consultoria3.jpg` | Site oficial |
+| Serviços — Vídeos Animados | 600×180 | `https://guellalmeida.com.br/images/portfolio/video2.jpg` | Site oficial |
+| Portfólio 1 | 600×300 | `https://guellalmeida.com.br/images/portfolio/site3.jpg` | Site oficial |
+| Portfólio 2 | 600×300 | `https://guellalmeida.com.br/images/portfolio/post5.jpg` | Site oficial |
+| Portfólio 3 | 600×300 | `https://guellalmeida.com.br/images/portfolio/logotipo6.jpg` | Site oficial |
+| Ícone Instagram | 28×28 | `https://cdn-icons-png.flaticon.com/512/2111/2111463.png` | Flaticon |
+| Ícone Facebook | 28×28 | `https://cdn-icons-png.flaticon.com/512/733/733547.png` | Flaticon |
+| Ícone YouTube | 28×28 | `https://cdn-icons-png.flaticon.com/512/733/733646.png` | Flaticon |
+
+## Assuntos e preheaders sugeridos
+
+| # | Assunto (50–60 c.) | Preheader (35–70 c.) |
+|---|--------------------|-----------------------|
+| 1 | Design que vende: agende sua consultoria on-line | Atendimento on-line, rápido e sem complicação. |
+| 2 | Seu marketing pronto para crescer? Fale com o Guell | WhatsApp aberto: tire dúvidas e peça orçamento. |
+| 3 | Do logotipo ao site: vamos tirar sua marca do papel | Mídia social, logotipos, sites, vídeos e mais. |
+| 4 | Precisa de posts, site e anúncios? Eu cuido disso | Criação + performance com foco em resultado. |
+| 5 | Resultados com design e estratégia — vamos juntos | Veja trabalhos e peça sua consultoria grátis. |
+| 6 | Consultoria grátis: plano de ação para sua marca | Design profissional para sua empresa crescer. |
+| 7 | Mais vendas com conteúdo e identidade consistentes | Layouts limpos, copy direto e CTAs que convertem. |
+| 8 | Portfólio + serviços: veja como posso ajudar | Vamos começar hoje? Clique e fale comigo. |
+
+## Mapeamento de links + UTMs
+
+Todos os links seguem o padrão `?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content={{bloco}}`.
+
+| Bloco | URL Base |
+|-------|----------|
+| `logo` | `https://guellalmeida.com.br/` |
+| `faixa_topo`, `hero`, `cta_hero`, `cta_secundario` | `https://api.whatsapp.com/send?phone=5511985830211&text=Olá! Quero uma consultoria para minha empresa.` |
+| `servico_midias` | `https://guellalmeida.com.br/#services` |
+| `servico_logotipos` | `https://guellalmeida.com.br/#services` |
+| `servico_mkt` | `https://guellalmeida.com.br/#services` |
+| `servico_site` | `https://guellalmeida.com.br/#services` |
+| `servico_consultoria` | `https://guellalmeida.com.br/#services` |
+| `servico_videos` | `https://guellalmeida.com.br/#services` |
+| `port1`, `port2`, `port3` | `https://guellalmeida.com.br/#portfolio` |
+| `ig` | `https://www.instagram.com/guellalmeida/` |
+| `fb` | `https://www.facebook.com/guell.almeida.3` |
+| `yt` | `https://www.youtube.com/channel/UCUKVyxn5psJhLyxjn3c33qg/videos` |
+
+## Checklist rápido de QA
+
+- [x] Alt text aplicado em todas as imagens.
+- [x] Botões com fallback em HTML (sem dependência de imagem).
+- [x] Largura máxima 600&nbsp;px + imagens responsivas.
+- [x] UTMs padronizadas em todos os links.
+- [x] CTA WhatsApp presente no topo e no rodapé.
+- [ ] Atualizar links de versão web, descadastro e e-mail oficial antes do disparo.
+- [ ] Submeter a testes de renderização/spam antes do disparo.
+
+## Prompts de imagem IA (caso queira gerar novas peças)
+
+Mesmo com a versão final pronta, mantivemos os prompts originais para facilitar a produção de alternativas visuais, caso prefira trocar os criativos:
+
+1. **Faixa topo (600×82)** — “Faixa horizontal clean, fundo claro com sutil textura, ícones minimalistas de design/marketing à esquerda, texto legível à direita ‘Agende sua consultoria on-line grátis’, estilo moderno, tipografia sem serifa, alto contraste, composição para e-mail 600×82.”
+2. **Hero (600×400)** — “Banner hero para newsletter, conceito ‘Design que vende’, workspace criativo (laptop, layout, paleta de cores, post-its), luz natural suave, estética profissional, espaço negativo para texto, paleta neutra com acento verde, proporção 600×400, foco em clareza para e-mail.”
+3. **Serviços (600×180)**
+   - Mídia Social — “Ícones de redes sociais minimalistas em linha, gradiente sutil, estilo flat, 600×180, espaço para título.”
+   - Logotipos — “Processo de marca: grids, caneta, curvas vetoriais, fundo claro, 600×180.”
+   - Marketing Digital — “Tela com dashboard de métricas, setas de crescimento, clean, 600×180.”
+   - Site Responsivo — “Mockups responsivos (desktop/tablet/mobile) alinhados, 600×180.”
+   - Consultoria — “Mãos planejando estratégia com bloco de notas, café, 600×180, minimal.”
+   - Vídeos Animados — “Clapboard/frames estilizados, linhas dinâmicas, 600×180.”
+4. **Portfólio (600×300)** — “Mockup elegante de projeto de design (post de rede/logotipo/site), fundo neutro, 600×300, foco no layout.”
+
+Pronto! Agora é só ajustar os detalhes operacionais e publicar. 🚀

--- a/inst/newsletter/final/guell-newsletter.html
+++ b/inst/newsletter/final/guell-newsletter.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>Newsletter | Guell Almeida</title>
+<style>
+body { margin:0; padding:0; background:#ffffff; }
+img { border:0; outline:none; text-decoration:none; display:block; }
+table { border-collapse:collapse; }
+a { color:#000000; text-decoration:none; }
+@media only screen and (max-width: 600px){
+  .container { width:100% !important; }
+  .mobile-hide { display:none !important; }
+  .fluid-img img { width:100% !important; height:auto !important; }
+  .stack { display:block !important; width:100% !important; }
+  .p16 { padding:16px !important; }
+  .center { text-align:center !important; }
+}
+</style>
+</head>
+<body style="margin:0; padding:0; background:#ffffff;">
+  <div style="display:none; max-height:0; overflow:hidden; font-size:1px; line-height:1px; color:#ffffff;">
+    Consultoria ON-LINE grátis para impulsionar seu marketing. Fale com o Guell.
+  </div>
+
+  <table role="presentation" width="100%" bgcolor="#ffffff" align="center">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" class="container">
+          <tr>
+            <td align="right" style="font:12px Arial,Helvetica,sans-serif; color:#444; padding:8px 12px;">
+              <a href="{{link_versao_web}}" style="color:#444;">Ver on-line</a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:12px;">
+              <a href="https://guellalmeida.com.br/?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=logo">
+                <img src="https://guellalmeida.com.br/images/logo.png" width="160" alt="Guell Almeida | Designer">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center">
+              <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=faixa_topo">
+                <img src="https://dummyimage.com/1200x164/25d366/ffffff&text=Agende+sua+consultoria+on-line+gr%C3%A1tis" width="600" height="82" alt="Agende sua consultoria on-line grátis" style="width:100%; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:0;">
+              <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=hero">
+                <img src="https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Design que vende: estratégia e criação para impulsionar sua marca" style="width:100%; height:auto;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td class="p16" style="padding:20px 24px; font:16px/1.5 Arial,Helvetica,sans-serif; color:#111;">
+              <h1 style="margin:0 0 8px; font:700 24px Arial,Helvetica,sans-serif;">Design &amp; Marketing sem complicação</h1>
+              <p style="margin:8px 0 16px;">Estratégia, criação e implementação para você vender mais. Atendimento on-line, com agilidade e foco total nos resultados da sua empresa.</p>
+              <table role="presentation" align="left">
+                <tr>
+                  <td bgcolor="#25D366" style="border-radius:6px;">
+                    <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=cta_hero"
+                       style="display:inline-block; padding:12px 18px; font:700 16px Arial,Helvetica,sans-serif; color:#ffffff;">
+                      Falar no WhatsApp
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:8px 12px;">
+              <table role="presentation" width="100%">
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_midias">
+                      <img src="https://guellalmeida.com.br/images/portfolio/post1.jpg" width="600" alt="Mídia Social" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_logotipos">
+                      <img src="https://guellalmeida.com.br/images/portfolio/logotipo2.jpg" width="600" alt="Logotipos" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_mkt">
+                      <img src="https://images.pexels.com/photos/6476584/pexels-photo-6476584.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Marketing Digital" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_site">
+                      <img src="https://guellalmeida.com.br/images/portfolio/site2.jpg" width="600" alt="Site Responsivo" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_consultoria">
+                      <img src="https://guellalmeida.com.br/images/portfolio/consultoria3.jpg" width="600" alt="Consultoria" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_videos">
+                      <img src="https://guellalmeida.com.br/images/portfolio/video2.jpg" width="600" alt="Vídeos Animados" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:8px 12px;">
+              <table role="presentation" width="100%">
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port1">
+                      <img src="https://guellalmeida.com.br/images/portfolio/site3.jpg" width="600" alt="Site institucional responsivo desenvolvido por Guell Almeida" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port2">
+                      <img src="https://guellalmeida.com.br/images/portfolio/post5.jpg" width="600" alt="Campanha social media com layouts vibrantes" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port3">
+                      <img src="https://guellalmeida.com.br/images/portfolio/logotipo6.jpg" width="600" alt="Identidade visual e logotipo exclusivo" style="width:100%; height:auto; border-radius:6px;">
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:12px;">
+              <table role="presentation">
+                <tr>
+                  <td bgcolor="#25D366" style="border-radius:6px;">
+                    <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=cta_secundario"
+                       style="display:inline-block; padding:12px 18px; font:700 16px Arial,Helvetica,sans-serif; color:#ffffff;">
+                      Agendar consultoria grátis
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:10px 0;">
+              <table role="presentation">
+                <tr>
+                  <td style="padding:0 6px;">
+                    <a href="https://www.instagram.com/guellalmeida/?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=ig">
+                      <img src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" width="28" height="28" alt="Instagram">
+                    </a>
+                  </td>
+                  <td style="padding:0 6px;">
+                    <a href="https://www.facebook.com/guell.almeida.3?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=fb">
+                      <img src="https://cdn-icons-png.flaticon.com/512/733/733547.png" width="28" height="28" alt="Facebook">
+                    </a>
+                  </td>
+                  <td style="padding:0 6px;">
+                    <a href="https://www.youtube.com/channel/UCUKVyxn5psJhLyxjn3c33qg/videos?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=yt">
+                      <img src="https://cdn-icons-png.flaticon.com/512/733/733646.png" width="28" height="28" alt="YouTube">
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:16px 24px; font:12px/1.6 Arial,Helvetica,sans-serif; color:#4a4a4a; border-top:1px solid #eee;">
+              <p style="margin:4px 0;"><strong>Guell Almeida | Designer</strong></p>
+              <p style="margin:4px 0;">WhatsApp: <a href="https://api.whatsapp.com/send?phone=5511985830211" style="color:#4a4a4a;">(11) 98583-0211</a> • E-mail: <a href="mailto:{{email_guell}}" style="color:#4a4a4a;">{{email_guell}}</a></p>
+              <p style="margin:4px 0;">Atendimento on-line • Jardim Anália Franco – São Paulo/SP</p>
+              <p style="margin:8px 0; color:#777;">
+                Você está recebendo este e-mail porque demonstrou interesse nos serviços do Guell.
+                Para não receber mais, <a href="{{link_descadastro}}" style="color:#777; text-decoration:underline;">clique aqui</a>.
+              </p>
+              <p style="margin:4px 0; color:#999;">© 2024 Guell Almeida. Todos os direitos reservados.</p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move the production-ready newsletter HTML into a `final/` subfolder so it appears in the exported package
- update the README instructions to point to the new location when personalizing the placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d17ac15a34832ba9e152366ef1b745