### PR TITLE
Remove box shadows from newsletter layout

### DIFF
--- a/inst/newsletter/README.md
+++ b/inst/newsletter/README.md
@@ -1,0 +1,96 @@
+# Newsletter Guell Almeida — Pacote Final
+
+Este diretório agora contém a newsletter concluída com imagens reais hospedadas on-line, pronta para ser importada em plataformas como SFMC, Mailchimp ou Braze. O HTML está limpo, responsivo (largura fixa de 600&nbsp;px), com UTMs padronizadas e CTAs de WhatsApp funcionais.
+
+### Destaques visuais atualizados
+
+- Tipografia principal com `"Segoe UI", "Helvetica Neue", Arial` para um visual mais sério sem perder sofisticação.
+- Paleta com base #f5f0ff em todo o boletim, com cartões claros e realces pontuais em #2e005b/#12ceb8.
+- Cards de serviços agora trazem legendas textuais ("Planejamento e gestão de mídias sociais", "Criação de sites responsivos" etc.) logo abaixo das imagens para reforçar o entendimento rápido dos blocos.
+
+## Como usar
+
+1. Abra [`guell-newsletter.html`](final/guell-newsletter.html) (dentro da pasta [`final/`](final)) e personalize os campos operacionais restantes (`{{link_versao_web}}` e `{{link_descadastro}}`). O e-mail de contato já está definido como `atendimento@guellalmeida.com.br`.
+2. Se preferir usar outros criativos, troque as URLs das imagens pelos seus próprios arquivos hospedados (veja a tabela abaixo com os tamanhos e fontes atuais).
+3. Faça o QA em inbox preview/spam checker, valide os links e parta para o disparo utilizando os assuntos e preheaders sugeridos.
+
+> **Observação:** todas as URLs já possuem o modelo de UTM `?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content={{bloco}}`. Ajuste apenas se a nomenclatura da campanha mudar.
+
+## Imagens aplicadas (pode substituir se desejar)
+
+| Bloco | Dimensão sugerida | URL utilizada | Fonte |
+|-------|-------------------|---------------|-------|
+| Logo | 160&nbsp;px de largura (máx. 600&nbsp;px) | `https://guellalmeida.com.br/images/logo.png` | Site oficial |
+| Faixa topo | 600×82 (entregue @2x) | `https://dummyimage.com/1200x164/25d366/ffffff&text=Agende+sua+consultoria+on-line+gr%C3%A1tis` | DummyImage (texto customizável) |
+| Hero | 600×400 | `https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1200` | Pexels — Fauxels |
+| Serviços — Mídia Social | 600×180 | `https://guellalmeida.com.br/images/portfolio/post1.jpg` | Site oficial |
+| Serviços — Logotipos | 600×180 | `https://guellalmeida.com.br/images/portfolio/logotipo2.jpg` | Site oficial |
+| Serviços — Marketing Digital | 600×180 | `https://images.pexels.com/photos/6476584/pexels-photo-6476584.jpeg?auto=compress&cs=tinysrgb&w=1200` | Pexels — Mikael Blomkvist |
+| Serviços — Site Responsivo | 600×180 | `https://guellalmeida.com.br/images/portfolio/site2.jpg` | Site oficial |
+| Serviços — Consultoria | 600×180 | `https://guellalmeida.com.br/images/portfolio/consultoria3.jpg` | Site oficial |
+| Serviços — Vídeos Animados | 600×180 | `https://guellalmeida.com.br/images/portfolio/video2.jpg` | Site oficial |
+| Portfólio 1 | 600×300 | `https://guellalmeida.com.br/images/portfolio/site3.jpg` | Site oficial |
+| Portfólio 2 | 600×300 | `https://guellalmeida.com.br/images/portfolio/post5.jpg` | Site oficial |
+| Portfólio 3 | 600×300 | `https://guellalmeida.com.br/images/portfolio/logotipo6.jpg` | Site oficial |
+| Ícone Instagram | 32×32 | `https://cdn-icons-png.flaticon.com/512/2111/2111463.png` | Flaticon |
+| Ícone Facebook | 32×32 | `https://cdn-icons-png.flaticon.com/512/733/733547.png` | Flaticon |
+| Ícone YouTube | 32×32 | `https://cdn-icons-png.flaticon.com/512/733/733646.png` | Flaticon |
+
+## Assuntos e preheaders sugeridos
+
+| # | Assunto (50–60 c.) | Preheader (35–70 c.) |
+|---|--------------------|-----------------------|
+| 1 | Design que vende: agende sua consultoria on-line | Atendimento on-line, rápido e sem complicação. |
+| 2 | Seu marketing pronto para crescer? Fale com o Guell | WhatsApp aberto: tire dúvidas e peça orçamento. |
+| 3 | Do logotipo ao site: vamos tirar sua marca do papel | Mídia social, logotipos, sites, vídeos e mais. |
+| 4 | Precisa de posts, site e anúncios? Eu cuido disso | Criação + performance com foco em resultado. |
+| 5 | Resultados com design e estratégia — vamos juntos | Veja trabalhos e peça sua consultoria grátis. |
+| 6 | Consultoria grátis: plano de ação para sua marca | Design profissional para sua empresa crescer. |
+| 7 | Mais vendas com conteúdo e identidade consistentes | Layouts limpos, copy direto e CTAs que convertem. |
+| 8 | Portfólio + serviços: veja como posso ajudar | Vamos começar hoje? Clique e fale comigo. |
+
+## Mapeamento de links + UTMs
+
+Todos os links seguem o padrão `?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content={{bloco}}`.
+
+| Bloco | URL Base |
+|-------|----------|
+| `logo` | `https://guellalmeida.com.br/` |
+| `faixa_topo`, `hero`, `cta_hero`, `cta_footer` | `https://api.whatsapp.com/send?phone=5511985830211&text=Olá! Quero uma consultoria para minha empresa.` |
+| `servico_midias` | `https://guellalmeida.com.br/#services` |
+| `servico_logotipos` | `https://guellalmeida.com.br/#services` |
+| `servico_mkt` | `https://guellalmeida.com.br/#services` |
+| `servico_site` | `https://guellalmeida.com.br/#services` |
+| `servico_consultoria` | `https://guellalmeida.com.br/#services` |
+| `servico_videos` | `https://guellalmeida.com.br/#services` |
+| `port1`, `port2`, `port3` | `https://guellalmeida.com.br/#portfolio` |
+| `ig` | `https://www.instagram.com/guellalmeida/` |
+| `fb` | `https://www.facebook.com/guell.almeida.3` |
+| `yt` | `https://www.youtube.com/channel/UCUKVyxn5psJhLyxjn3c33qg/videos` |
+
+## Checklist rápido de QA
+
+- [x] Alt text aplicado em todas as imagens.
+- [x] Botões com fallback em HTML (sem dependência de imagem).
+- [x] Largura máxima 600&nbsp;px + imagens responsivas.
+- [x] UTMs padronizadas em todos os links.
+- [x] CTA WhatsApp presente no topo e no rodapé.
+- [ ] Atualizar links de versão web, descadastro e e-mail oficial antes do disparo.
+- [ ] Submeter a testes de renderização/spam antes do disparo.
+
+## Prompts de imagem IA (caso queira gerar novas peças)
+
+Mesmo com a versão final pronta, mantivemos os prompts originais para facilitar a produção de alternativas visuais, caso prefira trocar os criativos:
+
+1. **Faixa topo (600×82)** — “Faixa horizontal clean, fundo claro com sutil textura, ícones minimalistas de design/marketing à esquerda, texto legível à direita ‘Agende sua consultoria on-line grátis’, estilo moderno, tipografia sem serifa, alto contraste, composição para e-mail 600×82.”
+2. **Hero (600×400)** — “Banner hero para newsletter, conceito ‘Design que vende’, workspace criativo (laptop, layout, paleta de cores, post-its), luz natural suave, estética profissional, espaço negativo para texto, paleta neutra com acento verde, proporção 600×400, foco em clareza para e-mail.”
+3. **Serviços (600×180)**
+   - Mídia Social — “Ícones de redes sociais minimalistas em linha, gradiente sutil, estilo flat, 600×180, espaço para título.”
+   - Logotipos — “Processo de marca: grids, caneta, curvas vetoriais, fundo claro, 600×180.”
+   - Marketing Digital — “Tela com dashboard de métricas, setas de crescimento, clean, 600×180.”
+   - Site Responsivo — “Mockups responsivos (desktop/tablet/mobile) alinhados, 600×180.”
+   - Consultoria — “Mãos planejando estratégia com bloco de notas, café, 600×180, minimal.”
+   - Vídeos Animados — “Clapboard/frames estilizados, linhas dinâmicas, 600×180.”
+4. **Portfólio (600×300)** — “Mockup elegante de projeto de design (post de rede/logotipo/site), fundo neutro, 600×300, foco no layout.”
+
+Pronto! Agora é só ajustar os detalhes operacionais e publicar. 🚀

--- a/inst/newsletter/final/guell-newsletter.html
+++ b/inst/newsletter/final/guell-newsletter.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>Newsletter | Guell Almeida</title>
+<style>
+body { margin:0; padding:0; background:#f5f0ff; font-family:"Segoe UI", "Helvetica Neue", Arial, sans-serif; color:#222222; }
+img { border:0; outline:none; text-decoration:none; display:block; border-radius:25px; }
+table { border-collapse:collapse; }
+a { color:#2e005b; text-decoration:none; }
+.shadow-block { background:#ffffff; border-radius:28px; }
+.shadow-inner { background:#ffffff; border-radius:22px; }
+@media only screen and (max-width: 600px){
+  .container { width:100% !important; }
+  .mobile-hide { display:none !important; }
+  .fluid-img img { width:100% !important; height:auto !important; }
+  .stack { display:block !important; width:100% !important; }
+  .p16 { padding:16px !important; }
+  .center { text-align:center !important; }
+}
+</style>
+</head>
+<body style="margin:0; padding:0; background:#f5f0ff; font-family:'Segoe UI', 'Helvetica Neue', Arial, sans-serif; color:#222222;">
+  <div style="display:none; max-height:0; overflow:hidden; font-size:1px; line-height:1px; color:#ffffff;">
+    Consultoria ON-LINE grátis para impulsionar seu marketing. Fale com o Guell.
+  </div>
+
+  <table role="presentation" width="100%" bgcolor="#f5f0ff" align="center" style="background:#f5f0ff;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" class="container shadow-block" bgcolor="#f5f0ff" style="background:#f5f0ff; border-radius:32px; overflow:hidden;">
+          <tr>
+            <td align="right" style="font:12px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#555555; padding:8px 12px;">
+              <a href="{{link_versao_web}}" style="color:#555555;">Ver on-line</a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:20px 12px 12px;">
+              <a href="https://guellalmeida.com.br/?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=logo">
+                <img src="https://guellalmeida.com.br/images/logo.png" width="240" alt="Guell Almeida | Designer" style="width:240px; max-width:100%; height:auto; border-radius:0;">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center">
+              <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=faixa_topo">
+                <img src="https://dummyimage.com/1200x164/25d366/ffffff&text=Agende+sua+consultoria+on-line+gr%C3%A1tis" width="600" height="82" alt="Agende sua consultoria on-line grátis" style="width:100%; height:auto; ">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding:0;">
+              <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=hero">
+                <img src="https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Design que vende: estratégia e criação para impulsionar sua marca" style="width:100%; height:auto; ">
+              </a>
+            </td>
+          </tr>
+
+          <tr>
+            <td class="p16" style="padding:28px 24px; font:16px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#222222; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:24px; ">
+                <tr>
+                  <td style="padding:28px 24px;">
+              <h1 style="margin:0 0 10px; font:700 26px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Design &amp; Marketing sem complicação</h1>
+              <p style="margin:8px 0 16px; color:#444444;">Estratégia, criação e implementação para você vender mais. Atendimento on-line, com agilidade e foco total nos resultados da sua empresa.</p>
+              <p style="margin:8px 0 20px; color:#444444;">Começamos mergulhando nos seus objetivos de negócio e transformamos cada necessidade em um plano visual e textual consistente. Acompanhamos a jornada inteira — do conceito das campanhas à análise dos resultados — para garantir que você tenha clareza, previsibilidade e um parceiro ao seu lado em todas as etapas.</p>
+              <table role="presentation" align="center" style="margin:0 auto;">
+                <tr>
+                  <td bgcolor="#2e005b" style="border-radius:12px; ">
+                    <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=cta_hero"
+                       style="display:inline-block; padding:14px 28px; font:700 16px 'Segoe UI','Helvetica Neue',Arial,sans-serif;color:#ffffff;">
+                      Falar no WhatsApp
+                    </a>
+                  </td>
+                </tr>
+              </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:24px; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:24px; ">
+                <tr>
+                  <td class="stack" width="50%" style="padding:0 0 12px;">
+                    <img src="https://images.pexels.com/photos/4348404/pexels-photo-4348404.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Equipe criativa alinhando ideias com laptop e tablet" style="width:100%; height:auto; ">
+                  </td>
+                  <td class="stack" width="50%" style="padding:0 0 12px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333;" valign="top">
+                    <h2 style="margin:0 0 12px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Processo colaborativo do briefing ao go live</h2>
+                    <p style="margin:0 0 12px; color:#444444;">Trabalhamos com rituais leves e checkpoints semanais para que você acompanhe a evolução das artes, copies e automações. Todo o fluxo fica centralizado em ferramentas simples, permitindo aprovações rápidas e feedbacks claros.</p>
+                    <p style="margin:0; color:#444444;">Também fornecemos um board com referências, rascunhos e arquivos finais organizados por campanha. Assim, seu time tem um histórico completo e consegue replicar o aprendizado nas próximas ações.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" bgcolor="#f5f0ff" style="padding:24px; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:26px; ">
+                <tr>
+                  <td class="stack" width="50%" style="padding:24px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333;" valign="top">
+                    <h2 style="margin:0 0 12px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Conteúdo inteligente que conecta</h2>
+                    <p style="margin:0 0 12px; color:#444444;">Criamos narrativas que valorizam sua autoridade e constroem relação com seu público. Cada peça é pensada para guiar o leitor da descoberta à ação, mantendo consistência de mensagem e estética.</p>
+                    <p style="margin:0; color:#444444;">Relatórios com métricas claras fecham o ciclo, mostrando impactos em engajamento, leads e vendas.</p>
+                  </td>
+                  <td class="stack" width="50%" style="padding:0 0 12px;">
+                    <img src="https://images.pexels.com/photos/3183150/pexels-photo-3183150.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Profissional apresentando dashboards de marketing" style="width:100%; height:auto; ">
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:24px; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#f7f9fb; border-radius:26px; ">
+                <tr>
+                  <td style="padding:24px 28px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333;">
+                    <h2 style="margin:0 0 12px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">O que você recebe em cada projeto</h2>
+                    <ul style="margin:0; padding-left:18px; color:#444444;">
+                      <li style="margin:6px 0;">Calendário editorial com temas, ofertas e datas de disparo.</li>
+                      <li style="margin:6px 0;">Criação de peças gráficas em até 3 formatos, otimizadas para inbox.</li>
+                      <li style="margin:6px 0;">Copywriting persuasivo com variações de assunto e preheader testadas.</li>
+                      <li style="margin:6px 0;">Implementação HTML table-based, testes de renderização e QA completo.</li>
+                      <li style="margin:6px 0;">Relatório pós-envio com insights e sugestões de otimização.</li>
+                    </ul>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td bgcolor="#f5f0ff" style="padding:28px 24px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:26px; ">
+                <tr>
+                  <td style="padding:28px 28px 26px;">
+              <h2 style="margin:0 0 12px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Cases recentes que mostram nossa versatilidade</h2>
+              <p style="margin:0 0 12px; color:#444444;">Do branding para clínicas e profissionais liberais à construção de experiências digitais completas para e-commerce, unimos direção de arte, performance e automação para entregar entregáveis consistentes. Cada peça recebe estudo de cores, tipografia e narrativa pensada para reforçar sua proposta de valor.</p>
+              <p style="margin:0; color:#444444;">Gostamos de trabalhar em parceria: você apresenta os objetivos e desafios, e nós cuidamos do layout, copy e tecnologia para que o cliente final vivencie a melhor versão da sua marca.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" bgcolor="#f5f0ff" style="padding:24px 18px; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:28px; ">
+                <tr>
+                  <td style="padding:28px 24px 8px; text-align:center;">
+              <h2 style="margin:0 16px 8px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Principais serviços para acelerar sua marca</h2>
+              <p style="margin:0 0 20px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#555555;">Atendo do conceito à execução, com entregáveis completos para garantir consistência em todos os pontos de contato.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 16px 24px;">
+              <table role="presentation" width="100%">
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_midias">
+                      <img src="https://guellalmeida.com.br/images/portfolio/post1.jpg" width="600" alt="Mídia Social" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Planejamento e gestão de mídias sociais</p>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_logotipos">
+                      <img src="https://guellalmeida.com.br/images/portfolio/logotipo2.jpg" width="600" alt="Logotipos" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Desenvolvimento de logotipos únicos</p>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_mkt">
+                      <img src="https://images.pexels.com/photos/6476584/pexels-photo-6476584.jpeg?auto=compress&cs=tinysrgb&w=1200" width="600" alt="Marketing Digital" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Campanhas e performance digital</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_site">
+                      <img src="https://guellalmeida.com.br/images/portfolio/site2.jpg" width="600" alt="Site Responsivo" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Criação de sites responsivos</p>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_consultoria">
+                      <img src="https://guellalmeida.com.br/images/portfolio/consultoria3.jpg" width="600" alt="Consultoria" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Consultoria estratégica contínua</p>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#services?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=servico_videos">
+                      <img src="https://guellalmeida.com.br/images/portfolio/video2.jpg" width="600" alt="Vídeos Animados" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                    <p style="margin:8px 0 0; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; text-align:center;">Produção de vídeos animados</p>
+                  </td>
+                </tr>
+              </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" bgcolor="#f5f0ff" style="padding:24px 18px; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:28px; ">
+                <tr>
+                  <td style="padding:28px 24px 16px; text-align:center;">
+              <h2 style="margin:0 0 16px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Portfólio em foco</h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 16px 24px;">
+              <table role="presentation" width="100%">
+                <tr>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port1">
+                      <img src="https://guellalmeida.com.br/images/portfolio/site3.jpg" width="600" alt="Site institucional responsivo desenvolvido por Guell Almeida" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port2">
+                      <img src="https://guellalmeida.com.br/images/portfolio/post5.jpg" width="600" alt="Campanha social media com layouts vibrantes" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                  </td>
+                  <td class="stack" width="33.33%" style="padding:6px;">
+                    <a href="https://guellalmeida.com.br/#portfolio?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=port3">
+                      <img src="https://guellalmeida.com.br/images/portfolio/logotipo6.jpg" width="600" alt="Identidade visual e logotipo exclusivo" style="width:100%; height:auto; border-radius:25px; border:4px solid #ffffff; ">
+                    </a>
+                  </td>
+                </tr>
+              </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td bgcolor="#f5f0ff" style="padding:28px 24px; font:15px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#333333; background:#f5f0ff;">
+              <table role="presentation" width="100%" class="shadow-inner" style="background:#ffffff; border-radius:26px; ">
+                <tr>
+                  <td style="padding:28px 28px 26px;">
+              <h2 style="margin:0 0 12px; font:700 24px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">Depoimento que inspira</h2>
+              <p style="margin:0 0 12px; color:#444444;">“O Guell entendeu o posicionamento da nossa empresa em tempo recorde e estruturou uma newsletter que rendeu 3x mais respostas no primeiro envio. Hoje conseguimos manter uma cadência de comunicação alinhada com nossos lançamentos.” — <strong>Marina S., fundadora de startup de educação</strong></p>
+              <p style="margin:0; color:#444444;">Vamos construir o próximo case juntos? Escolha um dos serviços, envie uma mensagem e damos o start na consultoria gratuita.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" bgcolor="#2e005b" style="padding:40px 28px; background:#2e005b; color:#ffffff;">
+              <table role="presentation" width="100%">
+                <tr>
+                  <td style="text-align:center; font:16px/1.6 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#ffffff;">
+                    <h2 style="margin:0 0 12px; font:700 26px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#ffffff;">Pronto para transformar seus projetos?</h2>
+                    <p style="margin:0 0 24px; color:#e7e1ff;">Agende a consultoria on-line gratuita ou envie um e-mail direto para receber um plano personalizado.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="padding:0 0 26px;">
+                    <table role="presentation" align="center" style="margin:0 auto;">
+                      <tr>
+                        <td bgcolor="#12ceb8" style="border-radius:14px; ">
+                          <a href="https://api.whatsapp.com/send?phone=5511985830211&text=Ol%C3%A1!%20Quero%20uma%20consultoria%20para%20minha%20empresa.&utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=cta_footer"
+                             style="display:inline-block; padding:16px 32px; font:700 17px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#2e005b;">
+                            Falar no WhatsApp agora
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="padding:0 0 18px;">
+                    <a href="mailto:atendimento@guellalmeida.com.br" style="display:inline-block; padding:12px 20px; font:600 15px 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#12ceb8; background:rgba(255,255,255,0.08); border-radius:12px;">atendimento@guellalmeida.com.br</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td align="center" style="padding:10px 0 24px;">
+                    <table role="presentation">
+                      <tr>
+                        <td style="padding:0 6px;">
+                          <a href="https://www.instagram.com/guellalmeida/?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=ig">
+                            <img src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" width="32" height="32" alt="Instagram" style="display:block; background:#462c7a; padding:8px; border-radius:50%; border:1px solid rgba(255,255,255,0.24);">
+                          </a>
+                        </td>
+                        <td style="padding:0 6px;">
+                          <a href="https://www.facebook.com/guell.almeida.3?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=fb">
+                            <img src="https://cdn-icons-png.flaticon.com/512/733/733547.png" width="32" height="32" alt="Facebook" style="display:block; background:#462c7a; padding:8px; border-radius:50%; border:1px solid rgba(255,255,255,0.24);">
+                          </a>
+                        </td>
+                        <td style="padding:0 6px;">
+                          <a href="https://www.youtube.com/channel/UCUKVyxn5psJhLyxjn3c33qg/videos?utm_source=newsletter&utm_medium=email&utm_campaign=nl_guell_consultoria&utm_content=yt">
+                            <img src="https://cdn-icons-png.flaticon.com/512/733/733646.png" width="32" height="32" alt="YouTube" style="display:block; background:#462c7a; padding:8px; border-radius:50%; border:1px solid rgba(255,255,255,0.24);">
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="text-align:center; font:13px/1.7 'Segoe UI','Helvetica Neue',Arial,sans-serif; color:#e7e1ff;">
+                    <p style="margin:4px 0;"><strong>Guell Almeida | Designer</strong></p>
+                    <p style="margin:4px 0;">WhatsApp: <a href="https://api.whatsapp.com/send?phone=5511985830211" style="color:#12ceb8;">(11) 98583-0211</a> • E-mail: <a href="mailto:atendimento@guellalmeida.com.br" style="color:#12ceb8;">atendimento@guellalmeida.com.br</a></p>
+                    <p style="margin:4px 0;">Atendimento on-line • Jardim Anália Franco – São Paulo/SP</p>
+                    <p style="margin:8px 0;">Você está recebendo este e-mail porque demonstrou interesse nos serviços do Guell. Para não receber mais, <a href="{{link_descadastro}}" style="color:#12ceb8; text-decoration:underline;">clique aqui</a>.</p>
+                    <p style="margin:4px 0; color:#c9c1ef;">© 2025 Guell Almeida. Todos os direitos reservados.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove all box-shadow declarations from the Guell Almeida newsletter HTML while retaining the existing structure and styling tokens
- refresh the README highlight to describe the flat lilac canvas without referencing drop shadows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17ac15a34832ba9e152366ef1b745