### PR TITLE
Fix PDF report calculations and wording

### DIFF
--- a/bolao-x/bolao-x.php
+++ b/bolao-x/bolao-x.php
@@ -1,0 +1,4247 @@
+<?php
+/*
+Plugin Name: Bolao X
+Description: Sistema de gerenciamento de bolão com conferência automática, histórico de resultados, exportação em PDF e Excel e pagamento via Mercado Pago.
+Version: 2.8.80
+Text Domain: bolao-x
+Domain Path: /languages
+Author: Bolao X
+License: GPL2
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/lib/fpdf.php';
+if ( ! class_exists( 'BOLAOX_PDF' ) ) {
+    class BOLAOX_PDF extends FPDF {
+        public $headerTitle = '';
+        public $headerSubtitle = '';
+        public $headerLogo = '';
+        public $footerText = '';
+        public $footerLabel = '';
+        public $primaryColor = array( 30, 115, 76 );
+        public $secondaryColor = array( 37, 159, 60 );
+        public $accentColor = array( 185, 217, 56 );
+        public $mutedColor = array( 92, 110, 102 );
+        public $softBackground = array( 245, 249, 246 );
+
+        protected function prepare_text( $text ) {
+            if ( null === $text ) {
+                return '';
+            }
+
+            if ( is_bool( $text ) ) {
+                $text = $text ? '1' : '0';
+            } elseif ( ! is_string( $text ) ) {
+                if ( is_object( $text ) && method_exists( $text, '__toString' ) ) {
+                    $text = (string) $text;
+                } elseif ( is_scalar( $text ) ) {
+                    $text = (string) $text;
+                } else {
+                    return '';
+                }
+            }
+
+            if ( '' === $text ) {
+                return '';
+            }
+
+            if ( function_exists( 'seems_utf8' ) && ! seems_utf8( $text ) ) {
+                return $text;
+            }
+
+            if ( function_exists( 'iconv' ) ) {
+                $converted = @iconv( 'UTF-8', 'ISO-8859-1//TRANSLIT', $text );
+                if ( false !== $converted ) {
+                    return $converted;
+                }
+            }
+
+            if ( function_exists( 'mb_convert_encoding' ) ) {
+                $converted = @mb_convert_encoding( $text, 'ISO-8859-1', 'UTF-8' );
+                if ( false !== $converted ) {
+                    return $converted;
+                }
+            }
+
+            return utf8_decode( $text );
+        }
+
+        public function Cell( $w, $h = 0, $txt = '', $border = 0, $ln = 0, $align = '', $fill = false, $link = '' ) {
+            $txt  = $this->prepare_text( $txt );
+            $link = is_string( $link ) ? $this->prepare_text( $link ) : $link;
+
+            return parent::Cell( $w, $h, $txt, $border, $ln, $align, $fill, $link );
+        }
+
+        public function MultiCell( $w, $h, $txt, $border = 0, $align = 'J', $fill = false ) {
+            $txt = $this->prepare_text( $txt );
+
+            return parent::MultiCell( $w, $h, $txt, $border, $align, $fill );
+        }
+
+        public function Text( $x, $y, $txt ) {
+            $txt = $this->prepare_text( $txt );
+
+            return parent::Text( $x, $y, $txt );
+        }
+
+        public function Write( $h, $txt, $link = '' ) {
+            $txt  = $this->prepare_text( $txt );
+            $link = is_string( $link ) ? $this->prepare_text( $link ) : $link;
+
+            return parent::Write( $h, $txt, $link );
+        }
+
+        public function getLeftMargin() {
+            return $this->lMargin;
+        }
+
+        public function getRightMargin() {
+            return $this->rMargin;
+        }
+
+        public function getTopMargin() {
+            return $this->tMargin;
+        }
+
+        public function getBottomMargin() {
+            return $this->bMargin;
+        }
+
+        public function getContentWidth() {
+            return $this->GetPageWidth() - $this->getLeftMargin() - $this->getRightMargin();
+        }
+
+        public function Header() {
+            $width = $this->GetPageWidth();
+            $this->LinearGradient( 0, 0, $width, 42, $this->primaryColor, $this->secondaryColor );
+            if ( $this->headerLogo ) {
+                $this->Image( $this->headerLogo, $this->lMargin, 10, 28 );
+            }
+            $this->SetTextColor( 255, 255, 255 );
+            $this->SetFont( 'Arial', 'B', 16 );
+            $title_x = $this->lMargin + ( $this->headerLogo ? 34 : 4 );
+            $this->SetXY( $title_x, 14 );
+            if ( $this->headerTitle ) {
+                $this->Cell( $width - $title_x - $this->rMargin, 8, $this->headerTitle, 0, 2, 'L' );
+            }
+            if ( $this->headerSubtitle ) {
+                $this->SetFont( 'Arial', '', 11 );
+                $this->SetXY( $title_x, 24 );
+                $this->Cell( $width - $title_x - $this->rMargin, 6, $this->headerSubtitle, 0, 2, 'L' );
+            }
+            $this->SetY( 42 );
+        }
+
+        public function Footer() {
+            $width = $this->GetPageWidth() - $this->lMargin - $this->rMargin;
+            $this->SetY( -18 );
+            $y = $this->GetY();
+            $this->SetDrawColor( 220, 235, 227 );
+            $this->SetFillColor( 245, 249, 246 );
+            $this->Rect( $this->lMargin, $y, $width, 14, 'F' );
+            $this->SetY( $y + 2 );
+            $this->SetFont( 'Arial', '', 8.5 );
+            $this->SetTextColor( 92, 110, 102 );
+            if ( $this->footerText ) {
+                $this->Cell( 0, 4, $this->footerText, 0, 1, 'L' );
+            }
+            $label = $this->footerLabel ? $this->footerLabel : 'Página %d';
+            $this->SetFont( 'Arial', '', 8 );
+            $this->SetTextColor( 130, 145, 138 );
+            $this->Cell( 0, 4, sprintf( $label, $this->PageNo() ), 0, 0, 'R' );
+        }
+
+        public function LinearGradient( $x, $y, $w, $h, $start, $end, $steps = 30 ) {
+            $steps = max( 1, intval( $steps ) );
+            for ( $i = 0; $i < $steps; $i++ ) {
+                $ratio = ( $steps > 1 ) ? $i / ( $steps - 1 ) : 0;
+                $r = (int) round( $start[0] + ( $end[0] - $start[0] ) * $ratio );
+                $g = (int) round( $start[1] + ( $end[1] - $start[1] ) * $ratio );
+                $b = (int) round( $start[2] + ( $end[2] - $start[2] ) * $ratio );
+                $this->SetDrawColor( $r, $g, $b );
+                $this->SetFillColor( $r, $g, $b );
+                $this->Rect( $x, $y + ( $h / $steps ) * $i, $w, $h / $steps, 'F' );
+            }
+        }
+
+        public function Circle( $x, $y, $r, $style = 'D' ) {
+            $this->Ellipse( $x, $y, $r, $r, $style );
+        }
+
+        public function Ellipse( $x, $y, $rx, $ry, $style = 'D' ) {
+            $op = 'S';
+            if ( 'F' === $style ) {
+                $op = 'f';
+            } elseif ( in_array( $style, array( 'FD', 'DF' ), true ) ) {
+                $op = 'B';
+            }
+            $lx = 4 / 3 * ( sqrt( 2 ) - 1 ) * $rx;
+            $ly = 4 / 3 * ( sqrt( 2 ) - 1 ) * $ry;
+            $k  = $this->k;
+            $h  = $this->h;
+            $this->_out( sprintf( '%.2F %.2F m', ( $x + $rx ) * $k, ( $h - $y ) * $k ) );
+            $this->_out( sprintf( '%.2F %.2F %.2F %.2F %.2F %.2F c', ( $x + $rx ) * $k, ( $h - ( $y - $ly ) ) * $k, ( $x + $lx ) * $k, ( $h - ( $y - $ry ) ) * $k, $x * $k, ( $h - ( $y - $ry ) ) * $k ) );
+            $this->_out( sprintf( '%.2F %.2F %.2F %.2F %.2F %.2F c', ( $x - $lx ) * $k, ( $h - ( $y - $ry ) ) * $k, ( $x - $rx ) * $k, ( $h - ( $y - $ly ) ) * $k, ( $x - $rx ) * $k, ( $h - $y ) * $k ) );
+            $this->_out( sprintf( '%.2F %.2F %.2F %.2F %.2F %.2F c', ( $x - $rx ) * $k, ( $h - ( $y + $ly ) ) * $k, ( $x - $lx ) * $k, ( $h - ( $y + $ry ) ) * $k, $x * $k, ( $h - ( $y + $ry ) ) * $k ) );
+            $this->_out( sprintf( '%.2F %.2F %.2F %.2F %.2F %.2F c %s', ( $x + $lx ) * $k, ( $h - ( $y + $ry ) ) * $k, ( $x + $rx ) * $k, ( $h - ( $y + $ly ) ) * $k, ( $x + $rx ) * $k, ( $h - $y ) * $k, $op ) );
+        }
+    }
+}
+
+class BOLAOX_Plugin {
+    private static $instance = null;
+    private $notice = '';
+    private $log_file = '';
+    private $general_log_file = '';
+    /**
+     * Guard flag to prevent recursive save_post calls when creating bets
+     * programmatically.
+     *
+     * @var bool
+     */
+    private $saving_meta = false;
+    const TEXT_DOMAIN = 'bolao-x';
+const VERSION = '2.8.80';
+    const MP_WEBHOOK_TOKEN = 'CwbzYUaV8TNfv*J$Dua6JiHy@';
+    const MP_API_URL = 'https://api.mercadopago.com';
+
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', array( $this, 'register_post_type' ) );
+        add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+        add_action( 'save_post', array( $this, 'save_meta' ) );
+        add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+        add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+        add_filter( 'gettext', array( $this, 'filter_gettext' ), 10, 3 );
+        add_filter( 'enter_title_here', array( $this, 'title_placeholder' ), 10, 2 );
+        add_action( 'init', array( $this, 'track_visit' ) );
+        add_action( 'init', array( $this, 'register_meta_fields' ) );
+        add_action( 'save_post_bolaox_result', array( $this, 'clear_pending_payments' ), 10, 3 );
+        add_action( 'save_post_bolaox_result', array( $this, 'recompute_scores_after_edit' ), 20, 3 );
+        add_action( 'save_post_bolaox_result', array( $this, 'update_repeats_after_edit' ), 30, 3 );
+        add_action( 'save_post_bolaox_concurso', array( $this, 'auto_create_result' ), 10, 3 );
+        add_action( 'admin_menu', array( $this, 'pending_payments_menu' ) );
+        add_action( 'admin_menu', array( $this, 'import_bets_menu' ) );
+        add_action( 'admin_post_bolaox_import_bets', array( $this, 'handle_import_bets' ) );
+        add_action( 'admin_post_bolao_x_export_winners', array( $this, 'handle_export_winners_pdf' ) );
+        add_action( 'wp_logout', array( $this, 'logout_session' ) );
+        add_filter( 'manage_bolaox_aposta_posts_columns', array( $this, 'aposta_columns' ) );
+        add_action( 'manage_bolaox_aposta_posts_custom_column', array( $this, 'aposta_column_content' ), 10, 2 );
+        add_filter( 'manage_bolaox_result_posts_columns', array( $this, 'result_columns' ) );
+        add_action( 'manage_bolaox_result_posts_custom_column', array( $this, 'result_column_content' ), 10, 2 );
+        add_action( 'restrict_manage_posts', array( $this, 'aposta_filter' ) );
+        add_action( 'restrict_manage_posts', array( $this, 'result_filter' ) );
+        add_filter( 'pre_get_posts', array( $this, 'aposta_filter_query' ) );
+        add_filter( 'pre_get_posts', array( $this, 'result_filter_query' ) );
+
+        $upload = wp_upload_dir();
+        $dir    = trailingslashit( $upload['basedir'] ) . 'bolao-x';
+        if ( ! file_exists( $dir ) ) {
+            wp_mkdir_p( $dir );
+        }
+        $this->log_file        = $dir . '/mp-error.log';
+        $this->general_log_file = $dir . '/general.log';
+        add_shortcode( 'bolao_x_form', array( $this, 'render_form_shortcode' ) );
+        add_shortcode( 'bolao_x_results', array( $this, 'render_results_shortcode' ) );
+        add_shortcode( 'bolao_x_history', array( $this, 'render_history_shortcode' ) );
+        add_shortcode( 'bolao_x_my_bets', array( $this, 'render_my_bets_shortcode' ) );
+        add_shortcode( 'bolao_x_stats', array( $this, 'render_stats_shortcode' ) );
+        add_shortcode( 'bolao_x_profile', array( $this, 'render_profile_shortcode' ) );
+        add_shortcode( 'bolao_x_minha_conta', array( $this, 'render_profile_shortcode' ) );
+        add_shortcode( 'bolao_x_login', array( $this, 'render_login_shortcode' ) );
+        add_shortcode( 'bolao_x_dashboard', array( $this, 'render_dashboard_shortcode' ) );
+        add_filter( 'query_vars', array( $this, 'add_query_vars' ) );
+    }
+
+    public function register_settings() {
+        register_setting( 'bolaox', 'bolaox_cutoffs' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_public' );
+        register_setting( 'bolaox', 'bolaox_mp_prod_token' );
+        register_setting( 'bolaox', 'bolaox_mp_test_public' );
+        register_setting( 'bolaox', 'bolaox_mp_test_token' );
+        register_setting( 'bolaox', 'bolaox_pix_key' );
+        register_setting( 'bolaox', 'bolaox_mp_mode' );
+        register_setting( 'bolaox', 'bolaox_lowest_info' );
+        register_setting( 'bolaox', 'bolaox_form_page' );
+        register_setting( 'bolaox', 'bolaox_price' );
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain( 'bolao-x', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    public function register_meta_fields() {
+        $caps = function() { return current_user_can( 'edit_posts' ); };
+        register_post_meta( 'bolaox_result', '_bolaox_numbers', array(
+            'type'         => 'string',
+            'single'       => true,
+            'show_in_rest' => true,
+            'sanitize_callback' => 'sanitize_text_field',
+            'auth_callback' => $caps,
+        ) );
+        register_post_meta( 'bolaox_result', '_bolaox_result', array(
+            'type'         => 'string',
+            'single'       => true,
+            'show_in_rest' => true,
+            'sanitize_callback' => 'sanitize_text_field',
+            'auth_callback' => $caps,
+        ) );
+        register_post_meta( 'bolaox_aposta', '_bolaox_hits', array(
+            'type'         => 'integer',
+            'single'       => true,
+            'show_in_rest' => true,
+            'auth_callback' => $caps,
+        ) );
+    }
+
+    private function validate_numbers( $numbers ) {
+        $nums = array_map( 'trim', explode( ',', $numbers ) );
+        if ( count( $nums ) !== 10 ) {
+            return false;
+        }
+        $clean = array();
+        foreach ( $nums as $n ) {
+            if ( $n === '00' || $n === '0' ) {
+                $clean[] = '00';
+                continue;
+            }
+            if ( ! ctype_digit( $n ) || (int) $n < 1 || (int) $n > 99 ) {
+                return false;
+            }
+            $clean[] = sprintf( '%02d', (int) $n );
+        }
+        return implode( ',', $clean );
+    }
+
+    private function validate_result_numbers( $numbers ) {
+        $nums = array_filter( array_map( 'trim', explode( ',', $numbers ) ), 'strlen' );
+        $count = count( $nums );
+        // Allow a much larger set of result numbers for bulk draws
+        if ( $count < 1 || $count > 500 ) {
+            return false;
+        }
+        $clean = array();
+        foreach ( $nums as $n ) {
+            if ( $n === '00' || $n === '0' ) {
+                $clean[] = '00';
+                continue;
+            }
+            if ( ! ctype_digit( $n ) || (int) $n < 1 || (int) $n > 99 ) {
+                return false;
+            }
+            $clean[] = sprintf( '%02d', (int) $n );
+        }
+        return implode( ',', $clean );
+    }
+
+    private function sanitize_phone( $phone ) {
+        return preg_replace( '/\D+/', '', $phone );
+    }
+
+    /**
+     * Count hits considering repeated numbers on both sides.
+     */
+    private function count_hits( $bet_numbers, $result_numbers ) {
+        $drawn = array_count_values( $result_numbers );
+        $hits = 0;
+        foreach ( $bet_numbers as $n ) {
+            if ( isset( $drawn[ $n ] ) && $drawn[ $n ] > 0 ) {
+                $hits++;
+                $drawn[ $n ]--;
+            }
+        }
+        return $hits;
+    }
+
+    /**
+     * Ensure the session is restored from the auth cookie when possible.
+     */
+    private function maybe_restore_session() {
+        if ( is_user_logged_in() ) {
+            return;
+        }
+
+        $uid = 0;
+        $cookie = isset( $_COOKIE['bolaox_session'] ) ? $_COOKIE['bolaox_session'] : '';
+        if ( $cookie && strpos( $cookie, ':' ) !== false ) {
+            list( $id, $token ) = explode( ':', $cookie, 2 );
+            $hash = get_user_meta( (int) $id, '_bolaox_token', true );
+            $exp  = intval( get_user_meta( (int) $id, '_bolaox_token_exp', true ) );
+            if ( $hash && $exp > time() && wp_check_password( $token, $hash, $id ) ) {
+                $uid = (int) $id;
+            } else {
+                $this->clear_session_cookie();
+            }
+        } else {
+            $uid = wp_validate_auth_cookie( '', 'logged_in' );
+        }
+
+        if ( $uid ) {
+            wp_set_current_user( $uid );
+        }
+    }
+
+    private function create_session( $user_id ) {
+        $token  = wp_generate_password( 20, false );
+        $hash   = wp_hash_password( $token );
+        update_user_meta( $user_id, '_bolaox_token', $hash );
+        update_user_meta( $user_id, '_bolaox_token_exp', time() + HOUR_IN_SECONDS );
+        // also set the default WordPress auth cookies so REST requests work
+        if ( ! is_user_logged_in() ) {
+            wp_set_current_user( $user_id );
+            wp_set_auth_cookie( $user_id );
+        }
+        $cookie = $user_id . ':' . $token;
+        $args   = array(
+            'expires'  => time() + HOUR_IN_SECONDS,
+            'path'     => COOKIEPATH ? COOKIEPATH : '/',
+            'domain'   => COOKIE_DOMAIN,
+            'secure'   => is_ssl(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        );
+        if ( ! headers_sent() ) {
+            setcookie( 'bolaox_session', $cookie, $args );
+            return '';
+        }
+        $js  = 'document.cookie="bolaox_session=' . rawurlencode( $cookie ) . ';path=' . ( COOKIEPATH ? COOKIEPATH : '/' ) . ';max-age=' . HOUR_IN_SECONDS;
+        if ( is_ssl() ) {
+            $js .= ';secure';
+        }
+        $js .= ';samesite=Lax";';
+        return '<script>' . $js . '</script>';
+    }
+
+    private function clear_session_cookie() {
+        if ( isset( $_COOKIE['bolaox_session'] ) ) {
+            setcookie( 'bolaox_session', '', time() - HOUR_IN_SECONDS, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, is_ssl(), true );
+            unset( $_COOKIE['bolaox_session'] );
+        }
+        if ( function_exists( 'wp_clear_auth_cookie' ) ) {
+            wp_clear_auth_cookie();
+        }
+    }
+
+    public function logout_session() {
+        $this->clear_session_cookie();
+    }
+
+    private function get_form_page_url() {
+        $page_id = get_option( 'bolaox_form_page', 0 );
+        if ( $page_id && get_post_status( $page_id ) ) {
+            return get_permalink( $page_id );
+        }
+        $pages = get_posts( array(
+            'post_type'      => 'page',
+            's'              => '[bolao_x_form',
+            'posts_per_page' => 1,
+        ) );
+        if ( $pages ) {
+            $page_id = $pages[0]->ID;
+            update_option( 'bolaox_form_page', $page_id );
+            return get_permalink( $page_id );
+        }
+        return home_url( '/' );
+    }
+
+    private function get_mp_access_token() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_token', '' ) );
+        }
+        return trim( get_option( 'bolaox_mp_test_token', '' ) );
+    }
+
+    private function get_mp_public_key() {
+        $mode = get_option( 'bolaox_mp_mode', 'test' );
+        if ( 'prod' === $mode ) {
+            return trim( get_option( 'bolaox_mp_prod_public', '' ) );
+        }
+        return trim( get_option( 'bolaox_mp_test_public', '' ) );
+    }
+
+    private function validate_mp_credentials( $mode ) {
+        $token = ( 'prod' === $mode ) ? get_option( 'bolaox_mp_prod_token', '' ) : get_option( 'bolaox_mp_test_token', '' );
+        if ( ! $token ) {
+            return false;
+        }
+        $url  = self::MP_API_URL . '/users/me';
+        $args = array(
+            'headers' => array( 'Authorization' => 'Bearer ' . $token ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_error( 'Falha ao validar credenciais: ' . $res->get_error_message() );
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
+        if ( $code !== 200 ) {
+            $this->log_error( 'Credenciais inválidas: HTTP ' . $code );
+        }
+        return $code === 200;
+    }
+
+    private function log_mp_error( $msg ) {
+        if ( ! $this->log_file ) {
+            return;
+        }
+        if ( strlen( $msg ) > 1000 ) {
+            $msg = substr( $msg, 0, 1000 ) . '...';
+        }
+        $entry = '[' . current_time( 'mysql' ) . "] " . $msg . "\n";
+        error_log( $entry, 3, $this->log_file );
+    }
+
+    private function log_error( $msg ) {
+        if ( ! $this->general_log_file ) {
+            return;
+        }
+        if ( strlen( $msg ) > 1000 ) {
+            $msg = substr( $msg, 0, 1000 ) . '...';
+        }
+        $entry = '[' . current_time( 'mysql' ) . "] " . $msg . "\n";
+        error_log( $entry, 3, $this->general_log_file );
+    }
+
+
+    private function get_browser_name( $ua ) {
+        if ( strpos( $ua, 'Firefox' ) !== false ) return 'Firefox';
+        if ( strpos( $ua, 'Edg' ) !== false ) return 'Edge';
+        if ( strpos( $ua, 'Chrome' ) !== false ) return 'Chrome';
+        if ( strpos( $ua, 'Safari' ) !== false ) return 'Safari';
+        if ( strpos( $ua, 'Trident' ) !== false || strpos( $ua, 'MSIE' ) !== false ) return 'IE';
+        return 'Outro';
+    }
+
+    private function get_platform_name( $ua ) {
+        $ua = strtolower( $ua );
+        if ( strpos( $ua, 'android' ) !== false ) return 'Android';
+        if ( strpos( $ua, 'iphone' ) !== false || strpos( $ua, 'ipad' ) !== false ) return 'iOS';
+        if ( strpos( $ua, 'windows' ) !== false ) return 'Windows';
+        if ( strpos( $ua, 'mac' ) !== false ) return 'macOS';
+        if ( strpos( $ua, 'linux' ) !== false ) return 'Linux';
+        return 'Outro';
+    }
+
+    public function track_visit() {
+        if ( is_admin() ) {
+            return;
+        }
+        $data = get_option( 'bolaox_visits', array() );
+        $date = current_time( 'Y-m-d' );
+        if ( ! isset( $data['days'][ $date ] ) ) {
+            $data['days'][ $date ] = 0;
+        }
+        $data['days'][ $date ]++;
+
+        $country = $_SERVER['HTTP_CF_IPCOUNTRY'] ?? '??';
+        $data['countries'][ $country ] = ( $data['countries'][ $country ] ?? 0 ) + 1;
+
+        $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $browser = $this->get_browser_name( $ua );
+        $platform = $this->get_platform_name( $ua );
+        $data['browsers'][ $browser ] = ( $data['browsers'][ $browser ] ?? 0 ) + 1;
+        $data['platforms'][ $platform ] = ( $data['platforms'][ $platform ] ?? 0 ) + 1;
+
+        if ( is_user_logged_in() ) {
+            $uid = get_current_user_id();
+            if ( ! isset( $data['users'][ $date ] ) ) {
+                $data['users'][ $date ] = array();
+            }
+            if ( ! in_array( $uid, $data['users'][ $date ], true ) ) {
+                $data['users'][ $date ][] = $uid;
+            }
+        }
+
+        if ( count( $data['days'] ) > 30 ) {
+            $data['days'] = array_slice( $data['days'], -30, true );
+        }
+        if ( isset( $data['users'] ) && count( $data['users'] ) > 30 ) {
+            $data['users'] = array_slice( $data['users'], -30, true );
+        }
+        update_option( 'bolaox_visits', $data );
+
+        $online = get_transient( 'bolaox_online' );
+        if ( ! is_array( $online ) ) {
+            $online = array();
+        }
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $online[ $ip ] = time();
+        foreach ( $online as $k => $t ) {
+            if ( $t < time() - 300 ) {
+                unset( $online[ $k ] );
+            }
+        }
+        set_transient( 'bolaox_online', $online, 5 * MINUTE_IN_SECONDS );
+    }
+
+    public function add_query_vars( $vars ) {
+        $vars[] = 'bolaox_page';
+        return $vars;
+    }
+
+    private function prepare_visit_stats() {
+        $data = get_option( 'bolaox_visits', array() );
+        $days = $data['days'] ?? array();
+        $users = $data['users'] ?? array();
+        $countries = $data['countries'] ?? array();
+        $platforms = $data['platforms'] ?? array();
+        $browsers = $data['browsers'] ?? array();
+        $dates = array();
+        $visit_counts = array();
+        $user_counts = array();
+        $today_views = 0;
+        for ( $i = 14; $i >= 0; $i-- ) {
+            $d = date( 'Y-m-d', strtotime( "-$i days" ) );
+            $dates[] = date_i18n( 'd/m', strtotime( $d ) );
+            $visit_counts[] = intval( $days[ $d ] ?? 0 );
+            $user_counts[]  = isset( $users[ $d ] ) ? count( $users[ $d ] ) : 0;
+            if ( 0 === $i ) {
+                $today_views = intval( $days[ $d ] ?? 0 );
+            }
+        }
+        arsort( $countries );
+        arsort( $platforms );
+        arsort( $browsers );
+        $online = get_transient( 'bolaox_online' );
+        $online_count = is_array( $online ) ? count( $online ) : 0;
+        return array(
+            'dates'       => $dates,
+            'visits'      => $visit_counts,
+            'users'       => $user_counts,
+            'countries'   => array( 'labels' => array_keys( $countries ), 'data' => array_values( $countries ) ),
+            'platforms'   => array( 'labels' => array_keys( $platforms ), 'data' => array_values( $platforms ) ),
+            'browsers'    => array( 'labels' => array_keys( $browsers ), 'data' => array_values( $browsers ) ),
+            'today_views' => $today_views,
+            'online'      => $online_count,
+        );
+    }
+    private function verify_mp_payment( $payment_id, $expected = null ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token || ! $payment_id ) {
+            return false;
+        }
+        $url  = self::MP_API_URL . '/v1/payments/' . intval( $payment_id );
+        $args = array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $token,
+            ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            $this->log_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            return false;
+        }
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $body['status'] ) && 'approved' === $body['status'] ) {
+            if ( null !== $expected && isset( $body['transaction_amount'] ) ) {
+                $amount = floatval( $body['transaction_amount'] );
+                if ( $amount + 0.001 < floatval( $expected ) ) {
+                    $this->log_error( 'Valor do pagamento divergente: ' . $amount );
+                    return false;
+                }
+            }
+            return true;
+        }
+        if ( isset( $body['status'] ) && in_array( $body['status'], array( 'in_process', 'pending' ), true ) ) {
+            $this->log_error( 'Pagamento pendente: ' . wp_remote_retrieve_body( $res ) );
+            return false;
+        }
+        $this->log_error( 'Pagamento não aprovado: ' . wp_remote_retrieve_body( $res ) );
+        return false;
+    }
+
+    private function create_mp_pix_payment( $ref, $qty = 1 ) {
+        $token = $this->get_mp_access_token();
+        if ( ! $token ) {
+            return array();
+        }
+        $url   = self::MP_API_URL . '/v1/payments';
+        $price = floatval( get_option( 'bolaox_price', 10 ) );
+        $amount = $price * max( 1, intval( $qty ) );
+        $pix_key = trim( get_option( 'bolaox_pix_key', '' ) );
+        $payer_email = 'apostador@example.com';
+        if ( is_user_logged_in() ) {
+            $user = wp_get_current_user();
+            if ( $user && $user->user_email ) {
+                $payer_email = $user->user_email;
+            }
+        } else {
+            $admin = get_option( 'admin_email' );
+            if ( $admin ) {
+                $payer_email = $admin;
+            }
+        }
+        $idempotency = $ref ? sanitize_text_field( $ref ) : sanitize_text_field( uniqid( 'pix_', true ) );
+        $body  = array(
+            'transaction_amount' => $amount,
+            'description'        => 'Aposta ' . $ref,
+            'payment_method_id'  => 'pix',
+            'external_reference' => (string) $ref,
+            'notification_url'   => home_url( '/wp-json/bolao-x/v1/mp?token=' . self::MP_WEBHOOK_TOKEN ),
+            'payer'              => array( 'email' => $payer_email ),
+        );
+        $args = array(
+            'headers' => array(
+                'Authorization'    => 'Bearer ' . $token,
+                'Content-Type'     => 'application/json',
+                'X-Idempotency-Key' => $idempotency,
+            ),
+            'body'    => wp_json_encode( $body ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_post( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro ao criar pagamento: ' . $res->get_error_message() );
+            $this->log_error( 'Erro ao criar pagamento Pix: ' . $res->get_error_message() );
+            return array();
+        }
+        $data = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $data['id'], $data['point_of_interaction']['transaction_data']['qr_code'] ) ) {
+            if ( is_numeric( $ref ) ) {
+                update_post_meta( intval( $ref ), '_bolaox_mp_pref', sanitize_text_field( $data['id'] ) );
+            }
+            return array(
+                'id'      => $data['id'],
+                'qr_code' => $data['point_of_interaction']['transaction_data']['qr_code'],
+                'qr_code_base64' => isset( $data['point_of_interaction']['transaction_data']['qr_code_base64'] ) ?
+                    $data['point_of_interaction']['transaction_data']['qr_code_base64'] : '',
+            );
+        }
+        $this->log_mp_error( 'Resposta inesperada da API: ' . wp_remote_retrieve_body( $res ) );
+        $this->log_error( 'Resposta inesperada da API Pix: ' . wp_remote_retrieve_body( $res ) );
+        return array();
+    }
+
+    public function admin_notices() {
+        if ( current_user_can( 'manage_options' ) ) {
+            $mode = get_option( 'bolaox_mp_mode', 'test' );
+            $token = 'prod' === $mode ? get_option( 'bolaox_mp_prod_token', '' ) : get_option( 'bolaox_mp_test_token', '' );
+            if ( ! $token ) {
+                $msg = ( 'prod' === $mode ) ? __( 'Informe o Access Token de produção do Mercado Pago em Bolao X > Configurações.', self::TEXT_DOMAIN ) : __( 'Informe o Access Token de teste do Mercado Pago em Bolao X > Configurações.', self::TEXT_DOMAIN );
+                echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
+            }
+        }
+        $import = get_transient( 'bolaox_import_notice' );
+        if ( $import ) {
+            echo '<div class="notice notice-success"><p>' . esc_html( sprintf( __( '%1$d apostas importadas, %2$d linhas inválidas.', self::TEXT_DOMAIN ), $import['created'], $import['invalid'] ) ) . '</p></div>';
+            delete_transient( 'bolaox_import_notice' );
+        }
+        if ( $this->notice ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $this->notice ) . '</p></div>';
+            $this->notice = '';
+        }
+    }
+
+    public function enqueue_assets() {
+        $this->maybe_restore_session();
+        wp_enqueue_style( 'dashicons' );
+        wp_enqueue_style(
+            'bolaox-fonts',
+            'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap',
+            array(),
+            null
+        );
+        wp_enqueue_style(
+            'bolaox-style',
+            plugin_dir_url( __FILE__ ) . 'assets/css/bolao-x.css',
+            array(),
+            self::VERSION
+        );
+        if ( is_admin() ) {
+            wp_enqueue_style(
+                'bolaox-admin',
+                plugin_dir_url( __FILE__ ) . 'assets/css/bolao-x-admin.css',
+                array(),
+                self::VERSION
+            );
+            if ( isset( $_GET['page'] ) && 'bolaox' === $_GET['page'] ) {
+                wp_enqueue_script(
+                    'chartjs',
+                    'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
+                    array(),
+                    '4.4.1',
+                    true
+                );
+                wp_enqueue_script(
+                    'bolaox-admin',
+                    plugin_dir_url( __FILE__ ) . 'assets/js/bolaox-admin.js',
+                    array( 'chartjs' ),
+                    self::VERSION,
+                    true
+                );
+                wp_localize_script( 'bolaox-admin', 'bolaoxStats', $this->prepare_visit_stats() );
+            }
+        }
+        wp_enqueue_script(
+            'bolaox-js',
+            plugin_dir_url( __FILE__ ) . 'assets/js/bolao-x.js',
+            array(),
+            self::VERSION,
+            true
+        );
+        $user = is_user_logged_in() ? wp_get_current_user() : null;
+        wp_localize_script(
+            'bolaox-js',
+            'bolaoxData',
+            array(
+                'nonce'       => wp_create_nonce( 'wp_rest' ),
+                'logged_in'   => is_user_logged_in(),
+                'user_name'   => $user ? $user->display_name : '',
+                'mybets_url'  => rest_url( 'bolao-x/v1/mybets', 'relative' ),
+                'form_url'    => add_query_arg( 'bx_sec', 'form', $this->get_form_page_url() ),
+                'loading'     => __( 'Carregando...', self::TEXT_DOMAIN ),
+                'load_error'  => __( 'Erro ao carregar apostas.', self::TEXT_DOMAIN ),
+                'login_url'   => home_url( '/login-cadastro' ),
+            )
+        );
+    }
+
+    public function register_post_type() {
+        register_post_type( 'bolaox_aposta', array(
+            'labels' => array(
+                'name'          => __( 'Apostas', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Aposta', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Aposta Manual', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Criar Aposta', self::TEXT_DOMAIN ),
+                'not_found'     => __( 'Nenhuma aposta encontrada.', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+
+        register_post_type( 'bolaox_result', array(
+            'labels' => array(
+                'name'          => __( 'Resultados', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Resultado', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Novo Resultado', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Publicar Resultado', self::TEXT_DOMAIN ),
+                'not_found'     => __( 'Nenhum resultado encontrado.', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+
+        register_post_type( 'bolaox_concurso', array(
+            'labels' => array(
+                'name'          => __( 'Concursos', self::TEXT_DOMAIN ),
+                'singular_name' => __( 'Concurso', self::TEXT_DOMAIN ),
+                'add_new'       => __( 'Novo Concurso', self::TEXT_DOMAIN ),
+                'add_new_item'  => __( 'Criar Concurso', self::TEXT_DOMAIN ),
+                'search_items'  => __( 'Pesquisar Concursos', self::TEXT_DOMAIN ),
+            ),
+            'public'  => false,
+            'show_ui' => true,
+            'supports' => array( 'title' ),
+        ) );
+    }
+
+    public function add_meta_boxes() {
+        add_meta_box( 'bolaox_numbers', __( 'Dezenas', self::TEXT_DOMAIN ), array( $this, 'numbers_meta_box' ), 'bolaox_aposta' );
+        add_meta_box( 'bolaox_numbers', __( 'Dezenas', self::TEXT_DOMAIN ), array( $this, 'numbers_meta_box' ), 'bolaox_result' );
+        add_meta_box( 'bolaox_aposta_concurso', __( 'Concurso', self::TEXT_DOMAIN ), array( $this, 'bet_concurso_meta_box' ), 'bolaox_aposta', 'side' );
+        add_meta_box( 'bolaox_res_concurso', __( 'Concurso', self::TEXT_DOMAIN ), array( $this, 'result_concurso_meta_box' ), 'bolaox_result', 'side' );
+        add_meta_box( 'bolaox_payment', __( 'Status do Pagamento', self::TEXT_DOMAIN ), array( $this, 'payment_meta_box' ), 'bolaox_aposta', 'side' );
+        add_meta_box( 'bolaox_fixed', __( 'Apostador Fixo', self::TEXT_DOMAIN ), array( $this, 'fixed_meta_box' ), 'bolaox_aposta', 'side' );
+        add_meta_box( 'bolaox_concurso_meta', __( 'Detalhes do Concurso', self::TEXT_DOMAIN ), array( $this, 'concurso_meta_box' ), 'bolaox_concurso' );
+    }
+
+    public function numbers_meta_box( $post ) {
+        $numbers = get_post_meta( $post->ID, '_bolaox_numbers', true );
+        if ( 'bolaox_result' === $post->post_type && '' === $numbers ) {
+            $numbers = get_post_meta( $post->ID, '_bolaox_result', true );
+        }
+        $placeholder = ( 'bolaox_result' === $post->post_type )
+            ? __( 'Ex: 05,12,23,34,45', self::TEXT_DOMAIN )
+            : __( 'Ex: 05,12,23,34,45,56,67,78,89,90', self::TEXT_DOMAIN );
+        echo '<input type="text" name="bolaox_numbers" value="' . esc_attr( $numbers ) . '" placeholder="' . esc_attr( $placeholder ) . '" style="width:100%" />';
+        if ( 'bolaox_aposta' === $post->post_type && 'auto-draft' === $post->post_status ) {
+            echo '<p><textarea name="bolaox_numbers_multi" rows="5" style="width:100%" placeholder="' . esc_attr__( 'Uma aposta por linha', self::TEXT_DOMAIN ) . '"></textarea></p>';
+        }
+    }
+
+    public function payment_meta_box( $post ) {
+        $status = get_post_meta( $post->ID, '_bolaox_payment', true );
+        if ( ! $status ) {
+            $status = 'pending';
+        }
+        echo '<select name="bolaox_payment">'
+            . '<option value="pending"' . selected( $status, 'pending', false ) . '>' . esc_html__( 'Pendente', self::TEXT_DOMAIN ) . '</option>'
+            . '<option value="paid"' . selected( $status, 'paid', false ) . '>' . esc_html__( 'Pago', self::TEXT_DOMAIN ) . '</option>'
+            . '</select>';
+    }
+
+    public function fixed_meta_box( $post ) {
+        $contest = get_post_meta( $post->ID, '_bolaox_concurso', true );
+        if ( $contest && '1' === get_post_meta( $contest, '_bolaox_emd', true ) ) {
+            echo '<p>' . esc_html__( 'Apostas fixas não disponíveis para este concurso.', self::TEXT_DOMAIN ) . '</p>';
+            return;
+        }
+        $fixed = get_post_meta( $post->ID, '_bolaox_fixed', true );
+        if ( '' === $fixed && 'auto-draft' === $post->post_status ) {
+            $fixed = '1';
+        }
+        echo '<label><input type="checkbox" name="bolaox_fixed" value="1"' . checked( $fixed, '1', false ) . ' /> ' . esc_html__( 'Manter para próximos concursos', self::TEXT_DOMAIN ) . '</label>';
+    }
+
+    public function concurso_meta_box( $post ) {
+        $start = get_post_meta( $post->ID, '_bolaox_start', true );
+        $end   = get_post_meta( $post->ID, '_bolaox_end', true );
+        $active = get_option( 'bolaox_active_concurso', 0 );
+        echo '<p><label>' . esc_html__( 'Início', self::TEXT_DOMAIN ) . '<br />';
+        echo '<input type="datetime-local" name="bolaox_start" value="' . esc_attr( $start ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Fim', self::TEXT_DOMAIN ) . '<br />';
+        echo '<input type="datetime-local" name="bolaox_end" value="' . esc_attr( $end ) . '" /></label></p>';
+        $emd = get_post_meta( $post->ID, '_bolaox_emd', true );
+        echo '<p><label><input type="checkbox" name="bolaox_active" value="1"' . checked( $active, $post->ID, false ) . ' /> ' . esc_html__( 'Concurso Ativo', self::TEXT_DOMAIN ) . '</label></p>';
+        echo '<p><label><input type="checkbox" name="bolaox_emd" value="1"' . checked( $emd, '1', false ) . ' /> ' . esc_html__( 'Bolão EMD', self::TEXT_DOMAIN ) . '</label></p>';
+    }
+
+    public function result_concurso_meta_box( $post ) {
+        $selected = get_post_meta( $post->ID, '_bolaox_concurso', true );
+        $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+        echo '<select name="bolaox_concurso">';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '"' . selected( $selected, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function bet_concurso_meta_box( $post ) {
+        $selected = get_post_meta( $post->ID, '_bolaox_concurso', true );
+        if ( ! $selected ) {
+            $selected = get_option( 'bolaox_active_concurso', 0 );
+        }
+        $contests = get_posts( array(
+            'post_type'   => 'bolaox_concurso',
+            'numberposts' => -1,
+            'post_status' => array( 'publish', 'draft' ),
+        ) );
+        echo '<select name="bolaox_concurso">';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '"' . selected( $selected, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function save_meta( $post_id ) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+
+        // Prevent recursive calls when creating posts during multi-line import.
+        if ( $this->saving_meta ) {
+            return;
+        }
+
+        $this->saving_meta = true;
+        if ( isset( $_POST['bolaox_numbers_multi'] ) && 'bolaox_aposta' === get_post_type( $post_id ) && trim( $_POST['bolaox_numbers_multi'] ) !== '' ) {
+            $lines   = array_filter( array_map( 'trim', preg_split( '/\r?\n/', sanitize_textarea_field( $_POST['bolaox_numbers_multi'] ) ) ) );
+            $contest = isset( $_POST['bolaox_concurso'] ) ? intval( $_POST['bolaox_concurso'] ) : 0;
+            $status  = ( isset( $_POST['bolaox_payment'] ) && in_array( $_POST['bolaox_payment'], array( 'pending', 'paid' ), true ) ) ? $_POST['bolaox_payment'] : 'pending';
+            $fixed   = isset( $_POST['bolaox_fixed'] ) ? '1' : '0';
+            if ( $contest && '1' === get_post_meta( $contest, '_bolaox_emd', true ) ) {
+                $fixed = '0';
+            }
+            $created = 0;
+            $invalid = array();
+            $processed_first = false;
+            $line_no = 0;
+            foreach ( $lines as $set ) {
+                $line_no++;
+                $valid = $this->validate_numbers( $set );
+                if ( false === $valid ) {
+                    $invalid[] = $line_no;
+                    continue;
+                }
+                if ( ! $processed_first ) {
+                    update_post_meta( $post_id, '_bolaox_numbers', $valid );
+                    update_post_meta( $post_id, '_bolaox_payment', $status );
+                    if ( '1' === $fixed ) {
+                        update_post_meta( $post_id, '_bolaox_fixed', '1' );
+                    } else {
+                        delete_post_meta( $post_id, '_bolaox_fixed' );
+                    }
+                    if ( $contest ) {
+                        update_post_meta( $post_id, '_bolaox_concurso', $contest );
+                    }
+                    $processed_first = true;
+                    continue;
+                }
+                $args = array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => get_the_title( $post_id ),
+                    'post_status' => 'publish',
+                    'post_author' => get_current_user_id(),
+                    'meta_input'  => array(
+                        '_bolaox_numbers' => $valid,
+                        '_bolaox_payment' => $status,
+                    ),
+                );
+                if ( $contest ) {
+                    $args['meta_input']['_bolaox_concurso'] = $contest;
+                }
+                if ( '1' === $fixed ) {
+                    $args['meta_input']['_bolaox_fixed'] = '1';
+                }
+                $new_id = wp_insert_post( $args );
+                if ( $new_id ) {
+                    $created++;
+                }
+            }
+            if ( ! $processed_first && 'auto-draft' === get_post_status( $post_id ) ) {
+                wp_delete_post( $post_id, true );
+            }
+            if ( $processed_first || $created || $invalid ) {
+                $msg = '';
+                if ( $processed_first || $created ) {
+                    $total = ( $processed_first ? 1 : 0 ) + $created;
+                    $msg .= sprintf( __( 'Importadas %d apostas.', self::TEXT_DOMAIN ), $total );
+                }
+                if ( $invalid ) {
+                    $msg .= ' ' . sprintf( __( 'Linhas inválidas: %s. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN ), implode( ', ', $invalid ) );
+                }
+                $this->notice = trim( $msg );
+            }
+            $this->saving_meta = false;
+            return;
+        }
+
+        if ( isset( $_POST['bolaox_numbers'] ) ) {
+            $numbers = sanitize_text_field( $_POST['bolaox_numbers'] );
+            if ( 'bolaox_result' === get_post_type( $post_id ) ) {
+                $valid = $this->validate_result_numbers( $numbers );
+                if ( false === $valid ) {
+                    $this->notice = __( 'Dezenas do resultado inválidas. Use até 500 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN );
+                    $this->saving_meta = false;
+                    return;
+                }
+                update_post_meta( $post_id, '_bolaox_numbers', $valid );
+                update_post_meta( $post_id, '_bolaox_result', $valid );
+                $contest = isset( $_POST['bolaox_concurso'] ) ? intval( $_POST['bolaox_concurso'] ) : get_post_meta( $post_id, '_bolaox_concurso', true );
+                if ( $contest ) {
+                    $this->update_bet_scores( $contest, $valid );
+                }
+            } else {
+                $valid = $this->validate_numbers( $numbers );
+                if ( false === $valid ) {
+                    $this->notice = __( 'Dezenas da aposta inválidas. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN );
+                    $this->saving_meta = false;
+                    return;
+                }
+                update_post_meta( $post_id, '_bolaox_numbers', $valid );
+            }
+        }
+        if ( isset( $_POST['bolaox_concurso'] ) ) {
+            update_post_meta( $post_id, '_bolaox_concurso', intval( $_POST['bolaox_concurso'] ) );
+        }
+        if ( isset( $_POST['bolaox_payment'] ) ) {
+            $status = in_array( $_POST['bolaox_payment'], array( 'pending', 'paid' ), true ) ? $_POST['bolaox_payment'] : 'pending';
+            update_post_meta( $post_id, '_bolaox_payment', $status );
+        }
+        $contest_for_fixed = isset( $_POST['bolaox_concurso'] ) ? intval( $_POST['bolaox_concurso'] ) : get_post_meta( $post_id, '_bolaox_concurso', true );
+        if ( $contest_for_fixed && '1' === get_post_meta( $contest_for_fixed, '_bolaox_emd', true ) ) {
+            delete_post_meta( $post_id, '_bolaox_fixed' );
+        } else {
+            if ( isset( $_POST['bolaox_fixed'] ) ) {
+                update_post_meta( $post_id, '_bolaox_fixed', '1' );
+            } else {
+                delete_post_meta( $post_id, '_bolaox_fixed' );
+            }
+        }
+        if ( isset( $_POST['bolaox_start'] ) || isset( $_POST['bolaox_end'] ) ) {
+            $start = isset( $_POST['bolaox_start'] ) ? sanitize_text_field( $_POST['bolaox_start'] ) : '';
+            $end   = isset( $_POST['bolaox_end'] ) ? sanitize_text_field( $_POST['bolaox_end'] ) : '';
+            update_post_meta( $post_id, '_bolaox_start', $start );
+            update_post_meta( $post_id, '_bolaox_end', $end );
+        }
+        if ( 'bolaox_concurso' === get_post_type( $post_id ) ) {
+            if ( isset( $_POST['bolaox_emd'] ) ) {
+                update_post_meta( $post_id, '_bolaox_emd', '1' );
+            } else {
+                delete_post_meta( $post_id, '_bolaox_emd' );
+            }
+        }
+        if ( isset( $_POST['bolaox_active'] ) ) {
+            $prev = get_option( 'bolaox_active_concurso', 0 );
+            update_option( 'bolaox_active_concurso', $post_id );
+            if ( $prev != $post_id ) {
+                $this->on_contest_switch( $prev, $post_id );
+            }
+        } elseif ( 'bolaox_concurso' === get_post_type( $post_id ) && get_option( 'bolaox_active_concurso' ) == $post_id ) {
+            delete_option( 'bolaox_active_concurso' );
+        }
+        $this->saving_meta = false;
+    }
+
+    public function admin_menu() {
+        add_menu_page( 'Bolao X', 'Bolao X', 'manage_options', 'bolaox', array( $this, 'results_page' ) );
+        add_submenu_page( 'bolaox', __( 'Configurações', self::TEXT_DOMAIN ), __( 'Configurações', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-settings', array( $this, 'settings_page' ) );
+        add_submenu_page( 'bolaox', __( 'Importar CSV', self::TEXT_DOMAIN ), __( 'Importar CSV', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-import', array( $this, 'import_page' ) );
+        add_submenu_page( 'bolaox', __( 'Histórico', self::TEXT_DOMAIN ), __( 'Histórico', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-history', array( $this, 'history_page' ) );
+        add_submenu_page( 'bolaox', __( 'Estatísticas', self::TEXT_DOMAIN ), __( 'Estatísticas', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-stats', array( $this, 'stats_page' ) );
+        add_submenu_page( 'bolaox', __( 'Concursos', self::TEXT_DOMAIN ), __( 'Concursos', self::TEXT_DOMAIN ), 'manage_options', 'edit.php?post_type=bolaox_concurso' );
+        add_submenu_page( 'bolaox', __( 'Concursos em Andamento', self::TEXT_DOMAIN ), __( 'Concursos em Andamento', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-running', array( $this, 'running_contests_page' ) );
+        add_submenu_page( 'bolaox', __( 'Logs', self::TEXT_DOMAIN ), __( 'Logs', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-logs', array( $this, 'logs_page' ) );
+        add_submenu_page( 'bolaox', __( 'Logs Gerais', self::TEXT_DOMAIN ), __( 'Logs Gerais', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-general-logs', array( $this, 'general_logs_page' ) );
+        add_submenu_page( 'bolaox', __( 'Zerar Análises', self::TEXT_DOMAIN ), __( 'Zerar Análises', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-clear-stats', array( $this, 'clear_analytics_page' ) );
+        add_menu_page( __( 'Contemplados', self::TEXT_DOMAIN ), __( 'Contemplados', self::TEXT_DOMAIN ), 'manage_options', 'bolaox-contemplados', array( $this, 'contemplados_page' ), 'dashicons-awards' );
+    }
+
+    public function results_page() {
+        $stats = $this->prepare_visit_stats();
+        $total_visits = array_sum( $stats['visits'] );
+        $total_users  = array_sum( $stats['users'] );
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Análises Gerais', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<div class="bolaox-dashboard-analytics">';
+        echo '<div class="bx-info-tabs">';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'USUÁRIOS ONLINE', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $stats['online'] ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'EXIBIÇÕES HOJE', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $stats['today_views'] ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'VISITAS NOS ÚLTIMOS 15 DIAS', self::TEXT_DOMAIN ) . '</span><strong>' . intval( $total_visits ) . '</strong></div>';
+        $browser_lines = array();
+        $browser_total = array_sum( $stats['browsers']['data'] );
+        for ( $i = 0; $i < 3; $i++ ) {
+            $label = $stats['browsers']['labels'][ $i ] ?? '-';
+            $count = $stats['browsers']['data'][ $i ] ?? 0;
+            $pct   = $browser_total ? round( $count / $browser_total * 100 ) : 0;
+            $browser_lines[] = esc_html( $label ) . ' ' . intval( $pct ) . '%';
+        }
+        $platform_lines = array();
+        $platform_total = array_sum( $stats['platforms']['data'] );
+        for ( $i = 0; $i < 3; $i++ ) {
+            $label = $stats['platforms']['labels'][ $i ] ?? '-';
+            $count = $stats['platforms']['data'][ $i ] ?? 0;
+            $pct   = $platform_total ? round( $count / $platform_total * 100 ) : 0;
+            $platform_lines[] = esc_html( $label ) . ' ' . intval( $pct ) . '%';
+        }
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'NAVEGADORES MAIS USADOS', self::TEXT_DOMAIN ) . '</span><strong>' . implode( '<br>', $browser_lines ) . '</strong></div>';
+        echo '<div class="bx-info-tab"><span>' . esc_html__( 'SISTEMAS OPERACIONAIS MAIS USADOS', self::TEXT_DOMAIN ) . '</span><strong>' . implode( '<br>', $platform_lines ) . '</strong></div>';
+        echo '</div>';
+        echo '<div class="bolaox-graphs">';
+        echo '<div class="bolaox-graph"><h2>' . esc_html__( 'VISITAS NOS ÚLTIMOS 15 DIAS', self::TEXT_DOMAIN ) . '</h2><canvas id="bx-visits"></canvas></div>';
+        echo '<div class="bolaox-graph"><h2>' . esc_html__( 'USUÁRIOS NOS ÚLTIMOS 15 DIAS', self::TEXT_DOMAIN ) . '</h2><canvas id="bx-users"></canvas></div>';
+        echo '<div class="bolaox-graph"><h2>' . esc_html__( 'VISITAS POR PAÍS', self::TEXT_DOMAIN ) . '</h2><canvas id="bx-countries"></canvas></div>';
+        echo '<div class="bolaox-graph"><h2>' . esc_html__( 'PLATAFORMAS USADAS', self::TEXT_DOMAIN ) . '</h2><canvas id="bx-platforms"></canvas></div>';
+        echo '<div class="bolaox-graph"><h2>' . esc_html__( 'NAVEGADORES USADOS', self::TEXT_DOMAIN ) . '</h2><canvas id="bx-browsers"></canvas></div>';
+        echo '</div></div>';
+        echo '</div>';
+    }
+
+    public function settings_page() {
+        $days = array(
+            1 => __( 'Segunda', self::TEXT_DOMAIN ),
+            2 => __( 'Terça', self::TEXT_DOMAIN ),
+            3 => __( 'Quarta', self::TEXT_DOMAIN ),
+            4 => __( 'Quinta', self::TEXT_DOMAIN ),
+            5 => __( 'Sexta', self::TEXT_DOMAIN ),
+            6 => __( 'Sábado', self::TEXT_DOMAIN ),
+            7 => __( 'Domingo', self::TEXT_DOMAIN ),
+        );
+        if ( isset( $_POST['bolaox_nonce'] ) && wp_verify_nonce( $_POST['bolaox_nonce'], 'bolaox_settings' ) ) {
+            if ( isset( $_POST['bolaox_cutoffs'] ) && is_array( $_POST['bolaox_cutoffs'] ) ) {
+                $new = array();
+                foreach ( $days as $idx => $label ) {
+                    $t = isset( $_POST['bolaox_cutoffs'][ $idx ] ) ? sanitize_text_field( $_POST['bolaox_cutoffs'][ $idx ] ) : '';
+                    $new[ $idx ] = $t;
+                }
+                update_option( 'bolaox_cutoffs', $new );
+            }
+            update_option( 'bolaox_mp_prod_public', sanitize_text_field( $_POST['bolaox_mp_prod_public'] ?? '' ) );
+            update_option( 'bolaox_mp_prod_token', sanitize_text_field( $_POST['bolaox_mp_prod_token'] ?? '' ) );
+            update_option( 'bolaox_mp_test_public', sanitize_text_field( $_POST['bolaox_mp_test_public'] ?? '' ) );
+            update_option( 'bolaox_mp_test_token', sanitize_text_field( $_POST['bolaox_mp_test_token'] ?? '' ) );
+            update_option( 'bolaox_pix_key', sanitize_text_field( $_POST['bolaox_pix_key'] ?? '' ) );
+            $mode = in_array( $_POST['bolaox_mp_mode'] ?? 'test', array( 'prod', 'test' ), true ) ? $_POST['bolaox_mp_mode'] : 'test';
+            update_option( 'bolaox_mp_mode', $mode );
+            if ( isset( $_POST['bolaox_price'] ) ) {
+                $price = floatval( sanitize_text_field( $_POST['bolaox_price'] ) );
+                if ( $price <= 0 ) {
+                    $price = 10;
+                }
+                update_option( 'bolaox_price', $price );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Configurações salvas.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        $cutoffs = get_option( 'bolaox_cutoffs', array() );
+        $prod_public = get_option( 'bolaox_mp_prod_public', '' );
+        $prod_token  = get_option( 'bolaox_mp_prod_token', '' );
+        $test_public = get_option( 'bolaox_mp_test_public', '' );
+        $test_token  = get_option( 'bolaox_mp_test_token', '' );
+        $mode        = get_option( 'bolaox_mp_mode', 'test' );
+        $pix_key     = get_option( 'bolaox_pix_key', '' );
+        $price       = get_option( 'bolaox_price', 10 );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Configurações', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<form method="post">';
+        wp_nonce_field( 'bolaox_settings', 'bolaox_nonce' );
+        echo '<h2>' . esc_html__( 'Horários de Restrição de Apostas', self::TEXT_DOMAIN ) . '</h2>';
+        echo '<table class="form-table bolaox-cutoffs"><tbody>';
+        foreach ( $days as $idx => $label ) {
+            $val = isset( $cutoffs[ $idx ] ) ? $cutoffs[ $idx ] : '';
+            echo '<tr><th scope="row">' . esc_html( $label ) . '</th><td>';
+            echo '<input type="time" name="bolaox_cutoffs[' . $idx . ']" value="' . esc_attr( $val ) . '" /></td></tr>';
+        }
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Produção', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_prod_public" value="' . esc_attr( $prod_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_prod_token" value="' . esc_attr( $prod_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Credenciais de Teste', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<p><label>Public Key<br /><input type="text" name="bolaox_mp_test_public" value="' . esc_attr( $test_public ) . '" class="regular-text" /></label></p>';
+        echo '<p><label>Access Token<br /><input type="text" name="bolaox_mp_test_token" value="' . esc_attr( $test_token ) . '" class="regular-text" /></label></p>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Modo ativo', self::TEXT_DOMAIN ) . '</th><td><select name="bolaox_mp_mode">';
+        echo '<option value="test"' . selected( $mode, 'test', false ) . '>Teste</option>';
+        echo '<option value="prod"' . selected( $mode, 'prod', false ) . '>Produção</option>';
+        echo '</select></td></tr>';
+        $nonce = wp_create_nonce( 'wp_rest' );
+        echo '<tr><th scope="row">' . esc_html__( 'Validar credenciais', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<button type="button" class="button bolaox-validate-creds" data-nonce="' . esc_attr( $nonce ) . '">' . esc_html__( 'Validar', self::TEXT_DOMAIN ) . '</button> <span class="bolaox-valid-msg"></span>';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Chave Pix para exibir', self::TEXT_DOMAIN ) . '</th><td>';
+        echo '<input type="text" name="bolaox_pix_key" value="' . esc_attr( $pix_key ) . '" class="regular-text" />';
+        echo '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html__( 'Preço da aposta (R$)', self::TEXT_DOMAIN ) . '</th><td><input type="number" step="0.01" name="bolaox_price" value="' . esc_attr( $price ) . '" /></td></tr>';
+        echo '</tbody></table>';
+        submit_button();
+        echo '</form></div>';
+    }
+
+    public function import_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Importar Apostas via CSV', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_import_nonce'] ) && wp_verify_nonce( $_POST['bolaox_import_nonce'], 'bolaox_import' ) && ! empty( $_FILES['bolaox_csv']['tmp_name'] ) ) {
+            $count = 0;
+            $fh = fopen( $_FILES['bolaox_csv']['tmp_name'], 'r' );
+            if ( $fh ) {
+                while ( ( $data = fgetcsv( $fh ) ) !== false ) {
+                    if ( count( $data ) < 11 ) {
+                        continue;
+                    }
+                    $name = array_shift( $data );
+                    $numbers = implode( ',', $data );
+                    $numbers = $this->validate_numbers( $numbers );
+                    if ( false === $numbers ) {
+                        continue;
+                    }
+                    $post_id = wp_insert_post( array(
+                        'post_type'   => 'bolaox_aposta',
+                        'post_title'  => sanitize_text_field( $name ),
+                        'post_status' => 'publish',
+                        'post_author' => get_current_user_id(),
+                    ) );
+                    if ( $post_id ) {
+                        update_post_meta( $post_id, '_bolaox_numbers', $numbers );
+                        update_post_meta( $post_id, '_bolaox_fixed', '1' );
+                        if ( get_current_user_id() ) {
+                            update_post_meta( $post_id, '_bolaox_user', get_current_user_id() );
+                        }
+                        $count++;
+                    }
+                }
+                fclose( $fh );
+            }
+            echo '<div class="updated"><p>' . sprintf( esc_html__( 'Importadas %d apostas.', self::TEXT_DOMAIN ), intval( $count ) ) . '</p></div>';
+        }
+        echo '<form method="post" enctype="multipart/form-data">';
+        wp_nonce_field( 'bolaox_import', 'bolaox_import_nonce' );
+        echo '<input type="file" name="bolaox_csv" accept="text/csv" required /> ';
+        submit_button( __( 'Importar', self::TEXT_DOMAIN ) );
+        echo '</form></div>';
+    }
+
+    public function history_page() {
+        if ( isset( $_GET['export'] ) ) {
+            $id = intval( $_GET['export'] );
+            $numbers = get_post_meta( $id, '_bolaox_result', true );
+            if ( $numbers ) {
+                if ( isset( $_GET['type'] ) && 'pdf' === $_GET['type'] ) {
+                    $this->export_pdf( $numbers );
+                } elseif ( isset( $_GET['type'] ) && 'xls' === $_GET['type'] ) {
+                    $this->export_xls( $numbers );
+                } else {
+                    $this->export_csv( $numbers );
+                }
+            }
+        }
+        $posts = get_posts( array( 'post_type' => 'bolaox_result', 'numberposts' => -1, 'orderby' => 'date', 'order' => 'DESC' ) );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Histórico de Resultados', self::TEXT_DOMAIN ) . '</h1>';
+        if ( ! $posts ) {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        echo '<table class="widefat"><thead><tr><th>Data</th><th>Resultado</th><th>Ações</th></tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            $base = admin_url( 'admin.php?page=bolaox-history&export=' . $p->ID );
+            $csv  = esc_url( $base . '&type=csv' );
+            $xls  = esc_url( $base . '&type=xls' );
+            $pdf  = esc_url( $base . '&type=pdf' );
+            echo '<tr><td>' . esc_html( get_the_date( '', $p ) ) . '</td><td>' . esc_html( $nums ) . '</td><td><a class="button" href="' . $csv . '">CSV</a> <a class="button" href="' . $xls . '">Excel</a> <a class="button" href="' . $pdf . '">PDF</a></td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function stats_page() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            echo '<div class="wrap"><h1>' . esc_html__( 'Estatísticas', self::TEXT_DOMAIN ) . '</h1><p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $total = array_sum( $counts );
+        echo '<div class="wrap"><h1>' . esc_html__( 'Estatísticas de Frequência', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Dezena', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Ocorrências', self::TEXT_DOMAIN ) . '</th><th>%</th></tr></thead><tbody>';
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 0 ) {
+                $num  = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+                $perc = round( ( $counts[ $i ] / $total ) * 100 );
+                $bar  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $perc . '" data-progress="' . $perc . '%"><span style="width:' . $perc . '%"></span></div>';
+                echo '<tr><td>' . $num . '</td><td>' . $counts[ $i ] . '</td><td>' . $bar . '</td></tr>';
+            }
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function logs_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Logs de Pagamento', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_clear_logs'] ) && check_admin_referer( 'bolaox_clear_logs' ) ) {
+            if ( file_exists( $this->log_file ) ) {
+                file_put_contents( $this->log_file, '' );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Logs limpos.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        if ( file_exists( $this->log_file ) && filesize( $this->log_file ) ) {
+            $content = file_get_contents( $this->log_file );
+            echo '<textarea readonly rows="20" style="width:100%">' . esc_textarea( $content ) . '</textarea>';
+            echo '<form method="post">';
+            wp_nonce_field( 'bolaox_clear_logs' );
+            echo '<p><input type="submit" name="bolaox_clear_logs" class="button" value="' . esc_attr__( 'Limpar logs', self::TEXT_DOMAIN ) . '" /></p>';
+            echo '</form>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum log encontrado.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        echo '</div>';
+    }
+
+    public function general_logs_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Logs Gerais', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_clear_general'] ) && check_admin_referer( 'bolaox_clear_general' ) ) {
+            if ( file_exists( $this->general_log_file ) ) {
+                file_put_contents( $this->general_log_file, '' );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Logs limpos.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        if ( file_exists( $this->general_log_file ) && filesize( $this->general_log_file ) ) {
+            $content = file_get_contents( $this->general_log_file );
+            echo '<textarea readonly rows="20" style="width:100%">' . esc_textarea( $content ) . '</textarea>';
+            echo '<form method="post">';
+            wp_nonce_field( 'bolaox_clear_general' );
+            echo '<p><input type="submit" name="bolaox_clear_general" class="button" value="' . esc_attr__( 'Limpar logs', self::TEXT_DOMAIN ) . '" /></p>';
+            echo '</form>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum log encontrado.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        echo '</div>';
+    }
+
+    public function clear_analytics_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Zerar Análises Gerais', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_clear_stats'] ) && check_admin_referer( 'bolaox_clear_stats' ) ) {
+            delete_option( 'bolaox_visits' );
+            echo '<div class="updated"><p>' . esc_html__( 'Dados apagados.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        echo '<form method="post">';
+        wp_nonce_field( 'bolaox_clear_stats' );
+        echo '<p><input type="submit" name="bolaox_clear_stats" class="button delete" value="' . esc_attr__( 'Zerar Dados', self::TEXT_DOMAIN ) . '" /></p>';
+        echo '</form></div>';
+    }
+
+    public function running_contests_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Concursos em Andamento', self::TEXT_DOMAIN ) . '</h1>';
+        $search = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
+        echo '<form method="get"><input type="hidden" name="page" value="bolaox-running" />';
+        echo '<p class="search-box">';
+        echo '<label class="screen-reader-text" for="bolaox-search">' . esc_html__( 'Pesquisar apostador', self::TEXT_DOMAIN ) . '</label>';
+        echo '<input type="search" id="bolaox-search" name="s" value="' . esc_attr( $search ) . '" placeholder="' . esc_attr__( 'Nome do apostador', self::TEXT_DOMAIN ) . '" />';
+        submit_button( __( 'Pesquisar', self::TEXT_DOMAIN ), 'secondary', false, false, array( 'id' => 'search-submit' ) );
+        echo '</p></form>';
+        $contests = get_posts( array(
+            'post_type'   => 'bolaox_concurso',
+            'numberposts' => -1,
+            'post_status' => array( 'publish', 'draft' ),
+            'orderby'     => 'date',
+            'order'       => 'ASC',
+        ) );
+        if ( ! $contests ) {
+            echo '<p>' . esc_html__( 'Nenhum concurso encontrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        foreach ( $contests as $c ) {
+            $has_result = get_posts( array(
+                'post_type'   => 'bolaox_result',
+                'numberposts' => 1,
+                'post_status' => 'publish',
+                'meta_query'  => array( array( 'key' => '_bolaox_concurso', 'value' => $c->ID ) ),
+            ) );
+            if ( $has_result ) {
+                continue;
+            }
+            $bet_args = array(
+                'post_type'   => 'bolaox_aposta',
+                'numberposts' => -1,
+                'meta_query'  => array( array( 'key' => '_bolaox_concurso', 'value' => $c->ID ) ),
+            );
+            if ( $search ) {
+                $bet_args['s'] = $search;
+            }
+            $bets = get_posts( $bet_args );
+            echo '<h2>' . esc_html( $c->post_title ) . '</h2>';
+            if ( ! $bets ) {
+                echo '<p>' . esc_html__( 'Nenhuma aposta registrada.', self::TEXT_DOMAIN ) . '</p>';
+                continue;
+            }
+            echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Aposta', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Ações', self::TEXT_DOMAIN ) . '</th></tr></thead><tbody>';
+            foreach ( $bets as $b ) {
+                $nums = get_post_meta( $b->ID, '_bolaox_numbers', true );
+                $edit = get_edit_post_link( $b->ID );
+                $del  = get_delete_post_link( $b->ID );
+                $actions = '<a href="' . esc_url( $edit ) . '">' . esc_html__( 'Editar', self::TEXT_DOMAIN ) . '</a> | ';
+                $actions .= '<a href="' . esc_url( $del ) . '">' . esc_html__( 'Excluir', self::TEXT_DOMAIN ) . '</a>';
+                echo '<tr><td>' . esc_html( $b->post_title ) . '</td><td>' . esc_html( $nums ) . '</td><td>' . $actions . '</td></tr>';
+            }
+            echo '</tbody></table>';
+        }
+        echo '</div>';
+    }
+
+    public function import_bets_menu() {
+        add_submenu_page(
+            'edit.php?post_type=bolaox_aposta',
+            __( 'Importar Apostas', self::TEXT_DOMAIN ),
+            __( 'Importar Apostas', self::TEXT_DOMAIN ),
+            'manage_options',
+            'bolaox-import',
+            array( $this, 'import_bets_page' )
+        );
+    }
+
+    public function import_bets_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Importar Apostas', self::TEXT_DOMAIN ) . '</h1>';
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" enctype="multipart/form-data">';
+        echo '<input type="hidden" name="action" value="bolaox_import_bets" />';
+        wp_nonce_field( 'bolaox_import_bets' );
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="bolaox_import_file">' . esc_html__( 'Arquivo', self::TEXT_DOMAIN ) . '</label></th><td><input type="file" name="bolaox_import_file" id="bolaox_import_file" required /></td></tr>';
+        $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+        echo '<tr><th><label for="bolaox_concurso">' . esc_html__( 'Concurso', self::TEXT_DOMAIN ) . '</label></th><td><select name="bolaox_concurso" id="bolaox_concurso"><option value="">' . esc_html__( 'Selecione', self::TEXT_DOMAIN ) . '</option>';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '">' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select></td></tr>';
+        echo '<tr><th>' . esc_html__( 'Apostador fixo', self::TEXT_DOMAIN ) . '</th><td><label><input type="checkbox" name="bolaox_fixed" value="1" /> ' . esc_html__( 'Apostador fixo', self::TEXT_DOMAIN ) . '</label></td></tr>';
+        echo '</table>';
+        submit_button( __( 'Importar', self::TEXT_DOMAIN ) );
+        echo '</form></div>';
+    }
+
+    public function pending_payments_menu() {
+        add_submenu_page(
+            'edit.php?post_type=bolaox_aposta',
+            __( 'Pagamentos não confirmados', self::TEXT_DOMAIN ),
+            __( 'Pagamentos não confirmados', self::TEXT_DOMAIN ),
+            'manage_options',
+            'bolaox-pending',
+            array( $this, 'pending_payments_page' )
+        );
+    }
+
+    public function pending_payments_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Pagamentos via Pix não confirmados', self::TEXT_DOMAIN ) . '</h1>';
+        if ( isset( $_POST['bolaox_mark_paid'], $_POST['post_id'] ) && check_admin_referer( 'bolaox_mark_paid_' . intval( $_POST['post_id'] ) ) ) {
+            update_post_meta( intval( $_POST['post_id'] ), '_bolaox_payment', 'paid' );
+            echo '<div class="updated"><p>' . esc_html__( 'Pagamento marcado como pago.', self::TEXT_DOMAIN ) . '</p></div>';
+        }
+        $contest = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        $posts   = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_payment', 'value' => 'pending' ),
+                array( 'key' => '_bolaox_concurso', 'value' => $contest ),
+            ),
+        ) );
+        if ( ! $posts ) {
+            echo '<p>' . esc_html__( 'Nenhum pagamento pendente.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+        echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Aposta', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th><th>' . esc_html__( 'Ações', self::TEXT_DOMAIN ) . '</th></tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            echo '<tr><td>' . esc_html( $p->post_title ) . '</td><td>' . esc_html( $nums ) . '</td><td>';
+            echo '<form method="post" style="display:inline">';
+            wp_nonce_field( 'bolaox_mark_paid_' . $p->ID );
+            echo '<input type="hidden" name="post_id" value="' . $p->ID . '" />';
+            echo '<input type="submit" name="bolaox_mark_paid" class="button" value="' . esc_attr__( 'Marcar como pago', self::TEXT_DOMAIN ) . '" />';
+            echo '</form></td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public function handle_import_bets() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( __( 'Sem permissão.', self::TEXT_DOMAIN ) );
+        }
+        check_admin_referer( 'bolaox_import_bets' );
+        $contest = isset( $_POST['bolaox_concurso'] ) ? intval( $_POST['bolaox_concurso'] ) : 0;
+        $fixed   = isset( $_POST['bolaox_fixed'] ) ? 1 : 0;
+        if ( $contest && '1' === get_post_meta( $contest, '_bolaox_emd', true ) ) {
+            $fixed = 0;
+        }
+        $created = 0;
+        $invalid = 0;
+        if ( isset( $_FILES['bolaox_import_file']['tmp_name'] ) && $_FILES['bolaox_import_file']['tmp_name'] ) {
+            require_once __DIR__ . '/lib/simplexlsx.php';
+            if ( $xlsx = \Shuchkin\SimpleXLSX::parse( $_FILES['bolaox_import_file']['tmp_name'] ) ) {
+                $rows = $xlsx->rows();
+                if ( $rows && count( $rows ) > 1 ) {
+                    $header = array_map( 'strtolower', array_map( 'trim', $rows[0] ) );
+                    if ( ( 'posição' !== $header[0] && 'posicao' !== $header[0] ) || false === strpos( $header[1], 'nome' ) || count( $rows[0] ) < 13 || false === strpos( $header[12], 'status' ) ) {
+                        $invalid = count( $rows ) - 1;
+                    } else {
+                        $seen = array();
+                        foreach ( array_slice( $rows, 1 ) as $row ) {
+                            $pos  = isset( $row[0] ) ? trim( $row[0] ) : '';
+                            $name = isset( $row[1] ) ? trim( $row[1] ) : '';
+                            if ( '' === $pos && '' === $name ) {
+                                continue;
+                            }
+                            $key = $pos . '|' . strtolower( $name );
+                            if ( isset( $seen[ $key ] ) ) {
+                                $invalid++;
+                                continue;
+                            }
+                            $seen[ $key ] = true;
+                            $numbers = array();
+                            for ( $i = 2; $i < 12; $i++ ) {
+                                $n = isset( $row[ $i ] ) ? trim( $row[ $i ] ) : '';
+                                if ( '' === $n || ! is_numeric( $n ) || $n < 0 || $n > 99 ) {
+                                    $numbers = array();
+                                    break;
+                                }
+                                $numbers[] = sprintf( '%02d', (int) $n );
+                            }
+                            if ( 10 !== count( $numbers ) ) {
+                                $invalid++;
+                                continue;
+                            }
+                            $status_cell = isset( $row[12] ) ? strtolower( trim( $row[12] ) ) : '';
+                            $status      = ( 'pago' === $status_cell ) ? 'paid' : 'pending';
+                            $pid = wp_insert_post( array(
+                                'post_title'  => $name,
+                                'post_type'   => 'bolaox_aposta',
+                                'post_status' => 'publish',
+                            ) );
+                            if ( $pid && ! is_wp_error( $pid ) ) {
+                                update_post_meta( $pid, '_bolaox_numbers', implode( ',', $numbers ) );
+                                update_post_meta( $pid, '_bolaox_payment', $status );
+                                update_post_meta( $pid, '_bolaox_posicao', $pos );
+                                if ( $contest ) {
+                                    update_post_meta( $pid, '_bolaox_concurso', $contest );
+                                }
+                                if ( $fixed ) {
+                                    update_post_meta( $pid, '_bolaox_fixed', 1 );
+                                }
+                                $created++;
+                            } else {
+                                $invalid++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        set_transient( 'bolaox_import_notice', array( 'created' => $created, 'invalid' => $invalid ), 30 );
+        wp_safe_redirect( admin_url( 'post-new.php?post_type=bolaox_aposta' ) );
+        exit;
+    }
+
+    public function handle_export_winners_pdf() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Você não tem permissão para gerar este relatório.', self::TEXT_DOMAIN ), '', array( 'response' => 403 ) );
+        }
+
+        check_admin_referer( 'bolao_x_export_winners' );
+
+        $contest_id = isset( $_GET['contest_id'] ) ? absint( wp_unslash( $_GET['contest_id'] ) ) : 0;
+        $order_key  = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : '';
+        $order      = ( 'date' === $order_key ) ? 'date' : 'score';
+
+        if ( ! $contest_id ) {
+            wp_die( esc_html__( 'Concurso inválido.', self::TEXT_DOMAIN ) );
+        }
+
+        $result_post = get_posts(
+            array(
+                'post_type'   => 'bolaox_result',
+                'numberposts' => 1,
+                'post_status' => 'publish',
+                'meta_query'  => array(
+                    array(
+                        'key'   => '_bolaox_concurso',
+                        'value' => $contest_id,
+                    ),
+                ),
+            )
+        );
+
+        if ( ! $result_post ) {
+            wp_die( esc_html__( 'Nenhum resultado encontrado para o concurso selecionado.', self::TEXT_DOMAIN ) );
+        }
+
+        $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_result', true );
+        if ( ! $numbers ) {
+            $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_numbers', true );
+        }
+
+        if ( ! $numbers ) {
+            wp_die( esc_html__( 'Nenhuma dezena cadastrada para este concurso.', self::TEXT_DOMAIN ) );
+        }
+
+        $prize_values = get_post_meta( $result_post[0]->ID, '_bolaox_prize_values', true );
+        if ( ! is_array( $prize_values ) ) {
+            $prize_values = array();
+        }
+
+        $prize_winners = get_post_meta( $result_post[0]->ID, '_bolaox_prize_winners', true );
+        if ( ! is_array( $prize_winners ) ) {
+            $prize_winners = array();
+        }
+
+        $fundo_caixa = get_post_meta( $result_post[0]->ID, '_bolaox_fundo_caixa', true );
+        if ( ! is_string( $fundo_caixa ) ) {
+            $fundo_caixa = '';
+        }
+
+        if ( function_exists( 'nocache_headers' ) ) {
+            nocache_headers();
+        }
+
+        while ( ob_get_level() > 0 ) {
+            ob_end_clean();
+        }
+
+        $this->export_winners_pdf(
+            $numbers,
+            $contest_id,
+            get_the_title( $contest_id ),
+            $order,
+            $prize_values,
+            $prize_winners,
+            $fundo_caixa
+        );
+        exit;
+    }
+
+    public function contemplados_page() {
+        $selected = isset( $_GET['contest'] ) ? intval( $_GET['contest'] ) : 0;
+        $order    = isset( $_GET['orderby'] ) && 'date' === $_GET['orderby'] ? 'date' : 'score';
+
+        $active   = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        if ( ! $selected ) {
+            $selected = $active;
+        }
+
+        $ids = $this->get_recent_result_contests( 15 );
+        if ( $ids ) {
+            $contests = get_posts( array(
+                'post_type'   => 'bolaox_concurso',
+                'post__in'    => $ids,
+                'numberposts' => 15,
+                'orderby'     => 'date',
+                'order'       => 'DESC',
+            ) );
+        } else {
+            $contests = array();
+        }
+
+        echo '<div class="wrap bolaox-contemplados"><h1>' . esc_html__( 'Contemplados', self::TEXT_DOMAIN ) . '</h1>';
+
+        if ( ! $contests ) {
+            echo '<p>' . esc_html__( 'Nenhum concurso cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        echo '<form method="get" class="bolaox-contest-form" style="margin-bottom:15px">';
+        echo '<input type="hidden" name="page" value="bolaox-contemplados" />';
+        echo '<label>' . esc_html__( 'Filtrar por Concurso', self::TEXT_DOMAIN ) . ' ';
+        echo '<select name="contest">';
+        foreach ( $contests as $c ) {
+            echo '<option value="' . $c->ID . '"' . selected( $selected, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+        }
+        echo '</select></label> ';
+        echo '<label>' . esc_html__( 'Ordenar por', self::TEXT_DOMAIN ) . ' ';
+        echo '<select name="orderby">';
+        echo '<option value="score"' . selected( $order, 'score', false ) . '>' . esc_html__( 'Pontuação', self::TEXT_DOMAIN ) . '</option>';
+        echo '<option value="date"' . selected( $order, 'date', false ) . '>' . esc_html__( 'Data', self::TEXT_DOMAIN ) . '</option>';
+        echo '</select></label> ';
+        submit_button( __( 'Filtrar', self::TEXT_DOMAIN ), 'secondary', '', false );
+        echo '</form>';
+
+        if ( ! $selected ) {
+            echo '<p>' . esc_html__( 'Nenhum concurso ativo.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        $result_post = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'numberposts' => 1,
+            'post_status' => 'publish',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $selected ),
+            ),
+        ) );
+        if ( ! $result_post ) {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p></div>';
+            return;
+        }
+
+        $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_result', true );
+        if ( ! $numbers ) {
+            $numbers = get_post_meta( $result_post[0]->ID, '_bolaox_numbers', true );
+        }
+        if ( isset( $_POST['bolaox_prize_values'] ) && current_user_can( 'manage_options' ) && isset( $_POST['_bxprize'] ) && wp_verify_nonce( $_POST['_bxprize'], 'bolaox_prize_values' ) ) {
+            $vals = array_map( 'sanitize_text_field', wp_unslash( $_POST['bolaox_prize_values'] ) );
+            update_post_meta( $result_post[0]->ID, '_bolaox_prize_values', $vals );
+            $wins = isset( $_POST['bolaox_prize_winners'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['bolaox_prize_winners'] ) ) : array();
+            update_post_meta( $result_post[0]->ID, '_bolaox_prize_winners', $wins );
+            $fund = isset( $_POST['bolaox_fundo_caixa'] ) ? sanitize_text_field( wp_unslash( $_POST['bolaox_fundo_caixa'] ) ) : '';
+            update_post_meta( $result_post[0]->ID, '_bolaox_fundo_caixa', $fund );
+        }
+        $prize_values  = get_post_meta( $result_post[0]->ID, '_bolaox_prize_values', true );
+        if ( ! is_array( $prize_values ) ) {
+            $prize_values = array();
+        }
+        $prize_winners = get_post_meta( $result_post[0]->ID, '_bolaox_prize_winners', true );
+        if ( ! is_array( $prize_winners ) ) {
+            $prize_winners = array();
+        }
+        $fundo_caixa = get_post_meta( $result_post[0]->ID, '_bolaox_fundo_caixa', true );
+        $export_link = wp_nonce_url(
+            add_query_arg(
+                array(
+                    'action'     => 'bolao_x_export_winners',
+                    'contest_id' => $selected,
+                    'orderby'    => $order,
+                ),
+                admin_url( 'admin-post.php' )
+            ),
+            'bolao_x_export_winners'
+        );
+        echo '<p><a href="' . esc_url( $export_link ) . '" class="button bolaox-export-pdf">' . esc_html__( 'Gerar PDF', self::TEXT_DOMAIN ) . '</a></p>';
+        echo '<h2>' . sprintf( esc_html__( 'Resultado do Concurso %s', self::TEXT_DOMAIN ), get_the_title( $selected ) ) . '</h2>';
+        echo $this->generate_report( $numbers, $selected, $order, $prize_values, $prize_winners, $fundo_caixa );
+        echo '</div>';
+    }
+
+
+    public function clear_pending_payments( $post_id, $post, $update ) {
+        if ( 'publish' !== $post->post_status ) {
+            return;
+        }
+        $contest = intval( get_post_meta( $post_id, '_bolaox_concurso', true ) );
+        if ( ! $contest ) {
+            $contest = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        }
+        if ( ! $contest ) {
+            return;
+        }
+        $pending = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'fields'      => 'ids',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest ),
+                array( 'key' => '_bolaox_payment', 'value' => 'paid', 'compare' => '!=' ),
+            ),
+        ) );
+        foreach ( $pending as $pid ) {
+            wp_delete_post( $pid, true );
+        }
+        $numbers = get_post_meta( $post_id, '_bolaox_result', true );
+        if ( $numbers ) {
+            $this->update_bet_scores( $contest, $numbers );
+        }
+    }
+
+    public function recompute_scores_after_edit( $post_id, $post, $update ) {
+        if ( 'bolaox_result' !== $post->post_type || 'publish' !== $post->post_status ) {
+            return;
+        }
+        $contest = intval( get_post_meta( $post_id, '_bolaox_concurso', true ) );
+        if ( ! $contest ) {
+            return;
+        }
+        $numbers = get_post_meta( $post_id, '_bolaox_result', true );
+        if ( '' === $numbers ) {
+            $numbers = get_post_meta( $post_id, '_bolaox_numbers', true );
+        }
+        if ( $numbers ) {
+            $this->update_bet_scores( $contest, $numbers );
+        }
+    }
+
+    public function update_repeats_after_edit( $post_id, $post, $update ) {
+        if ( 'bolaox_result' !== $post->post_type || 'publish' !== $post->post_status ) {
+            return;
+        }
+        $contest = intval( get_post_meta( $post_id, '_bolaox_concurso', true ) );
+        if ( ! $contest ) {
+            return;
+        }
+        $entries = $this->get_repeated_numbers_by_date( $contest );
+        $lines   = array();
+        foreach ( $entries as $e ) {
+            $lines[] = $e['date'] . ':' . implode( ',', $e['numbers'] );
+        }
+        update_post_meta( $post_id, '_bolaox_repeats', implode( "\n", $lines ) );
+    }
+
+    private function update_bet_scores( $contest_id, $numbers ) {
+        $res = array_filter( array_map( 'trim', explode( ',', $numbers ) ), 'strlen' );
+        if ( ! $res ) {
+            return;
+        }
+        $bets = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'fields'      => 'ids',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            ),
+        ) );
+        foreach ( $bets as $bid ) {
+            $nums = get_post_meta( $bid, '_bolaox_numbers', true );
+            $arr  = array_filter( array_map( 'trim', explode( ',', $nums ) ), 'strlen' );
+            $hits = $this->count_hits( $arr, $res );
+            update_post_meta( $bid, '_bolaox_hits', $hits );
+        }
+    }
+
+    private function get_recent_result_contests( $limit = 15 ) {
+        $results = get_posts(
+            array(
+                'post_type'   => 'bolaox_result',
+                'numberposts' => $limit,
+                'post_status' => 'publish',
+                'orderby'     => 'date',
+                'order'       => 'DESC',
+                'meta_key'    => '_bolaox_concurso',
+                'fields'      => 'ids',
+            )
+        );
+        $ids = array();
+        foreach ( $results as $rid ) {
+            $cid = get_post_meta( $rid, '_bolaox_concurso', true );
+            if ( $cid ) {
+                $ids[] = intval( $cid );
+            }
+        }
+        return array_unique( $ids );
+    }
+
+    private function generate_report( $result, $contest_id = 0, $order_by = 'score', $prizes = array(), $winners = array(), $fund = '' ) {
+        $res_numbers = array_filter( array_map( 'trim', explode( ',', $result ) ), 'strlen' );
+        $counts      = array_count_values( $res_numbers );
+        $res_display = array();
+        foreach ( $res_numbers as $r ) {
+            $class = array( 'bolaox-number' );
+            if ( $counts[ $r ] > 1 ) {
+                $class[] = 'multiple';
+            }
+            $res_display[] = sprintf(
+                '<span class="%s"><span class="bx-val">%s</span><span class="bx-count">%s</span></span>',
+                esc_attr( implode( ' ', $class ) ),
+                esc_html( $r ),
+                $counts[ $r ] > 1 ? 'x' . intval( $counts[ $r ] ) : ''
+            );
+        }
+        $res_drawn = implode( '', $res_display );
+        $out  = '<h3 class="bolaox-section-title">' . esc_html__( 'DEZENAS SORTEADAS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<p class="bolaox-numlist">' . $res_drawn . '</p>';
+        $args = array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'orderby'     => 'date',
+            'order'       => 'ASC',
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_payment', 'value' => 'paid' )
+            ),
+        );
+        if ( $contest_id ) {
+            $args['meta_query'][] = array( 'key' => '_bolaox_concurso', 'value' => $contest_id );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $rows = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_filter( array_map( 'trim', explode( ',', $numbers ) ), 'strlen' );
+            $hit_count = get_post_meta( $p->ID, '_bolaox_hits', true );
+            if ( '' === $hit_count ) {
+                $hit_count = $this->count_hits( $nums, $res_numbers );
+            } else {
+                $hit_count = intval( $hit_count );
+            }
+            // Mantém apostas com 8 acertos para exibir na listagem de vencedores.
+            $percentage = $hit_count * 10;
+            $progress  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $percentage . '" data-progress="' . $percentage . '%" style="--progress:' . $percentage . '%">';
+            $progress .= '<span></span></div>';
+            $bet_counts  = array_count_values( $nums );
+            $display_nums = array();
+            $display_res  = array();
+            $remaining    = array_count_values( $res_numbers );
+            foreach ( $nums as $n ) {
+                $n = trim( $n );
+                $classes = array( 'bolaox-number' );
+                if ( $bet_counts[ $n ] > 1 ) {
+                    $classes[] = 'dup';
+                    $classes[] = 'multiple';
+                }
+                if ( isset( $remaining[ $n ] ) && $remaining[ $n ] > 0 ) {
+                    $classes[] = 'hit';
+                    $remaining[ $n ]--;
+                }
+                $display_nums[] = sprintf(
+                    '<span class="%s"><span class="bx-val">%s</span><span class="bx-count">%s</span></span>',
+                    esc_attr( implode( ' ', $classes ) ),
+                    esc_html( $n ),
+                    $bet_counts[ $n ] > 1 ? 'x' . intval( $bet_counts[ $n ] ) : ''
+                );
+            }
+            foreach ( $res_numbers as $r ) {
+                $cls = array( 'bolaox-number' );
+                if ( in_array( $r, $nums ) ) {
+                    $cls[] = 'hit';
+                }
+                $display_res[] = sprintf( '<span class="%s">%s</span>', esc_attr( implode( ' ', $cls ) ), esc_html( $r ) );
+            }
+            $class = '';
+            if ( $hit_count >= 9 ) {
+                $class = ' class="bolaox-hit-' . $hit_count . '"';
+            }
+            $rows[] = array(
+                'id'      => $p->ID,
+                'hits'    => $hit_count,
+                'date'    => $p->post_date,
+                'class'   => $class,
+                'name'    => esc_html( $p->post_title ),
+                'progress' => $progress,
+                'numbers' => implode( '', $display_nums ),
+                'contest' => get_the_title( $contest_id ),
+                'type'    => '',
+            );
+        }
+
+        $all_rows = $rows;
+
+        if ( 'date' === $order_by ) {
+            usort( $rows, function ( $a, $b ) {
+                return strcmp( $b['date'], $a['date'] );
+            } );
+        } else {
+            usort( $rows, function ( $a, $b ) {
+                return $b['hits'] <=> $a['hits'];
+            } );
+        }
+
+        // Identify winners by hit count.
+        $non_winners = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] < 8;
+            }
+        );
+        $min_hits = $non_winners ? min( wp_list_pluck( $non_winners, 'hits' ) ) : 0;
+
+        $hits10 = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 10;
+            }
+        );
+        $hits9 = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 9;
+            }
+        );
+        $hits8 = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 8;
+            }
+        );
+        $winners_low  = array_filter(
+            $non_winners,
+            function ( $row ) use ( $min_hits ) {
+                return $row['hits'] === $min_hits;
+            }
+        );
+        foreach ( $hits10 as &$r ) {
+            $r['type'] = __( '10 pontos', self::TEXT_DOMAIN );
+        }
+        foreach ( $hits9 as &$r ) {
+            $r['type'] = __( '9 pontos', self::TEXT_DOMAIN );
+        }
+        foreach ( $hits8 as &$r ) {
+            $r['type'] = __( '8 pontos', self::TEXT_DOMAIN );
+        }
+        foreach ( $winners_low as &$r ) {
+            $r['type'] = __( 'Menos pontos', self::TEXT_DOMAIN );
+        }
+
+        $out .= $this->build_prize_table( $hits10, $hits9, $hits8, $winners_low, $prizes, $winners, $fund );
+
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'VENCEDORES COM 10 PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $hits10 );
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'VENCEDORES COM 9 PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $hits9 );
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'APOSTADORES COM 8 PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $hits8 );
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'MENOS PONTOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $winners_low );
+
+        $out .= '<h3 class="bolaox-section-title">' . esc_html__( 'TODAS AS APOSTAS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= $this->build_results_table( $all_rows );
+
+        $out .= $this->render_repeated_numbers_by_date( $contest_id );
+
+        return $this->wrap_app( $out );
+    }
+
+    private function build_results_table( $rows ) {
+        if ( ! $rows ) {
+            return '<p>' . esc_html__( 'Nenhum vencedor.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        $out  = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table"><thead><tr>';
+        $out .= '<th>#</th><th class="col-name">' . esc_html__( 'Apostador', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '<th class="col-contest">' . esc_html__( 'Concurso', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '<th class="col-bets">' . esc_html__( 'Números apostados', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '<th class="col-hits">' . esc_html__( 'Acertos', self::TEXT_DOMAIN ) . '</th></tr></thead><tbody>';
+        $idx  = 1;
+        foreach ( $rows as $row ) {
+            $num   = str_pad( strval( $idx++ ), 2, '0', STR_PAD_LEFT );
+            $out  .= '<tr' . $row['class'] . '><td class="col-index">' . $num . '</td><td class="col-name">' . $row['name'] . '</td><td class="col-contest">' . esc_html( $row['contest'] ) . '</td><td class="bolaox-numlist col-bets">' . $row['numbers'] . '</td><td class="col-hits">' . $row['hits'] . '</td></tr>';
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    private function build_prize_table( $hits10, $hits9, $hits8, $winners_low, $values, $winners, $fund, $editable = true ) {
+        $out = '';
+        if ( $editable ) {
+            $out .= '<form method="post" class="bolaox-prize-form">';
+            $out .= wp_nonce_field( 'bolaox_prize_values', '_bxprize', true, false );
+        }
+        $out .= '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table bolaox-prize-table"><thead><tr>';
+        $out .= '<th>' . esc_html__( 'Prêmio', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '<th>' . esc_html__( 'Valor', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '<th>' . esc_html__( 'Ganhadores', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '</tr></thead><tbody>';
+        $out .= $this->build_prize_row( __( '10 pontos', self::TEXT_DOMAIN ), '10', $hits10, $values, $winners, $editable );
+        $out .= $this->build_prize_row( __( '9 pontos', self::TEXT_DOMAIN ), '9', $hits9, $values, $winners, $editable );
+        $out .= $this->build_prize_row( __( 'Menos pontos', self::TEXT_DOMAIN ), 'low', $winners_low, $values, $winners, $editable );
+        $fund_val = isset( $fund ) ? $fund : '';
+        $input_fund = ( $editable && current_user_can( 'manage_options' ) ) ? '<input type="number" step="0.01" name="bolaox_fundo_caixa" value="' . esc_attr( $fund_val ) . '" class="small-text" />' : esc_html( $fund_val );
+        $out .= '<tr><td>' . esc_html__( 'Fundo de Caixa', self::TEXT_DOMAIN ) . '</td><td>' . $input_fund . '</td><td>-</td></tr>';
+        $out .= '</tbody></table></div>';
+        if ( $editable && current_user_can( 'manage_options' ) ) {
+            $out .= '<p><input type="submit" class="button button-primary" value="' . esc_attr__( 'Salvar', self::TEXT_DOMAIN ) . '" /></p>';
+        }
+        if ( $editable ) {
+            $out .= '</form>';
+        }
+        return $out;
+    }
+
+    private function build_prize_row( $label, $key, $rows, $values, $winners, $editable = true ) {
+        $value = isset( $values[ $key ] ) ? $values[ $key ] : '';
+        $winner_val = isset( $winners[ $key ] ) ? $winners[ $key ] : '';
+        $input_val = ( $editable && current_user_can( 'manage_options' ) )
+            ? '<input type="text" name="bolaox_prize_values[' . esc_attr( $key ) . ']" value="' . esc_attr( $value ) . '" class="small-text" />'
+            : esc_html( $value );
+        $input_win = ( $editable && current_user_can( 'manage_options' ) )
+            ? '<input type="text" name="bolaox_prize_winners[' . esc_attr( $key ) . ']" value="' . esc_attr( $winner_val ) . '" class="regular-text" />'
+            : esc_html( $winner_val );
+        return '<tr><td>' . esc_html( $label ) . '</td><td>' . $input_val . '</td><td>' . $input_win . '</td></tr>';
+    }
+
+    private function build_duplicates_table( $numbers, $contest_title ) {
+        if ( empty( $numbers ) ) {
+            return '<p>' . sprintf( esc_html__( 'No Concurso %s não tiveram números repetidos.', self::TEXT_DOMAIN ), esc_html( $contest_title ) ) . '</p>';
+        }
+        $list = '';
+        foreach ( $numbers as $n ) {
+            $list .= '<span class="bolaox-number dup">' . esc_html( $n ) . '</span>';
+        }
+        $out  = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table"><thead><tr>';
+        $out .= '<th class="col-bets">' . esc_html__( 'Números', self::TEXT_DOMAIN ) . '</th>';
+        $out .= '</tr></thead><tbody>';
+        $out .= '<tr><td class="bolaox-numlist col-bets">' . $list . '</td></tr>';
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    private function export_csv( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        header( 'Content-Type: text/csv' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.csv"' );
+        echo "Aposta,Acertos,Dezenas\n";
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            $title     = str_replace( '"', '""', $p->post_title );
+            echo '"' . $title . '",' . $hit_count . ',"' . implode( ' ', $nums ) . '"' . "\n";
+        }
+        exit;
+    }
+
+    private function export_xls( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        header( 'Content-Type: application/vnd.ms-excel' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.xls"' );
+        echo "Aposta\tAcertos\tDezenas\n";
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            echo $p->post_title . "\t" . $hit_count . "\t" . implode( ' ', $nums ) . "\n";
+        }
+        exit;
+    }
+
+    private function export_pdf( $result, $contest_title = '' ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts       = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+
+        $pdf = new FPDF();
+        $pdf->AddPage();
+        $pdf->SetFont( 'Arial', 'B', 14 );
+        if ( $contest_title ) {
+            $title = sprintf( __( 'Relatório do Concurso %s', self::TEXT_DOMAIN ), $contest_title );
+        } else {
+            $title = __( 'Relatório de Apostas', self::TEXT_DOMAIN );
+        }
+        $pdf->Cell( 0, 10, $title, 0, 1, 'C' );
+        $pdf->Ln( 2 );
+        $pdf->SetFont( 'Arial', 'B', 12 );
+        $pdf->Cell( 60, 8, __( 'Aposta', self::TEXT_DOMAIN ), 1 );
+        $pdf->Cell( 30, 8, __( 'Acertos', self::TEXT_DOMAIN ), 1, 0, 'C' );
+        $pdf->Cell( 0, 8, __( 'Dezenas', self::TEXT_DOMAIN ), 1, 1 );
+        $pdf->SetFont( 'Arial', '', 12 );
+        foreach ( $posts as $p ) {
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hits      = array_intersect( $res_numbers, $nums );
+            $hit_count = count( $hits );
+            $pdf->Cell( 60, 8, $p->post_title, 1 );
+            $pdf->Cell( 30, 8, $hit_count, 1, 0, 'C' );
+            $pdf->Cell( 0, 8, implode( ' ', $nums ), 1, 1 );
+        }
+
+        if ( ob_get_length() ) {
+            ob_end_clean();
+        }
+        nocache_headers();
+
+        $pdf->Output( 'D', 'bolao-resultados.pdf' );
+        exit;
+    }
+
+    private function export_winners_pdf( $result, $contest_id, $contest_title, $order_by = 'score', $prizes = array(), $winners = array(), $fund = '' ) {
+        $pdf           = new BOLAOX_PDF();
+        $bottom_margin = 20;
+        $res_numbers   = array_filter( array_map( 'trim', explode( ',', $result ) ), 'strlen' );
+        $args          = array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+            'meta_query'  => array(
+                array(
+                    'key'   => '_bolaox_payment',
+                    'value' => 'paid',
+                ),
+            ),
+        );
+        if ( $contest_id ) {
+            $args['meta_query'][] = array(
+                'key'   => '_bolaox_concurso',
+                'value' => $contest_id,
+            );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return;
+        }
+        $rows        = array();
+        $drawn       = $res_numbers;
+        $hits_totals = 0;
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_filter( array_map( 'trim', explode( ',', $numbers ) ), 'strlen' );
+            $hits    = get_post_meta( $p->ID, '_bolaox_hits', true );
+            if ( '' === $hits ) {
+                $hits = $this->count_hits( $nums, $res_numbers );
+            } else {
+                $hits = (int) $hits;
+            }
+            $hits_totals += $hits;
+            $status_raw   = get_post_meta( $p->ID, '_bolaox_payment', true );
+            if ( ! in_array( $status_raw, array( 'paid', 'pending' ), true ) ) {
+                $status_raw = $status_raw ? $status_raw : 'pending';
+            }
+            $status_label = sprintf(
+                __( 'Status: %s', self::TEXT_DOMAIN ),
+                ( 'paid' === $status_raw ) ? __( 'Pago', self::TEXT_DOMAIN ) : __( 'Pendente', self::TEXT_DOMAIN )
+            );
+            $status_color = ( 'paid' === $status_raw ) ? array( 46, 125, 98 ) : array( 214, 118, 50 );
+            $timestamp    = mysql2date( 'U', $p->post_date );
+            $date_display = $timestamp ? date_i18n( 'd/m/Y \à\s H:i', $timestamp ) : '';
+            $rows[] = array(
+                'name'         => $p->post_title,
+                'contest'      => $contest_title,
+                'numbers'      => $nums,
+                'drawn'        => $drawn,
+                'hits'         => $hits,
+                'date'         => $p->post_date,
+                'date_display' => $date_display,
+                'status_label' => $status_label,
+                'status_state' => $status_raw,
+                'status_color' => $status_color,
+            );
+        }
+
+        if ( 'date' === $order_by ) {
+            usort( $rows, function ( $a, $b ) {
+                return strcmp( $b['date'], $a['date'] );
+            } );
+        } else {
+            usort( $rows, function ( $a, $b ) {
+                return $b['hits'] <=> $a['hits'];
+            } );
+        }
+
+        $non_winners = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] < 8;
+            }
+        );
+        $min_hits = $non_winners ? min( wp_list_pluck( $non_winners, 'hits' ) ) : 0;
+
+        $hits10      = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 10;
+            }
+        );
+        $hits9       = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 9;
+            }
+        );
+        $hits8       = array_filter(
+            $rows,
+            function ( $row ) {
+                return $row['hits'] === 8;
+            }
+        );
+        $winners_low = array_filter(
+            $non_winners,
+            function ( $row ) use ( $min_hits ) {
+                return $row['hits'] === $min_hits;
+            }
+        );
+
+        $repeated = $this->get_repeated_numbers_by_date( $contest_id );
+
+        $total_bets = count( $rows );
+        $avg_hits   = $total_bets ? ( $hits_totals / $total_bets ) : 0;
+        $max_hits   = $rows ? max( wp_list_pluck( $rows, 'hits' ) ) : 0;
+        $min_all    = $rows ? min( wp_list_pluck( $rows, 'hits' ) ) : 0;
+
+        $pdf->SetCreator( 'Bolao X', true );
+        $pdf->SetAuthor( 'Bolao X', true );
+        $pdf->SetTitle( sprintf( __( 'Relatório do Concurso %s', self::TEXT_DOMAIN ), $contest_title ), true );
+        $pdf->AliasNbPages();
+        $pdf->SetAutoPageBreak( true, $bottom_margin );
+        $pdf->SetMargins( 12, 46, 12 );
+        $pdf->headerLogo     = 'https://www.bolaox.com.br/wp-content/uploads/2025/06/bolaox.png';
+        $pdf->headerTitle    = sprintf( __( 'Relatório do Concurso %s', self::TEXT_DOMAIN ), $contest_title );
+        $pdf->headerSubtitle = sprintf(
+            __( '%1$s apostas avaliadas • %2$s dezenas sorteadas', self::TEXT_DOMAIN ),
+            number_format_i18n( $total_bets ),
+            number_format_i18n( count( $drawn ) )
+        );
+        $pdf->footerText  = sprintf( __( 'Gerado em %s', self::TEXT_DOMAIN ), date_i18n( 'd/m/Y H:i' ) );
+        $pdf->footerLabel = __( 'Página %d de {nb}', self::TEXT_DOMAIN );
+
+        $pdf->AddPage();
+        $pdf->SetFont( 'Arial', '', 11 );
+
+        $this->pdf_section_header( $pdf, __( 'DEZENAS SORTEADAS', self::TEXT_DOMAIN ), null, null, 0 );
+        $pdf->SetX( $pdf->getLeftMargin() );
+        $this->pdf_numbers_line( $pdf, $drawn, $drawn, true, $pdf->getContentWidth() );
+
+        $cards = array(
+            array(
+                'label'       => __( 'Total de apostas', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( $total_bets ),
+                'description' => __( 'Apostas conferidas neste concurso', self::TEXT_DOMAIN ),
+                'start'       => array( 46, 132, 98 ),
+                'end'         => array( 32, 102, 74 ),
+            ),
+            array(
+                'label'       => __( 'Pontuação média', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( $avg_hits, 1 ) . ' pts',
+                'description' => __( 'Média de acertos por aposta', self::TEXT_DOMAIN ),
+                'start'       => array( 37, 159, 60 ),
+                'end'         => array( 21, 90, 57 ),
+            ),
+            array(
+                'label'       => __( 'Maior pontuação', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( $max_hits ) . ' pts',
+                'description' => __( 'Melhor desempenho registrado', self::TEXT_DOMAIN ),
+                'start'       => array( 64, 122, 89 ),
+                'end'         => array( 101, 156, 120 ),
+            ),
+            array(
+                'label'       => __( 'Menor pontuação', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( $min_all ) . ' pts',
+                'description' => __( 'Piso de acertos entre todas as apostas', self::TEXT_DOMAIN ),
+                'start'       => array( 96, 112, 123 ),
+                'end'         => array( 70, 81, 94 ),
+            ),
+            array(
+                'label'       => __( 'Vencedores 10 pontos', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( count( $hits10 ) ),
+                'description' => __( 'Apostas com 10 acertos perfeitos', self::TEXT_DOMAIN ),
+                'start'       => array( 185, 217, 56 ),
+                'end'         => array( 142, 201, 72 ),
+            ),
+            array(
+                'label'       => __( 'Vencedores 9 pontos', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( count( $hits9 ) ),
+                'description' => __( 'Apostas na segunda faixa de premiação', self::TEXT_DOMAIN ),
+                'start'       => array( 78, 143, 212 ),
+                'end'         => array( 59, 110, 173 ),
+            ),
+            array(
+                'label'       => __( 'Apostadores 8 pontos', self::TEXT_DOMAIN ),
+                'value'       => number_format_i18n( count( $hits8 ) ),
+                'description' => __( 'Apostas na terceira faixa de premiação', self::TEXT_DOMAIN ),
+                'start'       => array( 255, 175, 102 ),
+                'end'         => array( 226, 131, 70 ),
+            ),
+        );
+        if ( '' !== $fund ) {
+            $cards[] = array(
+                'label'       => __( 'Fundo de caixa', self::TEXT_DOMAIN ),
+                'value'       => $this->pdf_format_currency( $fund ),
+                'description' => __( 'Saldo reservado para o próximo concurso', self::TEXT_DOMAIN ),
+                'start'       => array( 59, 110, 173 ),
+                'end'         => array( 96, 148, 214 ),
+            );
+        }
+        $this->pdf_summary_cards( $pdf, $cards, $bottom_margin );
+
+        $this->pdf_prize_panel( $pdf, $prizes, $winners, $fund, $bottom_margin );
+
+        $this->pdf_table_section(
+            $pdf,
+            __( 'VENCEDORES COM 10 PONTOS', self::TEXT_DOMAIN ),
+            $hits10,
+            $bottom_margin,
+            array(
+                'subtitle' => sprintf(
+                    _n( '%s aposta com 10 pontos', '%s apostas com 10 pontos', count( $hits10 ), self::TEXT_DOMAIN ),
+                    number_format_i18n( count( $hits10 ) )
+                ),
+            )
+        );
+
+        $this->pdf_table_section(
+            $pdf,
+            __( 'VENCEDORES COM 9 PONTOS', self::TEXT_DOMAIN ),
+            $hits9,
+            $bottom_margin,
+            array(
+                'subtitle' => sprintf(
+                    _n( '%s aposta com 9 pontos', '%s apostas com 9 pontos', count( $hits9 ), self::TEXT_DOMAIN ),
+                    number_format_i18n( count( $hits9 ) )
+                ),
+            )
+        );
+
+        $this->pdf_table_section(
+            $pdf,
+            __( 'APOSTADORES COM 8 PONTOS', self::TEXT_DOMAIN ),
+            $hits8,
+            $bottom_margin,
+            array(
+                'subtitle' => sprintf(
+                    _n( '%s aposta com 8 pontos', '%s apostas com 8 pontos', count( $hits8 ), self::TEXT_DOMAIN ),
+                    number_format_i18n( count( $hits8 ) )
+                ),
+            )
+        );
+
+        if ( $winners_low ) {
+            $this->pdf_table_section(
+                $pdf,
+                __( 'MENOS PONTOS', self::TEXT_DOMAIN ),
+                $winners_low,
+                $bottom_margin,
+                array(
+                    'color'    => array( array( 214, 140, 63 ), array( 237, 181, 87 ) ),
+                    'subtitle' => sprintf(
+                        __( 'Apostas com %s pontos (menor pontuação registrada)', self::TEXT_DOMAIN ),
+                        number_format_i18n( $min_hits )
+                    ),
+                )
+            );
+        }
+
+        $this->pdf_table_section(
+            $pdf,
+            __( 'TODAS AS APOSTAS', self::TEXT_DOMAIN ),
+            $rows,
+            $bottom_margin,
+            array(
+                'color'    => array( array( 96, 112, 123 ), array( 70, 81, 94 ) ),
+                'subtitle' => ( 'score' === $order_by )
+                    ? __( 'Ordenado por pontuação (mais acertos primeiro)', self::TEXT_DOMAIN )
+                    : __( 'Ordenado por data (mais recentes primeiro)', self::TEXT_DOMAIN ),
+            )
+        );
+
+        $this->pdf_repeated_section( $pdf, __( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ), $repeated, $bottom_margin );
+
+        if ( ob_get_length() ) {
+            ob_end_clean();
+        }
+        nocache_headers();
+
+        $pdf->Output( 'D', 'bolao-relatorio.pdf' );
+        exit;
+    }
+
+    private function pdf_summary_cards( $pdf, $cards, $bottom_margin ) {
+        if ( empty( $cards ) ) {
+            return;
+        }
+        $available = $pdf->getContentWidth();
+        $gap       = 6;
+        $per_row   = min( 3, max( 1, count( $cards ) ) );
+        $card_w    = ( $available - ( $gap * ( $per_row - 1 ) ) ) / $per_row;
+        $card_h    = 28;
+        $pdf->Ln( 6 );
+        $index      = 0;
+        $total      = count( $cards );
+        $max_bottom = $pdf->GetY();
+        while ( $index < $total ) {
+            $this->pdf_check_page_break( $pdf, $card_h + $gap, $bottom_margin );
+            $y          = $pdf->GetY();
+            $row_bottom = $y;
+            for ( $col = 0; $col < $per_row && $index < $total; $col++, $index++ ) {
+                $card  = $cards[ $index ];
+                $x     = $pdf->getLeftMargin() + $col * ( $card_w + $gap );
+                $start = isset( $card['start'] ) ? $card['start'] : array( 30, 115, 76 );
+                $end   = isset( $card['end'] ) ? $card['end'] : array( 37, 159, 60 );
+                $pdf->LinearGradient( $x, $y, $card_w, $card_h, $start, $end );
+                $pdf->SetXY( $x + 5, $y + 5 );
+                $pdf->SetFont( 'Arial', 'B', 12 );
+                $pdf->SetTextColor( 255, 255, 255 );
+                $pdf->Cell( $card_w - 10, 6, $card['value'], 0, 2, 'L' );
+                $pdf->SetFont( 'Arial', '', 8.5 );
+                $pdf->SetTextColor( 240, 253, 244 );
+                $pdf->Cell( $card_w - 10, 4, $card['label'], 0, 2, 'L' );
+                if ( ! empty( $card['description'] ) ) {
+                    $pdf->SetFont( 'Arial', '', 7.5 );
+                    $pdf->SetTextColor( 229, 244, 234 );
+                    $pdf->MultiCell( $card_w - 10, 3.5, $card['description'], 0, 'L' );
+                }
+                $row_bottom = max( $row_bottom, $y + $card_h );
+            }
+            $pdf->SetY( $row_bottom + $gap );
+            $max_bottom = max( $max_bottom, $row_bottom );
+        }
+        $pdf->SetY( $max_bottom + 6 );
+        $pdf->SetX( $pdf->getLeftMargin() );
+        $pdf->SetTextColor( 0, 0, 0 );
+        $pdf->SetFont( 'Arial', '', 11 );
+    }
+
+    private function pdf_prize_panel( $pdf, $prizes, $winners, $fund, $bottom_margin ) {
+        if ( ! is_array( $prizes ) ) {
+            $prizes = array();
+        }
+        if ( ! is_array( $winners ) ) {
+            $winners = array();
+        }
+        $map = array(
+            '10' => __( 'Vencedores com 10 pontos', self::TEXT_DOMAIN ),
+            '9'  => __( 'Vencedores com 9 pontos', self::TEXT_DOMAIN ),
+            '8'  => __( 'Apostadores com 8 pontos', self::TEXT_DOMAIN ),
+            'low'=> __( 'Menos pontos', self::TEXT_DOMAIN ),
+        );
+        $rows = array();
+        foreach ( $map as $key => $label ) {
+            $value  = isset( $prizes[ $key ] ) ? trim( (string) $prizes[ $key ] ) : '';
+            $winner = isset( $winners[ $key ] ) ? trim( (string) $winners[ $key ] ) : '';
+            if ( '' === $value && '' === $winner ) {
+                continue;
+            }
+            $rows[] = array(
+                'label'  => $label,
+                'value'  => $this->pdf_format_currency( $value ),
+                'winner' => ( '' !== $winner ) ? $winner : __( 'Sem registro', self::TEXT_DOMAIN ),
+            );
+        }
+        if ( '' !== $fund ) {
+            $rows[] = array(
+                'label'  => __( 'Fundo de Caixa', self::TEXT_DOMAIN ),
+                'value'  => $this->pdf_format_currency( $fund ),
+                'winner' => __( 'Acumulado', self::TEXT_DOMAIN ),
+            );
+        }
+        if ( ! $rows ) {
+            return;
+        }
+        $this->pdf_section_header( $pdf, __( 'Resumo da Premiação', self::TEXT_DOMAIN ), array( 64, 122, 89 ), array( 101, 156, 120 ) );
+        $content_width = $pdf->getContentWidth();
+        $padding       = 7;
+        $line_width    = $content_width - ( 2 * $padding );
+        $estimate      = 2 * $padding;
+        $pdf->SetFont( 'Arial', '', 8.5 );
+        foreach ( $rows as $row ) {
+            $estimate += 6;
+            $text   = $row['winner'];
+            $string = $pdf->GetStringWidth( $text );
+            $lines  = $line_width > 0 ? max( 1, ceil( $string / $line_width ) ) : 1;
+            $estimate += ( $lines * 4 ) + 2;
+        }
+        $this->pdf_check_page_break( $pdf, $estimate, $bottom_margin );
+        $y = $pdf->GetY();
+        $pdf->SetFillColor( 248, 252, 249 );
+        $pdf->SetDrawColor( 220, 235, 227 );
+        $pdf->Rect( $pdf->getLeftMargin(), $y, $content_width, $estimate, 'F' );
+        $pdf->SetXY( $pdf->getLeftMargin() + $padding, $y + $padding );
+        foreach ( $rows as $row ) {
+            $pdf->SetFont( 'Arial', 'B', 9 );
+            $pdf->SetTextColor( 30, 115, 76 );
+            $pdf->Cell( $line_width, 5, sprintf( '%s (%s)', $row['label'], $row['value'] ), 0, 1, 'L' );
+            $pdf->SetFont( 'Arial', '', 8.5 );
+            $pdf->SetTextColor( 92, 110, 102 );
+            $pdf->MultiCell( $line_width, 4, $row['winner'], 0, 'L' );
+            $pdf->Ln( 2 );
+            $pdf->SetX( $pdf->getLeftMargin() + $padding );
+        }
+        $pdf->SetY( $y + $estimate + 4 );
+        $pdf->SetTextColor( 0, 0, 0 );
+        $pdf->SetFont( 'Arial', '', 11 );
+    }
+
+    private function pdf_repeated_section( $pdf, $title, $entries, $bottom_margin ) {
+        $this->pdf_section_header( $pdf, $title, array( 55, 103, 80 ), array( 83, 142, 101 ) );
+        if ( empty( $entries ) ) {
+            $pdf->SetFont( 'Arial', '', 10 );
+            $pdf->SetTextColor( 92, 110, 102 );
+            $pdf->Cell( 0, 6, __( 'Nenhum número repetido.', self::TEXT_DOMAIN ), 0, 1, 'L' );
+            $pdf->SetTextColor( 0, 0, 0 );
+            return;
+        }
+        $content_width = $pdf->getContentWidth();
+        $padding       = 6;
+        foreach ( $entries as $entry ) {
+            $numbers_height = $this->pdf_estimate_numbers_height( $entry['numbers'], $content_width - ( 2 * $padding ) );
+            $box_height     = $padding + 5 + 4 + $numbers_height + $padding;
+            $this->pdf_check_page_break( $pdf, $box_height + 4, $bottom_margin );
+            $y = $pdf->GetY();
+            $pdf->SetFillColor( 248, 252, 249 );
+            $pdf->SetDrawColor( 220, 235, 227 );
+            $pdf->Rect( $pdf->getLeftMargin(), $y, $content_width, $box_height, 'F' );
+            $pdf->SetXY( $pdf->getLeftMargin() + $padding, $y + $padding );
+            $pdf->SetFont( 'Arial', 'B', 10 );
+            $pdf->SetTextColor( 30, 115, 76 );
+            $pdf->Cell( 0, 5, $entry['date'], 0, 1, 'L' );
+            $pdf->SetFont( 'Arial', '', 8.5 );
+            $pdf->SetTextColor( 92, 110, 102 );
+            $pdf->Cell( 0, 4, __( 'Números repetidos', self::TEXT_DOMAIN ), 0, 1, 'L' );
+            $pdf->SetX( $pdf->getLeftMargin() + $padding );
+            $pdf->SetTextColor( 0, 0, 0 );
+            $this->pdf_numbers_line( $pdf, $entry['numbers'], $entry['numbers'], true, $content_width - ( 2 * $padding ) );
+            $pdf->SetY( $y + $box_height + 4 );
+        }
+        $pdf->SetTextColor( 0, 0, 0 );
+        $pdf->SetFont( 'Arial', '', 11 );
+    }
+
+    private function pdf_table_section( $pdf, $title, $rows, $bottom_margin, $options = array() ) {
+        if ( empty( $rows ) ) {
+            return;
+        }
+        $colors = isset( $options['color'] ) ? $options['color'] : array( array( 30, 115, 76 ), array( 37, 159, 60 ) );
+        $subtitle = isset( $options['subtitle'] ) ? $options['subtitle'] : '';
+        $this->pdf_section_header( $pdf, $title, $colors[0], $colors[1] );
+        if ( $subtitle ) {
+            $pdf->SetFont( 'Arial', '', 9 );
+            $pdf->SetTextColor( 92, 110, 102 );
+            $pdf->SetX( $pdf->getLeftMargin() );
+            $pdf->Cell( 0, 5, $subtitle, 0, 1, 'L' );
+        }
+        $pdf->SetTextColor( 0, 0, 0 );
+        $content_width = $pdf->getContentWidth();
+        $padding       = 8;
+        $gap           = 6;
+        foreach ( $rows as $index => $row ) {
+            $numbers_height = $this->pdf_estimate_numbers_height( $row['numbers'], $content_width - ( 2 * $padding ) );
+            $drawn_height   = $this->pdf_estimate_numbers_height( $row['drawn'], $content_width - ( 2 * $padding ) );
+            $card_height    = $padding + 8 + 4 + 4 + $numbers_height + $gap + 4 + $drawn_height + $padding;
+            $this->pdf_check_page_break( $pdf, $card_height + 4, $bottom_margin );
+            $y = $pdf->GetY();
+            $bg = ( $index % 2 === 0 ) ? array( 255, 255, 255 ) : array( 245, 249, 246 );
+            $pdf->SetFillColor( $bg[0], $bg[1], $bg[2] );
+            $pdf->SetDrawColor( 220, 235, 227 );
+            $pdf->Rect( $pdf->getLeftMargin(), $y, $content_width, $card_height, 'F' );
+            $accent = ( $row['hits'] >= 9 ) ? array( 142, 201, 72 ) : array( 189, 207, 197 );
+            $pdf->SetFillColor( $accent[0], $accent[1], $accent[2] );
+            $pdf->Rect( $pdf->getLeftMargin(), $y, 3, $card_height, 'F' );
+
+            $inner_x = $pdf->getLeftMargin() + $padding;
+            $line_y  = $y + $padding;
+
+            $pdf->SetXY( $inner_x, $line_y );
+            $pdf->SetFont( 'Arial', 'B', 11 );
+            $pdf->SetTextColor( 30, 115, 76 );
+            $pdf->Cell( $content_width - ( 2 * $padding ) - 32, 6, $row['name'], 0, 0, 'L' );
+
+            $badge_width = 28;
+            $badge_x     = $pdf->getLeftMargin() + $content_width - $padding - $badge_width;
+            $badge_color = ( $row['hits'] >= 9 ) ? array( 46, 125, 98 ) : array( 96, 112, 123 );
+            $pdf->SetFillColor( $badge_color[0], $badge_color[1], $badge_color[2] );
+            $pdf->Rect( $badge_x, $line_y, $badge_width, 8, 'F' );
+            $pdf->SetXY( $badge_x, $line_y + 1.5 );
+            $pdf->SetFont( 'Arial', 'B', 9 );
+            $pdf->SetTextColor( 255, 255, 255 );
+            $pdf->Cell( $badge_width, 5, sprintf( __( '%d pts', self::TEXT_DOMAIN ), $row['hits'] ), 0, 0, 'C' );
+
+            $line_y += 8;
+            $pdf->SetXY( $inner_x, $line_y );
+            $pdf->SetFont( 'Arial', '', 8.5 );
+            $pdf->SetTextColor( 110, 130, 120 );
+            $pdf->Cell( $content_width - ( 2 * $padding ), 4, sprintf( __( 'Concurso: %s', self::TEXT_DOMAIN ), $row['contest'] ), 0, 1, 'L' );
+            if ( ! empty( $row['date_display'] ) ) {
+                $pdf->SetX( $inner_x );
+                $pdf->Cell( $content_width - ( 2 * $padding ), 4, sprintf( __( 'Data da aposta: %s', self::TEXT_DOMAIN ), $row['date_display'] ), 0, 1, 'L' );
+            }
+            if ( ! empty( $row['status_label'] ) ) {
+                $pdf->SetX( $inner_x );
+                $status_color = isset( $row['status_color'] ) ? $row['status_color'] : array( 110, 130, 120 );
+                $pdf->SetTextColor( $status_color[0], $status_color[1], $status_color[2] );
+                $pdf->Cell( $content_width - ( 2 * $padding ), 4, $row['status_label'], 0, 1, 'L' );
+                $pdf->SetTextColor( 110, 130, 120 );
+            }
+
+            $line_y = $pdf->GetY() + 2;
+            $pdf->SetXY( $inner_x, $line_y );
+            $pdf->SetFont( 'Arial', 'B', 9 );
+            $pdf->SetTextColor( 30, 115, 76 );
+            $pdf->Cell( 0, 5, __( 'Números apostados', self::TEXT_DOMAIN ), 0, 1, 'L' );
+            $pdf->SetX( $inner_x );
+            $pdf->SetTextColor( 0, 0, 0 );
+            $this->pdf_numbers_line( $pdf, $row['numbers'], $row['drawn'], false, $content_width - ( 2 * $padding ) );
+
+            $pdf->Ln( $gap / 2 );
+            $pdf->SetX( $inner_x );
+            $pdf->SetFont( 'Arial', 'B', 9 );
+            $pdf->SetTextColor( 30, 115, 76 );
+            $pdf->Cell( 0, 5, __( 'Dezenas sorteadas', self::TEXT_DOMAIN ), 0, 1, 'L' );
+            $pdf->SetX( $inner_x );
+            $pdf->SetTextColor( 0, 0, 0 );
+            $this->pdf_numbers_line( $pdf, $row['drawn'], $row['drawn'], true, $content_width - ( 2 * $padding ) );
+
+            $pdf->SetFont( 'Arial', '', 7.5 );
+            $pdf->SetTextColor( 130, 145, 138 );
+            $pdf->SetXY( $inner_x, $y + $card_height - $padding );
+            $pdf->Cell( $content_width - ( 2 * $padding ), 4, sprintf( __( 'Posição na lista: #%d', self::TEXT_DOMAIN ), $index + 1 ), 0, 1, 'R' );
+
+            $pdf->SetY( $y + $card_height + 4 );
+            $pdf->SetTextColor( 0, 0, 0 );
+        }
+        $pdf->SetX( $pdf->getLeftMargin() );
+        $pdf->SetFont( 'Arial', '', 11 );
+    }
+
+    private function pdf_section_header( $pdf, $title, $start_color = null, $end_color = null, $top_spacing = 8 ) {
+        if ( $top_spacing > 0 ) {
+            $pdf->Ln( $top_spacing );
+        }
+        $width = $pdf->getContentWidth();
+        $start = $start_color ? $start_color : array( 30, 115, 76 );
+        $end   = $end_color ? $end_color : array( 37, 159, 60 );
+        $y     = $pdf->GetY();
+        $pdf->LinearGradient( $pdf->getLeftMargin(), $y, $width, 10, $start, $end );
+        $pdf->SetXY( $pdf->getLeftMargin() + 4, $y + 2.5 );
+        $pdf->SetFont( 'Arial', 'B', 12 );
+        $pdf->SetTextColor( 255, 255, 255 );
+        $pdf->Cell( $width - 8, 5, $title, 0, 1, 'L' );
+        $pdf->SetY( $y + 12 );
+        $pdf->SetTextColor( 0, 0, 0 );
+        $pdf->SetX( $pdf->getLeftMargin() );
+        $pdf->SetFont( 'Arial', '', 11 );
+    }
+
+    private function pdf_check_page_break( $pdf, $height, $bottom_margin ) {
+        $page_height = $pdf->GetPageHeight();
+        if ( $pdf->GetY() + $height > $page_height - $bottom_margin ) {
+            $pdf->AddPage();
+        }
+    }
+
+    private function pdf_numbers_layout_data( $numbers, $width ) {
+        $radius       = 4;
+        $diameter     = $radius * 2;
+        $spacing      = 3;
+        $line_spacing = 4;
+        $numbers      = is_array( $numbers ) ? array_values( $numbers ) : array_values( array_filter( array_map( 'trim', (array) $numbers ), 'strlen' ) );
+        if ( empty( $numbers ) ) {
+            return array(
+                'rows'         => array(),
+                'height'       => 0,
+                'radius'       => $radius,
+                'diameter'     => $diameter,
+                'spacing'      => $spacing,
+                'line_spacing' => $line_spacing,
+            );
+        }
+        $per_row = max( 1, (int) floor( ( $width + $spacing ) / ( $diameter + $spacing ) ) );
+        $rows    = array_chunk( $numbers, $per_row );
+        $count   = count( $rows );
+        $height  = $count * $diameter + max( 0, $count - 1 ) * $line_spacing;
+        return array(
+            'rows'         => $rows,
+            'height'       => $height,
+            'radius'       => $radius,
+            'diameter'     => $diameter,
+            'spacing'      => $spacing,
+            'line_spacing' => $line_spacing,
+        );
+    }
+
+    private function pdf_estimate_numbers_height( $numbers, $width ) {
+        $layout = $this->pdf_numbers_layout_data( $numbers, $width );
+        return $layout['height'];
+    }
+
+    private function pdf_format_currency( $value ) {
+        $clean = trim( (string) $value );
+        if ( '' === $clean ) {
+            return __( '—', self::TEXT_DOMAIN );
+        }
+        $normalized = preg_replace( '/[^0-9.,-]/', '', $clean );
+        if ( false !== strpos( $normalized, ',' ) && false !== strpos( $normalized, '.' ) ) {
+            $normalized = str_replace( '.', '', $normalized );
+            $normalized = str_replace( ',', '.', $normalized );
+        } elseif ( false !== strpos( $normalized, ',' ) ) {
+            $normalized = str_replace( ',', '.', $normalized );
+        }
+        if ( is_numeric( $normalized ) ) {
+            return 'R$ ' . number_format_i18n( (float) $normalized, 2 );
+        }
+        return $clean;
+    }
+
+    private function pdf_numbers_line( $pdf, $numbers, $drawn, $is_drawn = false, $width = null ) {
+        $numbers = is_array( $numbers ) ? array_values( $numbers ) : array_values( array_filter( array_map( 'trim', (array) $numbers ), 'strlen' ) );
+        if ( empty( $numbers ) ) {
+            return 0;
+        }
+        $max_width = $width ? $width : $pdf->getContentWidth();
+        $layout    = $this->pdf_numbers_layout_data( $numbers, $max_width );
+        $drawn_counts = array_count_values( $drawn );
+        $counts       = array_count_values( $numbers );
+        $start_x      = $pdf->GetX();
+        $start_y      = $pdf->GetY();
+        $height       = 0;
+        $base_fill    = array( 33, 125, 87 );
+        $base_border  = array( 21, 90, 57 );
+        $hit_fill     = array( 142, 201, 72 );
+        $hit_border   = array( 30, 115, 76 );
+        $dup_fill     = array( 255, 230, 205 );
+        $dup_border   = array( 238, 145, 86 );
+        $draw_fill    = array( 232, 246, 236 );
+        $draw_border  = array( 141, 193, 160 );
+        $draw_dup     = array( 250, 255, 220 );
+        $draw_dup_b   = array( 176, 214, 85 );
+        $row_count    = count( $layout['rows'] );
+        foreach ( $layout['rows'] as $row_index => $chunk ) {
+            $row_y     = $start_y + $height;
+            $row_width = count( $chunk ) * $layout['diameter'] + max( 0, count( $chunk ) - 1 ) * $layout['spacing'];
+            $offset    = max( 0, ( $max_width - $row_width ) / 2 );
+            $x         = $start_x + $offset;
+            foreach ( $chunk as $n ) {
+                $number = sprintf( '%02d', $n );
+                $is_hit = ! $is_drawn && isset( $drawn_counts[ $n ] ) && $drawn_counts[ $n ] > 0;
+                $dup    = isset( $counts[ $n ] ) && $counts[ $n ] > 1;
+                if ( $is_hit ) {
+                    $drawn_counts[ $n ]--;
+                }
+                if ( $is_drawn ) {
+                    $fill_color   = $dup ? $draw_dup : $draw_fill;
+                    $border_color = $dup ? $draw_dup_b : $draw_border;
+                    $text_color   = array( 40, 85, 64 );
+                } else {
+                    if ( $dup && ! $is_hit ) {
+                        $fill_color   = $dup_fill;
+                        $border_color = $dup_border;
+                        $text_color   = array( 70, 45, 33 );
+                    } elseif ( $is_hit ) {
+                        $fill_color   = $hit_fill;
+                        $border_color = $hit_border;
+                        $text_color   = array( 35, 70, 40 );
+                    } else {
+                        $fill_color   = $base_fill;
+                        $border_color = $base_border;
+                        $text_color   = array( 255, 255, 255 );
+                    }
+                }
+                $pdf->SetFillColor( $fill_color[0], $fill_color[1], $fill_color[2] );
+                $pdf->SetDrawColor( $border_color[0], $border_color[1], $border_color[2] );
+                $pdf->Circle( $x + $layout['radius'], $row_y + $layout['radius'], $layout['radius'], 'FD' );
+                $pdf->SetTextColor( $text_color[0], $text_color[1], $text_color[2] );
+                $pdf->SetFont( 'Arial', 'B', 9 );
+                $pdf->SetXY( $x, $row_y + 1.5 );
+                $pdf->Cell( $layout['diameter'], 4, $number, 0, 0, 'C' );
+                if ( $dup ) {
+                    $pdf->SetFont( 'Arial', '', 6 );
+                    $pdf->SetXY( $x, $row_y + 5.2 );
+                    $pdf->Cell( $layout['diameter'], 3, 'x' . intval( $counts[ $n ] ), 0, 0, 'C' );
+                }
+                $x += $layout['diameter'] + $layout['spacing'];
+            }
+            $height += $layout['diameter'];
+            if ( $row_index < $row_count - 1 ) {
+                $height += $layout['line_spacing'];
+            }
+        }
+        $pdf->SetTextColor( 0, 0, 0 );
+        $pdf->SetFont( 'Arial', '', 11 );
+        $pdf->SetXY( $start_x, $start_y + $height );
+        return $height;
+    }
+    private function export_json( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return;
+        }
+        $rows = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            $hits    = count( array_intersect( $res_numbers, $nums ) );
+            $rows[] = array(
+                'aposta'  => $p->post_title,
+                'acertos' => $hits,
+                'dezenas' => $nums,
+            );
+        }
+        header( 'Content-Type: application/json' );
+        header( 'Content-Disposition: attachment; filename="bolao-resultados.json"' );
+        echo wp_json_encode( $rows );
+        exit;
+    }
+
+    private function send_results_email( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        foreach ( $posts as $p ) {
+            $user = get_user_by( 'ID', $p->post_author );
+            if ( ! $user || ! is_email( $user->user_email ) ) {
+                continue;
+            }
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            $hits    = count( array_intersect( $res_numbers, $nums ) );
+            $message  = sprintf( __( 'Olá %s,', self::TEXT_DOMAIN ), $p->post_title ) . "\n\n";
+            $message .= sprintf( __( 'O resultado da semana foi: %s', self::TEXT_DOMAIN ), $result ) . "\n";
+            $message .= sprintf( __( 'Sua aposta: %s', self::TEXT_DOMAIN ), implode( ',', $nums ) ) . "\n";
+            $message .= sprintf( __( 'Acertos: %d', self::TEXT_DOMAIN ), $hits ) . "\n";
+            if ( $hits >= 9 ) {
+                $message .= sprintf( __( 'Parabéns! Você acertou %d dezenas.', self::TEXT_DOMAIN ), $hits );
+            }
+            wp_mail( $user->user_email, __( 'Resultado do Bolão', self::TEXT_DOMAIN ), $message );
+        }
+    }
+
+    private function update_lowest_info( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            update_option( 'bolaox_lowest_info', array( 'id' => 0, 'hits' => 0, 'pool' => 0 ) );
+            return;
+        }
+        $min = null;
+        $ids = array();
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums = array_map( 'trim', explode( ',', $numbers ) );
+            $hits = count( array_intersect( $res_numbers, $nums ) );
+            if ( null === $min || $hits < $min ) {
+                $min = $hits;
+                $ids = array( $p->ID );
+            } elseif ( $hits === $min ) {
+                $ids[] = $p->ID;
+            }
+        }
+        $info = get_option( 'bolaox_lowest_info', array( 'id' => 0, 'hits' => 0, 'pool' => 0 ) );
+        if ( count( $ids ) === 1 ) {
+            $info = array( 'id' => $ids[0], 'hits' => $min, 'pool' => 0 );
+        } else {
+            $pool = isset( $info['pool'] ) ? intval( $info['pool'] ) : 0;
+            $info = array( 'id' => 0, 'hits' => $min, 'pool' => $pool + 1 );
+        }
+        update_option( 'bolaox_lowest_info', $info );
+    }
+
+    private function render_number_board( $result ) {
+        $res_numbers = array_map( 'trim', explode( ',', $result ) );
+        $out = '<div class="bolaox-scroll"><div class="bolaox-board">';
+        for ( $i = 0; $i < 100; $i++ ) {
+            $num   = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+            $class = 'bolaox-number';
+            if ( in_array( $num, $res_numbers, true ) ) {
+                $class .= ' drawn';
+            }
+            $out .= '<span class="' . $class . '">' . esc_html( $num ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function render_repeated_numbers( $contest_id = 0 ) {
+        $args = array(
+            'post_type'   => 'bolaox_aposta',
+            'numberposts' => -1,
+        );
+        if ( $contest_id ) {
+            $args['meta_query'] = array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return '';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $nums = array_map( 'trim', explode( ',', get_post_meta( $p->ID, '_bolaox_numbers', true ) ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $dups = array();
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 1 ) {
+                $dups[] = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+            }
+        }
+        if ( ! $dups ) {
+            return '';
+        }
+        $out  = '<h3>' . esc_html__( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<div class="bolaox-scroll"><div class="bolaox-board">';
+        foreach ( $dups as $n ) {
+            $out .= '<span class="bolaox-number">' . esc_html( $n ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function render_recent_repeated_numbers( $contest_id = 0 ) {
+        if ( ! $contest_id ) {
+            $contest_id = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        }
+        $args = array(
+            'post_type'   => 'bolaox_result',
+            'post_status' => 'publish',
+            'orderby'     => 'date',
+            'order'       => 'ASC',
+        );
+        if ( $contest_id ) {
+            $args['meta_query'] = array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            );
+        } else {
+            // Analyze the last 5 draws if no contest specified
+            $args['numberposts'] = 5;
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return '';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            }
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $repeats = array();
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 1 ) {
+                $repeats[ $i ] = $counts[ $i ];
+            }
+        }
+        if ( ! $repeats ) {
+            return '';
+        }
+        arsort( $repeats );
+        $out  = '<h3>' . esc_html__( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ) . '</h3>';
+        $out .= '<div class="bolaox-scroll"><div class="bolaox-board">';
+        foreach ( array_keys( $repeats ) as $n ) {
+            $out .= '<span class="bolaox-number">' . str_pad( strval( $n ), 2, '0', STR_PAD_LEFT ) . '</span>';
+        }
+        $out .= '</div></div>';
+        return $out;
+    }
+
+    private function render_repeated_numbers_by_date( $contest_id = 0 ) {
+        $entries = $this->get_repeated_numbers_by_date( $contest_id );
+        $out  = '<h3 class="bolaox-section-title">' . esc_html__( 'NÚMEROS REPETIDOS', self::TEXT_DOMAIN ) . '</h3>';
+        if ( $entries ) {
+            foreach ( $entries as $entry ) {
+                $list = '';
+                foreach ( $entry['numbers'] as $n ) {
+                    $list .= '<span class="bolaox-number">' . esc_html( $n ) . '</span>';
+                }
+                $out .= '<div class="bolaox-repeat-date"><strong>' . esc_html( $entry['date'] ) . '</strong>: ' . $list . '</div>';
+            }
+        } else {
+            $out .= '<p>' . esc_html__( 'Nenhum número repetido.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        return $out;
+    }
+
+    private function get_repeated_numbers_by_date( $contest_id = 0 ) {
+        if ( ! $contest_id ) {
+            $contest_id = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        }
+        $args = array(
+            'post_type'   => 'bolaox_result',
+            'post_status' => 'publish',
+            'orderby'     => 'date',
+            'order'       => 'ASC',
+        );
+        if ( $contest_id ) {
+            $args['meta_query'] = array(
+                array( 'key' => '_bolaox_concurso', 'value' => $contest_id ),
+            );
+        }
+        $posts = get_posts( $args );
+        if ( ! $posts ) {
+            return array();
+        }
+        $data = array();
+        foreach ( $posts as $p ) {
+            $nums_str = get_post_meta( $p->ID, '_bolaox_result', true );
+            if ( ! $nums_str ) {
+                $nums_str = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            }
+            $nums = array_filter( array_map( 'trim', explode( ',', $nums_str ) ), 'strlen' );
+            if ( ! $nums ) {
+                continue;
+            }
+            $counts   = array_count_values( $nums );
+            $repeats  = array();
+            foreach ( $counts as $n => $cnt ) {
+                if ( $cnt > 1 ) {
+                    $repeats[] = str_pad( strval( $n ), 2, '0', STR_PAD_LEFT );
+                }
+            }
+            if ( $repeats ) {
+                $data[] = array(
+                    'date'    => get_the_date( 'd/m/Y', $p ),
+                    'numbers' => $repeats,
+                );
+            }
+        }
+        return $data;
+    }
+
+    private function wrap_app( $html ) {
+        $logged = is_user_logged_in();
+        $class  = $logged ? 'bx-logged-in' : 'bx-logged-out';
+        $attr   = $logged ? '1' : '0';
+        return '<div class="bolaox-app ' . $class . '" data-logged-in="' . $attr . '">' . $html . '</div>';
+    }
+
+    public function render_form_shortcode() {
+        $this->maybe_restore_session();
+        $cutoffs  = get_option( 'bolaox_cutoffs', array() );
+        $countdown = '';
+        $contest_id = intval( get_option( 'bolaox_active_concurso', 0 ) );
+        $now = current_time( 'timestamp' );
+        if ( ! $contest_id ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum concurso ativo.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $start = get_post_meta( $contest_id, '_bolaox_start', true );
+        $end   = get_post_meta( $contest_id, '_bolaox_end', true );
+        if ( $start && $now < strtotime( $start ) ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Apostas ainda não liberadas.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        if ( $end && $now >= strtotime( $end ) ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Apostas encerradas. Tente novamente no próximo concurso.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+
+        $price   = floatval( get_option( 'bolaox_price', 10 ) );
+        $raw_key = get_option( 'bolaox_pix_key', '' );
+        $pix_key = is_string( $raw_key ) ? trim( $raw_key ) : '';
+        $msg     = '';
+        if ( $cutoffs ) {
+            $day  = (int) date( 'N', $now );
+            if ( ! empty( $cutoffs[ $day ] ) ) {
+                $cutoff_ts = strtotime( date( 'Y-m-d ' . $cutoffs[ $day ], $now ) );
+                if ( $now >= $cutoff_ts ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Apostas encerradas. Tente novamente no próximo concurso.', self::TEXT_DOMAIN ) . '</p>' );
+                }
+                $countdown = '<div class="bolaox-countdown" data-end="' . esc_attr( $cutoff_ts ) . '" data-expired="' . esc_attr__( 'Tempo esgotado', self::TEXT_DOMAIN ) . '"></div>';
+            }
+        }
+        $pix        = array();
+        $payment_id = '';
+
+        if ( isset( $_POST['bolaox_submit'] ) && isset( $_POST['bolaox_nonce'] ) && wp_verify_nonce( $_POST['bolaox_nonce'], 'bolaox_form' ) ) {
+            $numbers_raw = isset( $_POST['bolaox_numbers'] ) ? (array) $_POST['bolaox_numbers'] : array();
+            $valid_sets  = array();
+            foreach ( $numbers_raw as $set ) {
+                $clean = $this->validate_numbers( sanitize_text_field( $set ) );
+                if ( false === $clean ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Formato de dezenas inválido. Use 10 números de 00 a 99 separados por vírgula.', self::TEXT_DOMAIN ) . '</p>' );
+                }
+                $valid_sets[] = $clean;
+            }
+            $qty        = count( $valid_sets );
+            $payment_id = sanitize_text_field( $_POST['bolaox_payment_id'] );
+            $status = 'paid';
+            if ( ! $this->verify_mp_payment( $payment_id, $price * $qty ) ) {
+                $status      = 'pending';
+                $msg         = '<p class="bolaox-error">' . esc_html__( 'Pagamento via Pix não confirmado.', self::TEXT_DOMAIN ) . '</p>';
+                $pix         = $this->create_mp_pix_payment( 'tmp-' . wp_generate_password( 8, false, false ), $qty );
+                $payment_id  = isset( $pix['id'] ) ? $pix['id'] : '';
+            }
+
+            $phone = '';
+            if ( ! is_user_logged_in() ) {
+                $phone = isset( $_POST['bolaox_phone'] ) ? $this->sanitize_phone( $_POST['bolaox_phone'] ) : '';
+                if ( empty( $phone ) ) {
+                    return $this->wrap_app( '<p>' . esc_html__( 'Telefone obrigatório.', self::TEXT_DOMAIN ) . '</p>' );
+                }
+                $name = sanitize_text_field( $_POST['bolaox_name'] );
+            } else {
+                $name  = wp_get_current_user()->display_name;
+                $phone = get_user_meta( get_current_user_id(), 'bolaox_phone', true );
+            }
+            $i    = 1;
+            foreach ( $valid_sets as $set ) {
+                $title   = $qty > 1 ? $name . ' #' . $i : $name;
+                $post_id = wp_insert_post( array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => $title,
+                    'post_status' => 'publish',
+                    'post_author' => get_current_user_id(),
+                ) );
+                if ( $post_id ) {
+                    update_post_meta( $post_id, '_bolaox_numbers', $set );
+                    update_post_meta( $post_id, '_bolaox_payment', $status );
+                    update_post_meta( $post_id, '_bolaox_mp_pref', $payment_id );
+                    update_post_meta( $post_id, '_bolaox_concurso', $contest_id );
+                    update_post_meta( $post_id, '_bolaox_fixed', '0' );
+                    if ( $phone ) {
+                        update_post_meta( $post_id, '_bolaox_phone', $phone );
+                    }
+                    if ( get_current_user_id() ) {
+                        update_post_meta( $post_id, '_bolaox_user', get_current_user_id() );
+                    }
+                }
+                $i++;
+            }
+
+            if ( 'pending' === $status ) {
+                $redirect_url = home_url( '/minhas-apostas' );
+            } else {
+                $redirect_url = esc_url( add_query_arg( array(
+                    'phone'       => rawurlencode( $phone ),
+                    'redirect_to' => rawurlencode( home_url( '/minhas-apostas' ) ),
+                ), home_url( '/login-cadastro' ) ) );
+            }
+
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $redirect_url );
+                exit;
+            }
+
+            return '<script>window.location.href="' . esc_url( $redirect_url ) . '";</script>';
+        }
+
+        $html  = '<div class="bolaox-form">';
+        if ( $msg ) {
+            $html .= $msg;
+        }
+        $html .= '<div id="bolaox-pix-modal" class="bolaox-modal"><div class="bolaox-modal-content">';
+        $src = '';
+        $code = '';
+        if ( $pix ) {
+            if ( ! empty( $pix['qr_code_base64'] ) ) {
+                $src  = 'data:image/png;base64,' . $pix['qr_code_base64'];
+            } elseif ( ! empty( $pix['qr_code'] ) ) {
+                $src  = 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=' . rawurlencode( $pix['qr_code'] );
+            }
+            $code = isset( $pix['qr_code'] ) ? $pix['qr_code'] : '';
+        }
+        $html .= '<p><img src="' . esc_attr( $src ) . '" alt="Pix QR" width="500" height="500" /></p>';
+        $html .= '<p>' . esc_html__( 'Copie o Código:', self::TEXT_DOMAIN ) . '<br />';
+        $html .= '<input type="text" id="bolaox-pix-code" value="' . esc_attr( $code ) . '" readonly class="bolaox-pix-code" />';
+        $html .= '<button type="button" class="button bolaox-copy" data-target="#bolaox-pix-code">' . esc_html__( 'Copiar', self::TEXT_DOMAIN ) . '</button></p>';
+        $html .= '<p><span class="button bolaox-modal-close">' . esc_html__( 'Fechar', self::TEXT_DOMAIN ) . '</span></p></div></div>';
+
+        $html .= '<form method="post" class="bolaox-form-inner">';
+        if ( $countdown ) {
+            $html .= $countdown;
+        }
+        $html .= wp_nonce_field( 'bolaox_form', 'bolaox_nonce', true, false );
+        $html .= '<input type="hidden" name="bolaox_payment_id" value="' . esc_attr( $payment_id ) . '" />';
+        if ( ! is_user_logged_in() ) {
+            $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Como quer ser chamado?', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_name" required /></label></p>';
+            $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Telefone', self::TEXT_DOMAIN ) . '<br /><input type="tel" name="bolaox_phone" class="bolaox-phone" required /></label></p>';
+        }
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Escolha 10 dezenas', self::TEXT_DOMAIN ) . '</label>';
+        $html .= '<div class="bolaox-numbers">';
+        for ( $i = 0; $i < 100; $i++ ) {
+            $num = str_pad( (string) $i, 2, '0', STR_PAD_LEFT );
+            $html .= '<span class="bolaox-number"><span class="bx-val">' . esc_html( $num ) . '</span><span class="bx-count"></span></span>';
+        }
+        $html .= '<input type="hidden" class="bolaox-current" />';
+        $html .= '</div></p>';
+        $html .= '<p><button type="button" class="button bolaox-add-bet" data-label-init="' . esc_attr__( 'Adicionar Jogo', self::TEXT_DOMAIN ) . '" data-label-more="' . esc_attr__( 'Adicionar mais um Jogo', self::TEXT_DOMAIN ) . '">' . esc_html__( 'Adicionar Jogo', self::TEXT_DOMAIN ) . '</button></p>';
+        $html .= '<div class="bolaox-cart"></div>';
+        $html .= '<p><a href="#" class="button bolaox-pix-btn" data-target="#bolaox-pix-modal">' . esc_html__( 'PAGAR COM PIX', self::TEXT_DOMAIN ) . '</a></p>';
+        $html .= '<p class="bolaox-price" data-price="' . esc_attr( number_format( $price, 2, '.', '' ) ) . '">' . sprintf( esc_html__( 'Valor total: R$ %s', self::TEXT_DOMAIN ), number_format( $price, 2, ',', '.' ) ) . '</p>';
+        $html .= '<p class="bolaox-field"><input type="submit" name="bolaox_submit" value="' . esc_attr__( 'APOSTE AGORA', self::TEXT_DOMAIN ) . '" class="button bolaox-submit" /></p>';
+        $html .= '</form></div>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_results_shortcode() {
+        if ( isset( $_GET['bolaox_all_results'] ) ) {
+            return $this->render_all_results_shortcode();
+        }
+
+        $posts = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'numberposts' => 3,
+            'post_status' => 'publish',
+            'orderby'     => 'date',
+            'order'       => 'DESC',
+        ) );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+
+        $first_nums    = '';
+        $first_contest = 0;
+        $output  = '<div class="bolaox-result">';
+        $output .= '<h3>' . esc_html__( 'ÚLTIMOS RESULTADOS', self::TEXT_DOMAIN ) . '</h3>';
+        foreach ( $posts as $index => $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            }
+            if ( 0 === $index ) {
+                $first_nums    = $nums;
+                $first_contest = intval( get_post_meta( $p->ID, '_bolaox_concurso', true ) );
+            }
+            $title = get_the_title( $p );
+            $output .= '<h4 class="bolaox-result-title">' . esc_html( $title ) . '</h4>';
+            $output .= $this->render_number_board( $nums );
+        }
+        $link   = add_query_arg( 'bolaox_all_results', 1, get_permalink() );
+        $output .= '<p class="bolaox-center"><a href="' . esc_url( $link ) . '" class="bolaox-button bolaox-view-all">' . esc_html__( 'VER TODOS RESULTADOS', self::TEXT_DOMAIN ) . '</a></p>';
+        $output .= $this->render_recent_repeated_numbers( $first_contest );
+        $output .= $this->generate_report( $first_nums, $first_contest, 'score' );
+        $output .= '</div>';
+        return $this->wrap_app( $output );
+    }
+
+    private function render_all_results_shortcode() {
+        $paged    = max( 1, intval( get_query_var( 'bolaox_page' ) ) );
+        $per_page = 6;
+        $query    = new WP_Query( array(
+            'post_type'      => 'bolaox_result',
+            'post_status'    => 'publish',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'posts_per_page' => $per_page,
+            'paged'          => $paged,
+        ) );
+        if ( ! $query->have_posts() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $out = '<ul class="bolaox-history">';
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $nums = get_post_meta( get_the_ID(), '_bolaox_result', true );
+            if ( ! $nums ) {
+                $nums = get_post_meta( get_the_ID(), '_bolaox_numbers', true );
+            }
+            $numlist = '';
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $numlist .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+            }
+            $out .= '<li class="bolaox-history-item"><h3 class="bolaox-history-date">' . esc_html( get_the_title() ) . '</h3><div class="bolaox-scroll"><div class="bolaox-numlist">' . $numlist . '</div></div></li>';
+        }
+        wp_reset_postdata();
+        $out .= '</ul>';
+        $total = $query->max_num_pages;
+        if ( $total > 1 ) {
+            $out .= '<div class="bolaox-pagination">';
+            for ( $i = 1; $i <= $total; $i++ ) {
+                $url   = esc_url( add_query_arg( 'bolaox_page', $i ) );
+                $class = $i === $paged ? ' class="current"' : '';
+                $out  .= '<a href="' . $url . '"' . $class . '>' . $i . '</a> ';
+            }
+            $out .= '</div>';
+        }
+        return $this->wrap_app( $out );
+    }
+
+    public function render_history_shortcode() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_result', 'numberposts' => 5, 'orderby' => 'date', 'order' => 'DESC' ) );
+        if ( ! $posts ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Nenhum resultado cadastrado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $out = '<ul class="bolaox-history">';
+        foreach ( $posts as $p ) {
+            $nums = get_post_meta( $p->ID, '_bolaox_result', true );
+            $date = esc_html( get_the_date( '', $p ) );
+            $numlist = '';
+            foreach ( array_map( 'trim', explode( ',', $nums ) ) as $n ) {
+                $numlist .= '<span class="bolaox-number drawn">' . esc_html( $n ) . '</span>';
+            }
+            $out .= '<li class="bolaox-history-item"><h3 class="bolaox-history-date">' . $date . '</h3><div class="bolaox-scroll"><div class="bolaox-numlist">' . $numlist . '</div></div></li>';
+        }
+        $out .= '</ul>';
+        return $this->wrap_app( $out );
+    }
+
+    /**
+     * Get contest posts that contain bets from the given user.
+     */
+    private function get_user_contests( $user_id ) {
+        $phone = get_user_meta( $user_id, 'bolaox_phone', true );
+        $or    = array( 'relation' => 'OR', array( 'key' => '_bolaox_user', 'value' => $user_id ) );
+        if ( $phone ) {
+            $or[] = array( 'key' => '_bolaox_phone', 'value' => $phone );
+        }
+        $bet_ids = get_posts( array(
+            'post_type'   => 'bolaox_aposta',
+            'post_status' => 'publish',
+            'numberposts' => -1,
+            'fields'      => 'ids',
+            'meta_query'  => array( $or ),
+        ) );
+        if ( ! $bet_ids ) {
+            return array();
+        }
+        $contest_ids = array();
+        foreach ( $bet_ids as $bid ) {
+            $cid = get_post_meta( $bid, '_bolaox_concurso', true );
+            if ( $cid ) {
+                $contest_ids[] = intval( $cid );
+            }
+        }
+        $contest_ids = array_unique( $contest_ids );
+        if ( ! $contest_ids ) {
+            return array();
+        }
+        return get_posts( array(
+            'post_type'   => 'bolaox_concurso',
+            'post__in'    => $contest_ids,
+            'numberposts' => -1,
+            'orderby'     => 'date',
+            'order'       => 'DESC',
+        ) );
+    }
+
+    private function generate_my_bets_table( $user_id, $contest_id = 0 ) {
+        $phone = get_user_meta( $user_id, 'bolaox_phone', true );
+        $or    = array( 'relation' => 'OR', array( 'key' => '_bolaox_user', 'value' => $user_id ) );
+        if ( $phone ) {
+            $or[] = array( 'key' => '_bolaox_phone', 'value' => $phone );
+        }
+        $meta = array(
+            $or,
+            array(
+                'key'     => '_bolaox_payment',
+                'value'   => array( 'paid', 'pending' ),
+                'compare' => 'IN',
+            ),
+        );
+        if ( $contest_id ) {
+            $meta[] = array( 'key' => '_bolaox_concurso', 'value' => $contest_id );
+        }
+        $query = new WP_Query(
+            array(
+                'post_type'      => 'bolaox_aposta',
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'meta_query'     => $meta,
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+            )
+        );
+        $posts = $query->posts;
+        if ( ! $posts ) {
+            $query = new WP_Query(
+                array(
+                    'post_type'      => 'bolaox_aposta',
+                    'post_status'    => 'publish',
+                    'posts_per_page' => -1,
+                    'author'         => $user_id,
+                    'orderby'        => 'date',
+                    'order'          => 'DESC',
+                    'meta_query'     => array(
+                        array(
+                            'key'     => '_bolaox_payment',
+                            'value'   => array( 'paid', 'pending' ),
+                            'compare' => 'IN',
+                        ),
+                    ),
+                )
+            );
+            $posts = $query->posts;
+        }
+        if ( ! $posts ) {
+            $msg = $contest_id
+                ? __( 'Nenhuma aposta encontrada para este concurso.', self::TEXT_DOMAIN )
+                : __( 'Você ainda não cadastrou apostas.', self::TEXT_DOMAIN );
+            return '<p>' . esc_html( $msg ) . '</p>';
+        }
+        $results_cache = array();
+        $out  = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table">';
+        $out .= '<thead><tr>' .
+            '<th>' . esc_html__( 'Aposta', self::TEXT_DOMAIN ) . '</th>' .
+            '<th>' . esc_html__( 'Acertos', self::TEXT_DOMAIN ) . '</th>' .
+            '<th class="col-percent">%</th>' .
+            '<th>' . esc_html__( 'Dezenas', self::TEXT_DOMAIN ) . '</th>' .
+            '<th>' . esc_html__( 'Status', self::TEXT_DOMAIN ) . '</th>' .
+        '</tr></thead><tbody>';
+        foreach ( $posts as $p ) {
+            $cid       = get_post_meta( $p->ID, '_bolaox_concurso', true );
+            if ( ! isset( $results_cache[ $cid ] ) ) {
+                $res = '';
+                if ( $cid ) {
+                    $res_post = get_posts(
+                        array(
+                            'post_type'   => 'bolaox_result',
+                            'numberposts' => 1,
+                            'post_status' => 'publish',
+                            'meta_query'  => array( array( 'key' => '_bolaox_concurso', 'value' => $cid ) ),
+                        )
+                    );
+                    if ( $res_post ) {
+                        $res = get_post_meta( $res_post[0]->ID, '_bolaox_result', true );
+                    }
+                }
+                $results_cache[ $cid ] = $res ? array_map( 'trim', explode( ',', $res ) ) : array();
+            }
+            $res_numbers = $results_cache[ $cid ];
+
+            $numbers   = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums      = array_map( 'trim', explode( ',', $numbers ) );
+            $hit_count = $res_numbers ? $this->count_hits( $nums, $res_numbers ) : 0;
+            $percentage = $hit_count * 10;
+            $progress     = sprintf(
+                '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$d" data-progress="%1$d%%"><span></span></div>',
+                $percentage
+            );
+            $has_result  = ! empty( $res_numbers );
+            $duplicates   = $has_result ? array_unique( array_diff_assoc( $nums, array_unique( $nums ) ) ) : array();
+            $display_nums = array();
+            $remaining    = array_count_values( $res_numbers );
+            foreach ( $nums as $n ) {
+                $n = trim( $n );
+                $classes = array( 'bolaox-number' );
+                if ( $has_result && in_array( $n, $duplicates, true ) ) {
+                    $classes[] = 'dup';
+                }
+                if ( $has_result && isset( $remaining[ $n ] ) && $remaining[ $n ] > 0 ) {
+                    $classes[] = 'hit';
+                    $remaining[ $n ]--;
+                }
+                $display_nums[] = sprintf(
+                    '<span class="%s">%s</span>',
+                    esc_attr( implode( ' ', $classes ) ),
+                    esc_html( $n )
+                );
+            }
+            $status = get_post_meta( $p->ID, '_bolaox_payment', true );
+            if ( ! $status ) {
+                $status = 'pending';
+            }
+            if ( 'pending' === $status ) {
+                $label = '<span class="bolaox-unpaid">' . esc_html__( 'Não pago', self::TEXT_DOMAIN ) . '</span> ';
+                $label .= '<a href="#" class="button bolaox-pay-now" data-id="' . $p->ID . '" data-target="#bolaox-pix-modal">' . esc_html__( 'Pagar agora', self::TEXT_DOMAIN ) . '</a>';
+            } else {
+                $label = esc_html__( 'Pago', self::TEXT_DOMAIN );
+            }
+            $out   .= sprintf(
+                '<tr><td>%s</td><td>%d</td><td class="col-percent">%s</td><td class="bolaox-numlist">%s</td><td>%s</td></tr>',
+                esc_html( $p->post_title ),
+                $hit_count,
+                $progress,
+                implode( '', $display_nums ),
+                $label
+            );
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    public function render_my_bets_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            $redirect = esc_url_raw( $_SERVER['REQUEST_URI'] );
+            $url      = esc_url( add_query_arg( 'redirect_to', rawurlencode( $redirect ), home_url( '/login-cadastro' ) ) );
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $url );
+                exit;
+            }
+            return '<script>window.location.href="' . esc_url( $url ) . '";</script>';
+        }
+
+        if ( ! headers_sent() ) {
+            nocache_headers();
+            if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+                define( 'DONOTCACHEPAGE', true );
+            }
+        }
+        $contest   = isset( $_GET['contest'] ) ? intval( $_GET['contest'] ) : 0;
+        $contests  = $this->get_user_contests( get_current_user_id() );
+        $allowed   = wp_list_pluck( $contests, 'ID' );
+        if ( $contest && ! in_array( $contest, $allowed, true ) ) {
+            $contest = 0;
+        }
+        $table = $this->generate_my_bets_table( get_current_user_id(), $contest );
+        // Use esc_url_raw so the query string remains intact for JavaScript
+        // which reads this attribute and performs fetch requests.
+        $url   = esc_url_raw( add_query_arg( 'contest', $contest, rest_url( 'bolao-x/v1/mybets', 'relative' ) ) );
+        $html  = '';
+        if ( $contests ) {
+            $html .= '<form method="get" class="bolaox-contest-form" id="bolaox-contest-form">';
+            $html .= '<label>' . esc_html__( 'Filtrar por Concurso', self::TEXT_DOMAIN ) . '</label>';
+            $html .= '<select name="contest">';
+            $html .= '<option value="0">' . esc_html__( 'Todos', self::TEXT_DOMAIN ) . '</option>';
+            foreach ( $contests as $c ) {
+                $html .= '<option value="' . $c->ID . '"' . selected( $contest, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+            }
+            $html .= '</select>';
+            $html .= '</form>';
+        }
+        $html .= '<div id="bolaox-pix-modal" class="bolaox-modal"><div class="bolaox-modal-content">';
+        $html .= '<p><img src="" alt="Pix QR" width="500" height="500" /></p>';
+        $html .= '<p>' . esc_html__( 'Copie o Código:', self::TEXT_DOMAIN ) . '<br />';
+        $html .= '<input type="text" id="bolaox-pix-code" value="" readonly class="bolaox-pix-code" />';
+        $html .= '<button type="button" class="button bolaox-copy" data-target="#bolaox-pix-code">' . esc_html__( 'Copiar', self::TEXT_DOMAIN ) . '</button></p>';
+        $html .= '<p><span class="button bolaox-modal-close">' . esc_html__( 'Fechar', self::TEXT_DOMAIN ) . '</span></p></div></div>';
+
+        $html .= '<div id="bolaox-my-bets" data-mybets-url="' . $url . '">' . $table . '</div>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_stats_shortcode() {
+        $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+        if ( ! $posts ) {
+            return '<p>' . esc_html__( 'Nenhuma aposta cadastrada.', self::TEXT_DOMAIN ) . '</p>';
+        }
+        $counts = array_fill( 0, 100, 0 );
+        foreach ( $posts as $p ) {
+            $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+            $nums    = array_map( 'trim', explode( ',', $numbers ) );
+            foreach ( $nums as $n ) {
+                $idx = intval( $n );
+                if ( $idx >= 0 && $idx < 100 ) {
+                    $counts[ $idx ]++;
+                }
+            }
+        }
+        $total = array_sum( $counts );
+        $out = '<div class="bolaox-table-wrapper bolaox-scroll"><table class="widefat bolaox-table bolaox-stats"><thead><tr><th>Dezena</th><th>Ocorrências</th><th>%</th></tr></thead><tbody>';
+        for ( $i = 0; $i < 100; $i++ ) {
+            if ( $counts[ $i ] > 0 ) {
+                $num  = str_pad( strval( $i ), 2, '0', STR_PAD_LEFT );
+                $perc = round( ( $counts[ $i ] / $total ) * 100 );
+                $bar  = '<div class="bolaox-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . $perc . '" data-progress="' . $perc . '%"><span style="width:' . $perc . '%"></span></div>';
+                $out .= '<tr><td>' . $num . '</td><td>' . $counts[ $i ] . '</td><td>' . $bar . '</td></tr>';
+            }
+        }
+        $out .= '</tbody></table></div>';
+        return $out;
+    }
+
+    public function render_profile_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            $redirect = esc_url_raw( $_SERVER['REQUEST_URI'] );
+            $url      = esc_url( add_query_arg( 'redirect_to', rawurlencode( $redirect ), home_url( '/login-cadastro' ) ) );
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $url );
+                exit;
+            }
+            return '<script>window.location.href="' . esc_url( $url ) . '";</script>';
+        }
+        $user      = wp_get_current_user();
+        $avatar_id = get_user_meta( $user->ID, 'bolaox_avatar_id', true );
+        $msg = '';
+        if ( isset( $_POST['bolaox_profile_nonce'] ) && wp_verify_nonce( $_POST['bolaox_profile_nonce'], 'bolaox_profile' ) ) {
+            $first = sanitize_text_field( $_POST['bolaox_first_name'] );
+            $last  = sanitize_text_field( $_POST['bolaox_last_name'] );
+            wp_update_user( array( 'ID' => $user->ID, 'first_name' => $first, 'last_name' => $last ) );
+            $msg = '<p>' . esc_html__( 'Dados atualizados com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+        } elseif ( isset( $_POST['bolaox_pass_nonce'] ) && wp_verify_nonce( $_POST['bolaox_pass_nonce'], 'bolaox_pass' ) ) {
+            $p1 = sanitize_text_field( $_POST['bolaox_pass1'] );
+            $p2 = sanitize_text_field( $_POST['bolaox_pass2'] );
+            if ( $p1 && $p1 === $p2 ) {
+                wp_update_user( array( 'ID' => $user->ID, 'user_pass' => $p1 ) );
+                $msg = '<p>' . esc_html__( 'Senha alterada com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+            } else {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'As senhas não conferem.', self::TEXT_DOMAIN ) . '</p>';
+            }
+        }
+        if ( isset( $_POST['bolaox_avatar_nonce'] ) && wp_verify_nonce( $_POST['bolaox_avatar_nonce'], 'bolaox_avatar' ) ) {
+            if ( isset( $_POST['bolaox_delete_avatar'] ) && $avatar_id ) {
+                wp_delete_attachment( $avatar_id, true );
+                delete_user_meta( $user->ID, 'bolaox_avatar_id' );
+                $avatar_id = 0;
+                $msg = '<p>' . esc_html__( 'Avatar removido.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( ! empty( $_FILES['bolaox_avatar']['name'] ) ) {
+                require_once ABSPATH . 'wp-admin/includes/file.php';
+                require_once ABSPATH . 'wp-admin/includes/media.php';
+                require_once ABSPATH . 'wp-admin/includes/image.php';
+                $aid = media_handle_upload( 'bolaox_avatar', 0 );
+                if ( ! is_wp_error( $aid ) ) {
+                    if ( $avatar_id ) {
+                        wp_delete_attachment( $avatar_id, true );
+                    }
+                    update_user_meta( $user->ID, 'bolaox_avatar_id', $aid );
+                    $avatar_id = $aid;
+                    $msg = '<p>' . esc_html__( 'Avatar atualizado.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Falha ao enviar a imagem.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            }
+        }
+        $html  = $msg . '<form method="post" class="bolaox-profile">';
+        $html .= wp_nonce_field( 'bolaox_profile', 'bolaox_profile_nonce', true, false );
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Nome', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_first_name" class="bolaox-input" value="' . esc_attr( $user->first_name ) . '" /></label></p>';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Sobrenome', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_last_name" class="bolaox-input" value="' . esc_attr( $user->last_name ) . '" /></label></p>';
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Salvar', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+
+        $html .= '<form method="post" enctype="multipart/form-data" class="bolaox-avatar-form">';
+        $html .= wp_nonce_field( 'bolaox_avatar', 'bolaox_avatar_nonce', true, false );
+        $html .= '<div class="bolaox-avatar-preview">';
+        if ( $avatar_id ) {
+            $html .= wp_get_attachment_image( $avatar_id, array( 96, 96 ), false, array( 'class' => 'bolaox-avatar-img' ) );
+        } else {
+            $html .= '<span class="dashicons dashicons-admin-users bolaox-avatar-img"></span>';
+        }
+        $html .= '</div>';
+        $html .= '<p class="bolaox-field"><input type="file" name="bolaox_avatar" accept="image/*" /></p>';
+        if ( $avatar_id ) {
+            $html .= '<p class="bolaox-field"><button type="submit" name="bolaox_delete_avatar" value="1" class="bolaox-delete-avatar">' . esc_html__( 'Excluir avatar', self::TEXT_DOMAIN ) . '</button></p>';
+        }
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Salvar avatar', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+
+        $html .= '<form method="post" class="bolaox-pass-form">';
+        $html .= wp_nonce_field( 'bolaox_pass', 'bolaox_pass_nonce', true, false );
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Nova senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_pass1" class="bolaox-input" required /></label></p>';
+        $html .= '<p class="bolaox-field"><label>' . esc_html__( 'Confirme a senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_pass2" class="bolaox-input" required /></label></p>';
+        $html .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Alterar senha', self::TEXT_DOMAIN ) . '" /></p>';
+        $html .= '</form>';
+        $html .= '<p class="bolaox-field"><a class="button bolaox-submit" href="' . esc_url( wp_logout_url( home_url() ) ) . '">' . esc_html__( 'Sair', self::TEXT_DOMAIN ) . '</a></p>';
+        return $this->wrap_app( $html );
+    }
+
+    public function render_login_shortcode( $atts = array() ) {
+        if ( is_user_logged_in() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Você já está logado.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        $atts        = shortcode_atts( array( 'redirect_to' => '' ), $atts );
+        $default     = add_query_arg( 'bx_sec', 'form', $this->get_form_page_url() );
+        $redirect_to = $atts['redirect_to'] ? esc_url_raw( $atts['redirect_to'] ) : ( isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : esc_url_raw( $default ) );
+        $pref_phone  = isset( $_REQUEST['phone'] ) ? $this->sanitize_phone( $_REQUEST['phone'] ) : '';
+        $open_reg    = isset( $_REQUEST['register'] ) ? true : false;
+        $msg         = '';
+        $cookie_js   = '';
+        if ( isset( $_POST['bolaox_login_nonce'] ) && wp_verify_nonce( $_POST['bolaox_login_nonce'], 'bolaox_login' ) ) {
+            $phone = $this->sanitize_phone( $_POST['bolaox_phone'] );
+            $pass  = isset( $_POST['bolaox_password'] ) ? $_POST['bolaox_password'] : '';
+            $users = get_users( array( 'meta_key' => 'bolaox_phone', 'meta_value' => $phone, 'number' => 1 ) );
+            if ( $users ) {
+                $user  = $users[0];
+                if ( wp_check_password( $pass, $user->user_pass, $user->ID ) ) {
+                    wp_set_current_user( $user->ID );
+                    $cookie_js = $this->create_session( $user->ID );
+                    $msg = '<p class="bolaox-login-success" data-redirect="' . esc_attr( $redirect_to ) . '">' . esc_html__( 'Login realizado com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Senha incorreta.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            } else {
+                $url = add_query_arg( array( 'register' => 1, 'phone' => rawurlencode( $phone ), 'redirect_to' => rawurlencode( $redirect_to ) ), home_url( '/login-cadastro' ) );
+                if ( ! headers_sent() ) {
+                    wp_safe_redirect( $url );
+                    exit;
+                }
+                return '<script>window.location.href="' . esc_url( $url ) . '";</script>';
+            }
+        } elseif ( isset( $_POST['bolaox_register_nonce'] ) && wp_verify_nonce( $_POST['bolaox_register_nonce'], 'bolaox_register' ) ) {
+            $phone   = $this->sanitize_phone( $_POST['bolaox_phone'] );
+            $pass    = isset( $_POST['bolaox_password'] ) ? $_POST['bolaox_password'] : '';
+            $pass2   = isset( $_POST['bolaox_password2'] ) ? $_POST['bolaox_password2'] : '';
+            $display = sanitize_text_field( $_POST['bolaox_display'] );
+            if ( empty( $phone ) || empty( $pass ) || empty( $display ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Preencha todos os campos.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( ! preg_match( '/^\d{10,11}$/', $phone ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Telefone inválido.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( strlen( $pass ) < 6 ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'A senha precisa ter ao menos 6 caracteres.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( $pass !== $pass2 ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'As senhas não conferem.', self::TEXT_DOMAIN ) . '</p>';
+            } elseif ( get_users( array( 'meta_key' => 'bolaox_phone', 'meta_value' => $phone, 'number' => 1 ) ) ) {
+                $msg = '<p class="bolaox-error">' . esc_html__( 'Telefone já cadastrado.', self::TEXT_DOMAIN ) . '</p>';
+            } else {
+                $username = 'u' . $phone;
+                $email    = $phone . '@example.com';
+                $user_id  = wp_insert_user( array( 'user_login' => $username, 'user_pass' => $pass, 'user_email' => $email, 'display_name' => $display ) );
+                if ( is_wp_error( $user_id ) ) {
+                    $msg = '<p class="bolaox-error">' . esc_html__( 'Erro ao criar usuário.', self::TEXT_DOMAIN ) . '</p>';
+                } else {
+                    update_user_meta( $user_id, 'bolaox_phone', $phone );
+                    wp_set_current_user( $user_id );
+                    $cookie_js = $this->create_session( $user_id );
+                    $msg = '<p class="bolaox-register-success" data-redirect="' . esc_attr( $redirect_to ) . '">' . esc_html__( 'Cadastro realizado com sucesso.', self::TEXT_DOMAIN ) . '</p>';
+                }
+            }
+        }
+
+        $login_form  = '<form method="post" class="bolaox-login-form">';
+        $login_form .= wp_nonce_field( 'bolaox_login', 'bolaox_login_nonce', true, false );
+        $login_form .= '<input type="hidden" name="redirect_to" value="' . esc_attr( $redirect_to ) . '" />';
+        $login_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Telefone', self::TEXT_DOMAIN ) . '<br /><input type="tel" name="bolaox_phone" class="bolaox-phone" value="' . esc_attr( $pref_phone ) . '" required /></label></p>';
+        $login_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password" required /></label></p>';
+        $login_form .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Entrar', self::TEXT_DOMAIN ) . '" /></p>';
+        $login_form .= '</form>';
+
+        $register_form  = '<form method="post" class="bolaox-register-form">';
+        $register_form .= wp_nonce_field( 'bolaox_register', 'bolaox_register_nonce', true, false );
+        $register_form .= '<input type="hidden" name="redirect_to" value="' . esc_attr( $redirect_to ) . '" />';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Como quer ser chamado?', self::TEXT_DOMAIN ) . '<br /><input type="text" name="bolaox_display" class="bolaox-input" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Telefone', self::TEXT_DOMAIN ) . '<br /><input type="tel" name="bolaox_phone" class="bolaox-phone" value="' . esc_attr( $pref_phone ) . '" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><label>' . esc_html__( 'Confirme a senha', self::TEXT_DOMAIN ) . '<br /><input type="password" name="bolaox_password2" required /></label></p>';
+        $register_form .= '<p class="bolaox-field"><input type="submit" class="button bolaox-submit" value="' . esc_attr__( 'Criar conta', self::TEXT_DOMAIN ) . '" /></p>';
+        $register_form .= '</form>';
+
+        $redirect = '';
+        if ( strpos( $msg, 'bolaox-login-success' ) !== false || strpos( $msg, 'bolaox-register-success' ) !== false ) {
+            if ( ! headers_sent() ) {
+                wp_safe_redirect( $redirect_to );
+                exit;
+            }
+            $redirect = $cookie_js . '<script>window.location.href="' . esc_url( $redirect_to ) . '";</script>';
+        }
+
+        $tab_attr = $open_reg ? 'register' : 'login';
+        $html  = '<div class="bolaox-login-tabs" data-tab="' . $tab_attr . '">' . $msg;
+        $login_li_class = $open_reg ? '' : ' class="active"';
+        $reg_li_class   = $open_reg ? ' class="active"' : '';
+        $login_div = $open_reg ? '' : ' active';
+        $reg_div   = $open_reg ? ' active' : '';
+        $html .= '<ul class="bolaox-tabs"><li' . $login_li_class . '>' . esc_html__( 'Acessar', self::TEXT_DOMAIN ) . '</li><li' . $reg_li_class . '>' . esc_html__( 'Cadastrar', self::TEXT_DOMAIN ) . '</li></ul>';
+        $html .= '<div class="bolaox-tab-content' . $login_div . '">' . $login_form . '</div>';
+        $html .= '<div class="bolaox-tab-content' . $reg_div . '">' . $register_form . '</div>';
+        $html .= '</div>' . $redirect;
+        return $this->wrap_app( $html );
+    }
+
+    public function render_dashboard_shortcode() {
+        $this->maybe_restore_session();
+        if ( ! is_user_logged_in() ) {
+            return $this->wrap_app( '<p>' . esc_html__( 'Você precisa entrar para acessar o painel.', self::TEXT_DOMAIN ) . '</p>' );
+        }
+        if ( ! isset( $_GET['bx_sec'] ) ) {
+            return do_shortcode( '[bolao_x_form]' );
+        }
+        $avatar_id = get_user_meta( get_current_user_id(), 'bolaox_avatar_id', true );
+        $sections = array(
+            'profile'  => array( 'dashicons-admin-users', __( 'Perfil', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_profile]' ) ),
+            'form'     => array( 'dashicons-edit', __( 'Nova Aposta', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_form]' ) ),
+            'mybets'   => array( 'dashicons-chart-bar', __( 'Minhas Apostas', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_my_bets]' ) ),
+            'results'  => array( 'dashicons-awards', __( 'Resultados', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_results]' ) ),
+            'stats'    => array( 'dashicons-analytics', __( 'Estatísticas', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_stats]' ) ),
+            'history'  => array( 'dashicons-backup', __( 'Histórico', self::TEXT_DOMAIN ), do_shortcode( '[bolao_x_history]' ) ),
+            'logout'   => array( 'dashicons-migrate', __( 'Sair', self::TEXT_DOMAIN ), '<p><a class="button bolaox-submit" href="' . esc_url( wp_logout_url( home_url() ) ) . '">' . esc_html__( 'Sair', self::TEXT_DOMAIN ) . '</a></p>' ),
+        );
+        $logo = '<img src="https://www.bolaox.com.br/wp-content/uploads/2025/07/logo-footer.png" class="bolaox-mobile-logo" alt="Bolao X" />';
+        $html = $logo . '<div class="bolaox-dashboard">';
+        foreach ( $sections as $key => $data ) {
+            list( $icon, $label ) = $data;
+            $icon_html = '<span class="dashicons ' . esc_attr( $icon ) . '"></span>';
+            if ( 'profile' === $key && $avatar_id ) {
+                $icon_html = wp_get_attachment_image( $avatar_id, array( 32, 32 ), false, array( 'class' => 'bolaox-avatar-icon' ) );
+            }
+            $html .= '<div class="bolaox-card" data-target="bx-' . esc_attr( $key ) . '">' . $icon_html . '<span>' . esc_html( $label ) . '</span></div>';
+        }
+        $html .= '</div><div class="bolaox-dashboard-sections">';
+        foreach ( $sections as $key => $data ) {
+            $html .= '<div id="bx-' . esc_attr( $key ) . '" class="bolaox-section" style="display:none">' . $data[2] . '</div>';
+        }
+        $html .= '</div>';
+        return $this->wrap_app( $html );
+    }
+
+
+
+    public function register_dashboard_widget() {
+        wp_add_dashboard_widget( 'bolaox_overview', 'Resumo Bolao X', array( $this, 'dashboard_widget' ) );
+    }
+
+    public function dashboard_widget() {
+        $bets = wp_count_posts( 'bolaox_aposta' );
+        $count = $bets && isset( $bets->publish ) ? intval( $bets->publish ) : 0;
+        $result = get_option( 'bolaox_result', '' );
+        $winners = array( '10' => 0, '9' => 0 );
+        if ( $result ) {
+            $res_numbers = array_map( 'trim', explode( ',', $result ) );
+            $posts = get_posts( array( 'post_type' => 'bolaox_aposta', 'numberposts' => -1 ) );
+            foreach ( $posts as $p ) {
+                $numbers = get_post_meta( $p->ID, '_bolaox_numbers', true );
+                $nums    = array_map( 'trim', explode( ',', $numbers ) );
+                $hits    = count( array_intersect( $res_numbers, $nums ) );
+                if ( $hits >= 9 ) {
+                    $key = strval( $hits );
+                    if ( isset( $winners[ $key ] ) ) {
+                        $winners[ $key ]++;
+                    }
+                }
+            }
+        }
+        echo '<p>' . sprintf( esc_html__( 'Total de apostas: %d', self::TEXT_DOMAIN ), $count ) . '</p>';
+        if ( $result ) {
+            echo '<p>' . esc_html__( 'Acertos:', self::TEXT_DOMAIN ) . '</p><ul>';
+            echo '<li>' . sprintf( esc_html__( '10 dezenas: %d', self::TEXT_DOMAIN ), $winners['10'] ) . '</li>';
+            echo '<li>' . sprintf( esc_html__( '9 dezenas: %d', self::TEXT_DOMAIN ), $winners['9'] ) . '</li>';
+            echo '</ul>';
+        } else {
+            echo '<p>' . esc_html__( 'Nenhum resultado cadastrado ainda.', self::TEXT_DOMAIN ) . '</p>';
+        }
+    }
+
+    public function filter_gettext( $translated, $text, $domain ) {
+        if ( 'default' !== $domain || ! function_exists( 'get_current_screen' ) ) {
+            return $translated;
+        }
+        $screen = get_current_screen();
+        if ( ! $screen ) {
+            return $translated;
+        }
+        if ( 'bolaox_aposta' === $screen->post_type ) {
+            if ( in_array( $text, array( 'Add New Post', 'Adicionar post', 'Adicionar novo' ), true ) ) {
+                return __( 'Aposta Manual', self::TEXT_DOMAIN );
+            }
+            if ( 'Publish' === $text || 'Publicar' === $text ) {
+                return __( 'Criar Aposta', self::TEXT_DOMAIN );
+            }
+        } elseif ( 'bolaox_result' === $screen->post_type ) {
+            if ( in_array( $text, array( 'Add New Post', 'Adicionar post', 'Adicionar novo' ), true ) ) {
+                return __( 'Novo Resultado', self::TEXT_DOMAIN );
+            }
+            if ( 'Publish' === $text || 'Publicar' === $text ) {
+                return __( 'Publicar Resultado', self::TEXT_DOMAIN );
+            }
+            if ( in_array( $text, array( 'Edit Post', 'Editar post' ), true ) ) {
+                return __( 'Editar Resultado', self::TEXT_DOMAIN );
+            }
+        }
+        return $translated;
+    }
+
+    public function title_placeholder( $title, $post ) {
+        if ( 'bolaox_aposta' === $post->post_type ) {
+            return __( 'Nome do Apostador', self::TEXT_DOMAIN );
+        } elseif ( 'bolaox_result' === $post->post_type ) {
+            return __( 'Qual resultado deseja publicar?', self::TEXT_DOMAIN );
+        } elseif ( 'bolaox_concurso' === $post->post_type ) {
+            return __( 'Insira o Nome do Concurso', self::TEXT_DOMAIN );
+        }
+        return $title;
+    }
+
+
+    public function register_routes() {
+        register_rest_route(
+            'bolao-x/v1',
+            '/mp',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'handle_mp_webhook' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/validate',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'rest_validate_credentials' ),
+                'permission_callback' => function () { return current_user_can( 'manage_options' ); },
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/create-payment',
+            array(
+                'methods'  => 'POST',
+                'callback' => array( $this, 'rest_create_payment' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+        register_rest_route(
+            'bolao-x/v1',
+            '/mybets',
+            array(
+                'methods'  => 'GET',
+                'callback' => array( $this, 'rest_my_bets' ),
+                'permission_callback' => '__return_true',
+            )
+        );
+    }
+
+    public function handle_mp_webhook( WP_REST_Request $request ) {
+        $token = $request->get_param( 'token' );
+        if ( $token !== self::MP_WEBHOOK_TOKEN ) {
+            return new WP_Error( 'forbidden', 'Token inválido', array( 'status' => 403 ) );
+        }
+        $payment_id = intval( $request->get_param( 'data_id' ) );
+        if ( ! $payment_id ) {
+            return new WP_Error( 'bad_request', 'ID ausente', array( 'status' => 400 ) );
+        }
+        $url  = self::MP_API_URL . '/v1/payments/' . $payment_id;
+        $args = array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $this->get_mp_access_token(),
+            ),
+            'timeout' => 20,
+        );
+        $res = wp_remote_get( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            $this->log_mp_error( 'Erro consulta pagamento: ' . $res->get_error_message() );
+            return new WP_Error( 'request_failed', 'Erro na consulta', array( 'status' => 500 ) );
+        }
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( isset( $body['status'] ) && 'approved' === $body['status'] ) {
+            $post_id = intval( $body['external_reference'] );
+            if ( $post_id ) {
+                update_post_meta( $post_id, '_bolaox_payment', 'paid' );
+                return array( 'success' => true );
+            }
+        }
+        $this->log_mp_error( 'Pagamento não confirmado: ' . wp_remote_retrieve_body( $res ) );
+        return new WP_Error( 'invalid', 'Pagamento não confirmado', array( 'status' => 400 ) );
+    }
+
+    public function rest_validate_credentials( WP_REST_Request $request ) {
+        $mode = $request->get_param( 'mode' );
+        if ( ! in_array( $mode, array( 'prod', 'test' ), true ) ) {
+            return new WP_Error( 'invalid', 'Modo inválido', array( 'status' => 400 ) );
+        }
+        if ( $this->validate_mp_credentials( $mode ) ) {
+            return array( 'success' => true );
+        }
+        return new WP_Error( 'invalid', 'Credenciais inválidas', array( 'status' => 400 ) );
+    }
+
+    public function rest_create_payment( WP_REST_Request $request ) {
+        $qty = max( 1, intval( $request->get_param( 'qty' ) ) );
+        $pref = sanitize_text_field( $request->get_param( 'ref' ) );
+        $data = $this->create_mp_pix_payment( $pref, $qty );
+        if ( ! $data ) {
+            return new WP_Error( 'failed', 'Erro ao criar pagamento', array( 'status' => 500 ) );
+        }
+        return $data;
+    }
+
+    public function auto_create_result( $post_id, $post, $update ) {
+        if ( wp_is_post_revision( $post_id ) || 'auto-draft' === $post->post_status || 'trash' === $post->post_status ) {
+            return;
+        }
+
+        $existing = get_posts( array(
+            'post_type'   => 'bolaox_result',
+            'post_status' => 'any',
+            'numberposts' => 1,
+            'meta_query'  => array(
+                array( 'key' => '_bolaox_concurso', 'value' => $post_id ),
+            ),
+        ) );
+
+        $title = sprintf( __( 'Resultado do Concurso %s', self::TEXT_DOMAIN ), $post->post_title );
+
+        if ( $existing ) {
+            $eid = $existing[0]->ID;
+            if ( $existing[0]->post_title !== $title ) {
+                wp_update_post( array( 'ID' => $eid, 'post_title' => $title ) );
+            }
+            return;
+        }
+
+        $res_id = wp_insert_post( array(
+            'post_type'   => 'bolaox_result',
+            'post_title'  => $title,
+            'post_status' => 'draft',
+        ) );
+
+        if ( $res_id ) {
+            update_post_meta( $res_id, '_bolaox_concurso', $post_id );
+        }
+    }
+
+    private function on_contest_switch( $old_id, $new_id ) {
+        if ( $old_id ) {
+            // Previously rotating bets for the finished contest were removed
+            // here. This prevented viewing past contest reports, so we now keep
+            // the bets intact for history purposes.
+        }
+        if ( $new_id && $old_id ) {
+            if ( '1' === get_post_meta( $new_id, '_bolaox_emd', true ) ) {
+                return;
+            }
+            $fixed = get_posts( array(
+                'post_type'   => 'bolaox_aposta',
+                'numberposts' => -1,
+                'meta_query'  => array(
+                    array( 'key' => '_bolaox_concurso', 'value' => $old_id ),
+                    array( 'key' => '_bolaox_fixed', 'value' => '1' ),
+                ),
+            ) );
+            foreach ( $fixed as $fb ) {
+                $new_post = wp_insert_post( array(
+                    'post_type'   => 'bolaox_aposta',
+                    'post_title'  => $fb->post_title,
+                    'post_status' => 'publish',
+                    'post_author' => $fb->post_author,
+                ) );
+                if ( $new_post ) {
+                    update_post_meta( $new_post, '_bolaox_numbers', get_post_meta( $fb->ID, '_bolaox_numbers', true ) );
+                    update_post_meta( $new_post, '_bolaox_payment', get_post_meta( $fb->ID, '_bolaox_payment', true ) );
+                    update_post_meta( $new_post, '_bolaox_fixed', '1' );
+                    update_post_meta( $new_post, '_bolaox_concurso', $new_id );
+                }
+            }
+        }
+    }
+
+    public function aposta_columns( $cols ) {
+        $cols['bolaox_fixed'] = __( 'Fixo', self::TEXT_DOMAIN );
+        return $cols;
+    }
+
+    public function aposta_column_content( $col, $post_id ) {
+        if ( 'bolaox_fixed' === $col ) {
+            $val = get_post_meta( $post_id, '_bolaox_fixed', true );
+            echo $val ? '&#10004;' : '&#8211;';
+        }
+    }
+
+    public function aposta_filter() {
+        global $typenow;
+        if ( 'bolaox_aposta' === $typenow ) {
+            $val = $_GET['bolaox_fixed'] ?? '';
+            echo '<select name="bolaox_fixed"><option value="">' . esc_html__( 'Tipo', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="1"' . selected( $val, '1', false ) . '>' . esc_html__( 'Fixas', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="0"' . selected( $val, '0', false ) . '>' . esc_html__( 'Rotativas', self::TEXT_DOMAIN ) . '</option>';
+            echo '</select>';
+
+            $cid = $_GET['bolaox_concurso'] ?? '';
+            $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+            echo '<select name="bolaox_concurso"><option value="">' . esc_html__( 'Concurso', self::TEXT_DOMAIN ) . '</option>';
+            foreach ( $contests as $c ) {
+                echo '<option value="' . $c->ID . '"' . selected( $cid, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+            }
+            echo '</select>';
+        }
+    }
+
+    public function aposta_filter_query( $query ) {
+        global $pagenow;
+        if ( is_admin() && 'edit.php' === $pagenow && 'bolaox_aposta' === ( $query->get( 'post_type' ) ?? '' ) ) {
+            $meta_query = array();
+            $val = $_GET['bolaox_fixed'] ?? '';
+            if ( $val !== '' ) {
+                $meta_query[] = array( 'key' => '_bolaox_fixed', 'value' => $val );
+            }
+            $cid = $_GET['bolaox_concurso'] ?? '';
+            if ( $cid ) {
+                $meta_query[] = array( 'key' => '_bolaox_concurso', 'value' => intval( $cid ) );
+            }
+            if ( $meta_query ) {
+                $query->set( 'meta_query', $meta_query );
+            }
+        }
+    }
+
+    public function result_filter() {
+        global $typenow;
+        if ( 'bolaox_result' === $typenow ) {
+            $val = $_GET['bolaox_concurso'] ?? '';
+            $contests = get_posts( array( 'post_type' => 'bolaox_concurso', 'numberposts' => -1 ) );
+            echo '<select name="bolaox_concurso"><option value="">' . esc_html__( 'Concurso', self::TEXT_DOMAIN ) . '</option>';
+            foreach ( $contests as $c ) {
+                echo '<option value="' . $c->ID . '"' . selected( $val, $c->ID, false ) . '>' . esc_html( $c->post_title ) . '</option>';
+            }
+            echo '</select>';
+        }
+    }
+
+    public function result_filter_query( $query ) {
+        global $pagenow;
+        if ( is_admin() && 'edit.php' === $pagenow && 'bolaox_result' === ( $query->get( 'post_type' ) ?? '' ) ) {
+            $val = $_GET['bolaox_concurso'] ?? '';
+            if ( $val ) {
+                $query->set( 'meta_query', array(
+                    array( 'key' => '_bolaox_concurso', 'value' => intval( $val ) )
+                ) );
+            }
+        }
+    }
+
+    public function result_columns( $cols ) {
+        $cols['bolaox_concurso'] = __( 'Concurso', self::TEXT_DOMAIN );
+        return $cols;
+    }
+
+    public function result_column_content( $col, $post_id ) {
+        if ( 'bolaox_concurso' === $col ) {
+            $cid = get_post_meta( $post_id, '_bolaox_concurso', true );
+            if ( $cid ) {
+                $title = get_the_title( $cid );
+                echo esc_html( $title );
+            } else {
+                echo '&#8211;';
+            }
+        }
+    }
+
+    public function rest_my_bets( WP_REST_Request $req ) {
+        $this->maybe_restore_session();
+        nocache_headers();
+        if ( ! is_user_logged_in() ) {
+            return new WP_Error( 'forbidden', 'auth', array( 'status' => 401 ) );
+        }
+        $contest = intval( $req->get_param( 'contest' ) );
+        return array(
+            'html' => $this->generate_my_bets_table( get_current_user_id(), $contest ),
+        );
+    }
+    public static function activate() {
+        self::instance();
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+
+}
+
+register_activation_hook( __FILE__, array( 'BOLAOX_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'BOLAOX_Plugin', 'deactivate' ) );
+
+if ( extension_loaded( 'gd' ) ) {
+    BOLAOX_Plugin::instance();
+} else {
+    add_action( 'admin_notices', function() {
+        echo '<div class="notice notice-error"><p>' .
+            esc_html__( 'O plugin Bolao X requer a extensão PHP GD para gerar QR Codes.', 'bolao-x' ) .
+            '</p></div>';
+    } );
+}
+


### PR DESCRIPTION
## Summary
- align the PDF winners export with the dashboard by filtering to paid bets and reusing stored hit counts
- rename the 8-point summary card and prize map entries to reference apostadores instead of vencedores
- display prize amounts in parentheses to remove the stray article in the Resumo da Premiação section

## Testing
- php -l bolao-x/bolao-x.php

------
https://chatgpt.com/codex/tasks/task_e_68db360ba7d8832bb3bdd225e8bbde2d