### PR TITLE
Replace group cover asset with runtime placeholders

### DIFF
--- a/docs/demo-data.md
+++ b/docs/demo-data.md
@@ -1,0 +1,58 @@
+# Dados de demonstração do JuntaPlay
+
+Este repositório inclui um semeador opcional (`Gerar dados de demonstração` na tela **Importação e Páginas Automáticas** do painel WordPress) para ajudar a testar buscas, aprovações e notificações dos grupos. O botão cria usuários fictícios, associações e grupos populares inspirados nas referências fornecidas.
+
+> **Senha padrão**: `JuntaPlay#2024` para todos os perfis criados pelo semeador.
+
+## Usuários criados
+
+| Login              | Nome exibido          | E-mail                             | Função         | Avatar (URL)                         |
+| ------------------ | --------------------- | ---------------------------------- | -------------- | ------------------------------------ |
+| demo.superadmin    | Equipe JuntaPlay      | demo.superadmin@example.com        | administrator  | https://i.pravatar.cc/300?img=12     |
+| ana.streaming      | Ana Streaming         | ana.streaming@example.com          | subscriber     | https://i.pravatar.cc/300?img=47     |
+| bruno.sound        | Bruno Sound           | bruno.sound@example.com            | subscriber     | https://i.pravatar.cc/300?img=15     |
+| carla.series       | Carla Séries          | carla.series@example.com           | subscriber     | https://i.pravatar.cc/300?img=32     |
+| davi.cursos        | Davi Cursos           | davi.cursos@example.com            | subscriber     | https://i.pravatar.cc/300?img=38     |
+| edu.livros         | Edu Livros            | edu.livros@example.com             | subscriber     | https://i.pravatar.cc/300?img=54     |
+| fernanda.office    | Fernanda Office       | fernanda.office@example.com        | subscriber     | https://i.pravatar.cc/300?img=68     |
+| gustavo.games      | Gustavo Games         | gustavo.games@example.com          | subscriber     | https://i.pravatar.cc/300?img=23     |
+| helena.segura      | Helena Segura         | helena.segura@example.com          | subscriber     | https://i.pravatar.cc/300?img=9      |
+| igor.ai            | Igor AI               | igor.ai@example.com                | subscriber     | https://i.pravatar.cc/300?img=5      |
+| juliana.boloes     | Juliana Bolões        | juliana.boloes@example.com         | subscriber     | https://i.pravatar.cc/300?img=61     |
+
+Caso um desses logins já exista no ambiente, o semeador preserva a conta original e apenas reutiliza o ID ao criar os grupos.
+
+## Grupos criados
+
+| Serviço/Grupo                     | Categoria          | Responsável         |
+| --------------------------------- | ------------------ | ------------------- |
+| YouTube Premium Família           | Vídeo e streaming  | ana.streaming       |
+| MUBI Cinemateca                   | Vídeo e streaming  | carla.series        |
+| NBA League Pass Squad             | Jogos e esportes   | gustavo.games       |
+| PlayPlus Família                  | Vídeo e streaming  | (usuário atual ou demo.superadmin) |
+| Spotify Premium Família           | Música e áudio     | bruno.sound         |
+| Tidal HiFi Max Collective         | Música e áudio     | bruno.sound         |
+| Brainly Premium Squad             | Cursos e educação  | davi.cursos         |
+| Ubook Audiobooks Club             | Leitura e revistas | edu.livros          |
+| Super Interessante Digital        | Leitura e revistas | edu.livros          |
+| Veja Saúde Coletivo               | Leitura e revistas | edu.livros          |
+| Perplexity Pro Research Hub       | Ferramentas de IA  | igor.ai             |
+| Canva Pro Studios                 | Escritório         | fernanda.office     |
+| Google One 2TB Compartilhado      | Escritório         | fernanda.office     |
+| ExpressVPN Global Access          | Segurança & VPN    | helena.segura       |
+| Bolão Mega da Virada 2024         | Bolões e rifas     | juliana.boloes      |
+
+Todos os grupos são públicos e utilizam os mesmos campos, regras e descrições vistos nas telas de referência. Alguns registros ficam com status **Em análise** para validar o fluxo de aprovação manual do super administrador.
+
+## Como usar
+
+1. Acesse **JuntaPlay → Importar & Gerar Páginas** no painel do WordPress.
+2. Clique em **Criar dados de demonstração** e confirme a ação.
+3. Verifique o aviso verde com o total de usuários e grupos criados. A senha padrão é exibida junto com a mensagem de sucesso.
+
+Você pode executar o semeador novamente: contas ou grupos já existentes serão ignorados para evitar duplicidade. Para ambientes de produção, recomenda-se remover os dados de teste manualmente após a validação.
+
+### Sobre a capa de demonstração
+
+- O semeador não inclui imagens binárias no repositório. Em vez disso, ele gera dinamicamente uma arte 495×370 px usando a biblioteca GD e a envia para a pasta de uploads como anexo de mídia quando a ação é executada.
+- Caso a geração falhe (por exemplo, se a extensão GD estiver desativada), o plugin utiliza o placeholder SVG embutido (`JP_GROUP_COVER_PLACEHOLDER`) para manter a consistência visual nos cards e formulários dos grupos.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,126 @@
+# JuntaPlay
+
+## 1. Mapa Mental
+
+- **Frontend**
+- Home / Lista de Campanhas (cotas)
+- Página da Campanha (detalhes + seletor de cotas)
+- Rotador de Grupos (cards 495x370 em destaque na home)
+- Carrinho & Checkout (WooCommerce)
+- Painel do Usuário (pós-login)
+- Perfil do Usuário (edição)
+- Créditos & Carteira (saldo, bônus, recargas)
+- Dados Fiscais (PF/PJ e faturamento)
+- Segurança da Conta (senha, 2FA, sessões ativas)
+- Meus Grupos (campanhas criadas ou participações)
+- Dúvidas frequentes e bloco de compartilhamento nos grupos
+- Minhas Cotas (painel do cliente)
+- Extrato de Pedido (detalhes de pagamento e cotas)
+- Confirmação & E-mails transacionais
+- **Backend (WP Admin + páginas utilitárias)**
+  - Dashboard JuntaPlay
+  - Campanhas (CRUD)
+  - Importar CSV (campanhas/cotas)
+  - Gerar Páginas (instalador de shortcodes)
+  - Grupos (aprovação e auditoria)
+  - Configurações (Gerais, Pagamentos, E-mail/SMTP, Reservas)
+- **Núcleo**
+  - Tabelas: `jp_pools`, `jp_quotas`
+  - Estados: disponível, reservado, pago, cancelado, expirado
+  - Reserva temporária, expiração via WP-Cron
+  - API REST/AJAX
+  - Cache / transients
+- **Integrações**
+  - WooCommerce (validação e baixa de cotas)
+  - Elementor (widgets)
+  - SMTP (phpmailer_init)
+- **Segurança & Compliance**
+  - Nonces, capabilities, prepared statements
+  - Logs e trilhas
+  - LGPD/Consentimento
+- **Desempenho**
+  - Índices SQL, paginação, lazy loading
+  - Cache de disponibilidade
+  - CSS utilitário
+
+## 2. Organograma
+
+- **Produto/Negócio**
+  - Product Owner
+  - Atendimento/Operações
+- **Tecnologia**
+  - Tech Lead WP/PHP
+  - Dev Backend (plugin + hooks Woo)
+  - Dev Frontend (Elementor, CSS, shortcodes)
+  - QA (funcional e carga)
+- **Financeiro**
+  - Conciliação de pagamentos
+  - Reembolsos/cancelamentos
+- **Marketing**
+  - SEO/Analytics
+  - E-mail marketing
+
+## 3. Arquitetura Técnica
+
+### 3.1 Entidades
+
+- `jp_pools`: metadados das campanhas.
+- `jp_quotas`: números de cotas com status e vínculo a usuários/pedidos.
+- `jp_groups`: grupos criados por usuários para organizar compras coletivas.
+- `jp_group_members`: associação usuário ↔ grupo com papéis e status.
+- `jp_group_complaints`: protocolos de reclamação com motivo, anexos, status e vínculo opcional ao pedido WooCommerce.
+- *Dados de demonstração*: o botão "Criar dados de demonstração" no painel gera usuários fictícios e grupos populares (YouTube Premium, Mubi, NBA League Pass, Spotify, Brainly, Canva, ExpressVPN, entre outros) para acelerar testes de busca, aprovação e notificações.
+
+### 3.2 Fluxos
+
+1. Reserva atômica via `UPDATE ... WHERE status='available'` + `reserved_until`.
+2. Expiração automática via cron liberando cotas reservadas expiradas.
+3. Checkout: revalidação, marcação como pagas e liberação em cancelamentos.
+4. Grupos: solicitação entra como `pending`, dispara alerta para o super admin, aprovação/rejeição via painel altera para `approved|rejected|archived` e dispara e-mail ao criador (com observação quando houver motivo). Cada grupo requer uma capa 495x370 enviada pelo criador (obrigatória no formulário de criação, com seletor de mídia e aviso quando o placeholder estiver ativo), usada na vitrine interna e no rotador público de destaques. O criador e o administrador recebem um resumo completo com categoria, status de acesso instantâneo, valores promocionais e regras cadastradas. No painel do usuário cada grupo apresenta resumo financeiro (total da inscrição e aviso sobre caução bloqueada), vitrine de participantes, bloco de compartilhamento com cópia rápida e uma FAQ contextual que reforça os meios de pagamento habilitados no WooCommerce.
+   - Assim que o grupo é enviado, o dono recebe **dois e-mails automáticos**: um resumo detalhado com todos os campos preenchidos e um **código de validação de e-mail** (6 dígitos) que fica registrado na tabela `jp_groups` (`email_validation_hash`, `email_validation_sent_at`).
+   - Ao aprovar, recusar ou arquivar, o sistema envia mensagens com cabeçalho em texto plano UTF-8 e link direto para o painel/perfil para que o criador libere o grupo.
+5. E-mails transacionais disparados após confirmação ou expiração.
+6. Reclamações: o painel "Meus Grupos" oferece formulário com upload de evidências, grava registros em `jp_group_complaints`, atualiza o cartão do grupo com status/histórico e dispara alertas para o admin e para o cliente.
+
+### 3.3 Páginas & Shortcodes
+
+| Página / Área | Shortcode |
+| ------------- | --------- |
+| Campanhas | `[juntaplay_pools]` |
+| Detalhe da Campanha | `[juntaplay_pool id="{pool_id}"]` |
+| Seletor de Cotas | `[juntaplay_quota_selector id="{pool_id}" per_page="100"]` |
+| Dashboard do Cliente | `[juntaplay_dashboard]` |
+| Minhas Cotas | `[juntaplay_my_quotas]` |
+| Extrato de Pedido | `[juntaplay_statement order_id=""]` |
+| Perfil do Usuário | `[juntaplay_profile]` |
+| Diretório de Grupos | `[juntaplay_groups]` |
+| Busca hero de Grupos | `[juntaplay_group_search]` |
+| Rotador de Grupos | `[juntaplay_group_rotator limit="12" category=""]` |
+| Entrar / Criar Conta | `[juntaplay_login_form]` |
+| Desafio 2FA | `[juntaplay_two_factor]` |
+| Termos & Regras | `[juntaplay_terms]` |
+| Painel Operacional | `[juntaplay_admin]` |
+
+> O perfil reúne os blocos de **contato**, **créditos e carteira** (saldo disponível, reservas, bônus, recarga automática e chave Pix), **dados fiscais** (CPF/CNPJ, razão social, inscrição estadual e endereço de faturamento), **meus grupos** (listagem de bolões criados ou ingressados, pedidos pendentes e criação de novos grupos públicos) e a aba de **segurança** (alteração de senha, 2FA, alertas e sessões) com validação e máscaras de exibição inspiradas no Freeio.
+> O módulo de **Créditos e Carteira** ganhou um modal de recarga compatível com o WooCommerce: o shortcode cria um produto virtual `juntaplay_credit_topup`, envia o usuário direto para o checkout (Pix/cartão/boleto) e, ao confirmar o pagamento, registra o crédito na tabela `jp_credit_transactions`, atualiza o saldo/meta-dados e dispara notificações/e-mails; cancelamentos ou estornos fazem o ajuste inverso automaticamente.
+> O criador de grupos coleta o nome do serviço, URL oficial, regras principais, preço cheio e promocional, divisão sugerida por membro, vagas totais/reservadas, canal de suporte, prazo de entrega e formato de acesso — além de selecionar uma **categoria** do catálogo sugerido e indicar se o grupo terá **acesso instantâneo** após a aprovação. Uma prévia dinâmica de compartilhamento monta o texto de convite com todos os campos preenchidos e permite copiar o resumo para divulgar em redes sociais ou mensageiros, enquanto cartões de inspiração preenchem rapidamente o formulário com serviços populares. O cartão exibe ainda um bloco “Precisa de ajuda?” com contador de protocolos, FAQ específica e formulário de reclamação (com upload de prints/PDF) que alimenta `jp_group_complaints` e envia notificações imediatas para o super admin e para o participante.
+
+As categorias padrão cobrem **Bolões**, **Vídeo**, **Música**, **Cursos**, **Leitura**, **Escritório**, **Jogos/Esportes**, **Ferramentas de IA**, **Segurança/VPN**, além de lifestyle, marketplace e a opção genérica de outros serviços. Os cards de inspiração incluem serviços como YouTube Premium, Mubi, NBA League Pass, PlayPlus, Spotify, Tidal, Brainly Premium, Ubook, Super Interessante, Veja Saúde, Perplexity Pro, Canva, Google One, ExpressVPN e o Bolão Mega da Virada.
+
+### 3.4 Widgets Elementor
+
+- Lista de Campanhas
+- Hero da Campanha
+- Seletor de Cotas
+- Contador / Progresso (futuro)
+- Mural de Ganhadores (futuro)
+
+## 4. Roadmap
+
+1. Base do plugin (bootstrap, tabelas, shortcodes, instalador de páginas).
+2. Integração WooCommerce (produto custom, hooks de reserva/pagamento).
+3. Widgets Elementor.
+4. Importador CSV e gerador de páginas.
+5. SMTP & e-mails.
+6. CSS de identidade visual.
+7. QA e Go-live (testes de carga, sandbox, compliance LGPD).

--- a/juntaplay/assets/css/juntaplay.css
+++ b/juntaplay/assets/css/juntaplay.css
@@ -1,0 +1,4549 @@
+@import url("https://fonts.googleapis.com/css2?family=Figtree:wght@300;400;500;600;700&family=Fredoka:wght@400;500;600;700&display=swap");
+
+:root {
+    --jp-primary: #ff5a5f;
+    --jp-primary-dark: #e0494d;
+    --jp-primary-light: #ffe4e5;
+    --jp-primary-contrast: #ffffff;
+    --jp-surface: #ffffff;
+    --jp-border: #e6eaef;
+    --jp-text: #1f2933;
+    --jp-muted: #6b7280;
+    --jp-radius: 18px;
+    --jp-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    --jp-danger: #dc2626;
+    --jp-danger-dark: #b91c1c;
+    --jp-danger-light: #fee2e2;
+}
+
+@keyframes juntaplay-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+body .juntaplay-section,
+body .juntaplay-pool-list,
+body .juntaplay-pool-single,
+body .juntaplay-quota-selector,
+body .juntaplay-my-quotas,
+body .juntaplay-auth,
+body .juntaplay-dashboard,
+body .juntaplay-profile,
+body .juntaplay-groups-directory,
+body .juntaplay-group-search-hero,
+body .juntaplay-statement,
+body .juntaplay-credit-history,
+body .juntaplay-notifications-panel {
+    font-family: "Figtree", "Fredoka", "Segoe UI", sans-serif;
+    color: var(--jp-text);
+    font-weight: 400;
+}
+
+body .juntaplay-section h1,
+body .juntaplay-section h2,
+body .juntaplay-section h3,
+body .juntaplay-section h4,
+body .juntaplay-section h5,
+body .juntaplay-section h6,
+body .juntaplay-dashboard h1,
+body .juntaplay-dashboard h2,
+body .juntaplay-dashboard h3,
+body .juntaplay-dashboard h4,
+body .juntaplay-dashboard h5,
+body .juntaplay-dashboard h6,
+body .juntaplay-profile h1,
+body .juntaplay-profile h2,
+body .juntaplay-profile h3,
+body .juntaplay-profile h4,
+body .juntaplay-profile h5,
+body .juntaplay-profile h6,
+body .juntaplay-groups-directory h1,
+body .juntaplay-groups-directory h2,
+body .juntaplay-groups-directory h3,
+body .juntaplay-groups-directory h4,
+body .juntaplay-groups-directory h5,
+body .juntaplay-groups-directory h6,
+body .juntaplay-group-search-hero h1,
+body .juntaplay-group-search-hero h2,
+body .juntaplay-group-search-hero h3,
+body .juntaplay-group-search-hero h4,
+body .juntaplay-group-search-hero h5,
+body .juntaplay-group-search-hero h6,
+body .juntaplay-auth h1,
+body .juntaplay-auth h2,
+body .juntaplay-auth h3,
+body .juntaplay-auth h4,
+body .juntaplay-auth h5,
+body .juntaplay-auth h6 {
+    font-family: "Fredoka", "Figtree", "Segoe UI", sans-serif;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+body .juntaplay-section strong,
+body .juntaplay-dashboard .stat-value,
+body .juntaplay-dashboard .card-title,
+body .juntaplay-profile .jp-section-title,
+body .juntaplay-groups-directory .group-card-title,
+body .juntaplay-group-search-hero .hero-title,
+body .juntaplay-credit-history .jp-balance-amount,
+body .juntaplay-notifications-panel .jp-notification-title {
+    font-family: "Fredoka", "Figtree", "Segoe UI", sans-serif;
+    font-weight: 600;
+}
+
+body .juntaplay-section .jp-pill,
+body .juntaplay-section .jp-badge,
+body .juntaplay-section .jp-button,
+body .juntaplay-section .jp-button-secondary,
+body .juntaplay-section .jp-button-ghost,
+body .juntaplay-section .jp-chip,
+body .juntaplay-profile .jp-tab-button,
+body .juntaplay-profile .jp-input label,
+body .juntaplay-profile .jp-select label,
+body .juntaplay-profile .jp-toggle label,
+body .juntaplay-profile .jp-section-subtitle,
+body .juntaplay-groups-directory .group-card-meta,
+body .juntaplay-groups-directory .group-card-actions,
+body .juntaplay-quota-selector .jp-quota-stats-label,
+body .juntaplay-quota-selector .jp-quota-pill,
+body .juntaplay-auth .jp-auth-switch,
+body .juntaplay-auth .jp-auth-social button,
+body .juntaplay-auth .jp-auth-submit,
+body .juntaplay-dashboard .jp-nav-card-title {
+    font-family: "Fredoka", "Figtree", "Segoe UI", sans-serif;
+    font-weight: 500;
+}
+
+body .juntaplay-auth {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - 120px);
+    padding: 4rem 1.5rem;
+    background: linear-gradient(135deg, #f6f8fb 0%, #ffffff 40%, #f6f8fb 100%);
+}
+
+body .juntaplay-auth__container {
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    gap: 3rem;
+    max-width: 1080px;
+    width: 100%;
+    align-items: center;
+}
+
+body .juntaplay-auth__intro {
+    color: var(--jp-text);
+}
+
+body .juntaplay-auth__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+body .juntaplay-auth__intro h1 {
+    font-size: clamp(2rem, 2.6vw + 1rem, 2.9rem);
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+}
+
+body .juntaplay-auth__intro p {
+    font-size: 1.05rem;
+    max-width: 420px;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-auth__card {
+    background: #ffffff;
+    border-radius: 24px;
+    border: 1px solid #e2e8f4;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
+    padding: 2.25rem 2.5rem;
+}
+
+body .juntaplay-auth__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    margin-bottom: 1.75rem;
+}
+
+body .juntaplay-auth__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--jp-text);
+}
+
+body .juntaplay-auth__switch {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem;
+    border-radius: 999px;
+    background: #f4f6fb;
+    border: 1px solid #e2e8f4;
+    gap: 0.35rem;
+}
+
+body .juntaplay-auth__switch-btn {
+    border: 0;
+    background: transparent;
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.5rem 1.15rem;
+    border-radius: 999px;
+    color: var(--jp-muted);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body .juntaplay-auth__switch-btn.is-active {
+    background: var(--jp-primary);
+    color: var(--jp-primary-contrast);
+    box-shadow: 0 12px 25px rgba(255, 90, 95, 0.25);
+}
+
+body .juntaplay-auth__switch-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+body .juntaplay-auth__social {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+}
+
+body .juntaplay-auth__social-integrations > * {
+    margin-bottom: 0 !important;
+}
+
+body .juntaplay-auth__social-integrations .nsl-container .nsl-button {
+    width: 100%;
+    border-radius: 12px;
+}
+
+body .juntaplay-auth__social-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+body .juntaplay-auth__social-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid #dce3ef;
+    background: #f8fbff;
+    color: #1f2933;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body .juntaplay-auth__social-btn[aria-disabled="true"] {
+    cursor: default;
+}
+
+body .juntaplay-auth__social-btn:hover,
+body .juntaplay-auth__social-btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 35px rgba(15, 23, 42, 0.12);
+}
+
+body .juntaplay-auth__social-btn--facebook {
+    background: #f3f6ff;
+    border-color: rgba(59, 89, 152, 0.12);
+    color: #3b5998;
+}
+
+body .juntaplay-auth__social-btn--google {
+    background: #fef6f6;
+    border-color: rgba(234, 67, 53, 0.12);
+    color: #ea4335;
+}
+
+body .juntaplay-auth__form {
+    display: grid;
+    gap: 1.25rem;
+}
+
+body .juntaplay-auth__alert {
+    padding: 1rem 1.25rem;
+    border-radius: 14px;
+    border: 1px solid rgba(234, 67, 53, 0.2);
+    background: rgba(234, 67, 53, 0.08);
+    color: #b42318;
+    font-size: 0.9rem;
+}
+
+body .juntaplay-auth__alert ul {
+    margin: 0;
+    padding-left: 1.1rem;
+}
+
+body .juntaplay-auth__field label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-auth__field input[type='text'],
+body .juntaplay-auth__field input[type='password'],
+body .juntaplay-auth__field input[type='email'] {
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid #d4dbe8;
+    padding: 0.85rem 1rem;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    background: #f8fafc;
+}
+
+body .juntaplay-auth__field input[type='text']:focus,
+body .juntaplay-auth__field input[type='password']:focus,
+body .juntaplay-auth__field input[type='email']:focus {
+    outline: none;
+    border-color: var(--jp-primary);
+    box-shadow: 0 0 0 3px rgba(255, 90, 95, 0.2);
+    background: #fff;
+}
+
+body .juntaplay-auth__meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.95rem;
+}
+
+body .juntaplay-auth__remember {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: var(--jp-text);
+}
+
+body .juntaplay-auth__remember input {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 4px;
+}
+
+body .juntaplay-auth__forgot {
+    color: var(--jp-primary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+body .juntaplay-auth__forgot:hover,
+body .juntaplay-auth__forgot:focus {
+    text-decoration: underline;
+    color: var(--jp-primary-dark);
+}
+
+body .juntaplay-auth__submit {
+    width: 100%;
+    justify-content: center;
+    font-size: 1.05rem;
+    padding: 0.85rem 1.5rem;
+}
+
+body .juntaplay-auth__divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.75rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-auth__divider::before,
+body .juntaplay-auth__divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e2e8f4;
+}
+
+body .juntaplay-auth__panes {
+    position: relative;
+}
+
+body .juntaplay-auth__pane {
+    display: none;
+    animation: juntaplay-fade-in 0.25s ease;
+}
+
+body .juntaplay-auth__pane.is-active {
+    display: block;
+}
+
+body .juntaplay-auth__meta--terms {
+    align-items: flex-start;
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+body .juntaplay-auth__meta--terms .juntaplay-auth__remember {
+    align-items: flex-start;
+}
+
+body .juntaplay-auth__meta--terms input[type='checkbox'] {
+    margin-top: 0.2rem;
+}
+
+body .juntaplay-auth__footer {
+    margin-top: 1.75rem;
+    font-size: 0.95rem;
+    color: var(--jp-muted);
+    text-align: center;
+}
+
+body .juntaplay-auth__footer .juntaplay-link {
+    font-weight: 600;
+    margin-left: 0.35rem;
+}
+
+@media (max-width: 960px) {
+    body .juntaplay-auth {
+        padding-top: 3rem;
+        padding-bottom: 3rem;
+    }
+
+    body .juntaplay-auth__container {
+        grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+
+    body .juntaplay-auth__intro {
+        text-align: center;
+    }
+
+    body .juntaplay-auth__intro p {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    body .juntaplay-auth__header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    body .juntaplay-auth__switch {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
+@media (max-width: 600px) {
+    body .juntaplay-auth__card {
+        padding: 1.75rem 1.5rem;
+    }
+
+    body .juntaplay-auth__meta {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    body .juntaplay-auth__forgot {
+        align-self: flex-end;
+    }
+
+    body .juntaplay-auth__switch {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    body .juntaplay-auth__switch-btn {
+        flex: 1 1 auto;
+        text-align: center;
+    }
+
+    body .juntaplay-auth__social-list {
+        grid-template-columns: 1fr;
+    }
+}
+
+body .juntaplay-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+body .juntaplay-card,
+body .juntaplay-grid__item-wrapper {
+    position: relative;
+    background: var(--jp-surface);
+    border: 1px solid var(--jp-border);
+    border-radius: var(--jp-radius);
+    padding: 1.75rem;
+    box-shadow: var(--jp-shadow);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+body .juntaplay-card:hover,
+body .juntaplay-grid__item-wrapper:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
+}
+
+body .juntaplay-card h1,
+body .juntaplay-card h2,
+body .juntaplay-card h3 {
+    color: var(--jp-text);
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+body .juntaplay-card__price {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--jp-primary);
+}
+
+body .juntaplay-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+    margin-top: 1.25rem;
+    align-items: center;
+}
+
+body .juntaplay-progress {
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: #f4f6fb;
+    overflow: hidden;
+    position: relative;
+}
+
+body .juntaplay-progress__bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(135deg, var(--jp-primary), var(--jp-primary-dark));
+}
+
+body .juntaplay-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    color: var(--jp-primary-dark);
+    background: var(--jp-primary-light);
+}
+
+body .juntaplay-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.75rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    transition: all 0.25s ease;
+    text-decoration: none;
+}
+
+body .juntaplay-button--primary {
+    background: var(--jp-primary);
+    border-color: var(--jp-primary);
+    color: var(--jp-primary-contrast);
+    box-shadow: 0 10px 25px rgba(255, 90, 95, 0.35);
+}
+
+body .juntaplay-button--primary:hover,
+body .juntaplay-button--primary:focus {
+    background: var(--jp-primary-dark);
+    border-color: var(--jp-primary-dark);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px rgba(255, 90, 95, 0.4);
+}
+
+body .juntaplay-button--danger {
+    background: var(--jp-danger);
+    border-color: var(--jp-danger);
+    color: #fff;
+    box-shadow: 0 10px 25px rgba(220, 38, 38, 0.28);
+}
+
+body .juntaplay-button--danger:hover,
+body .juntaplay-button--danger:focus {
+    background: var(--jp-danger-dark);
+    border-color: var(--jp-danger-dark);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 16px 36px rgba(185, 28, 28, 0.32);
+}
+
+body .juntaplay-card__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    margin-top: 1rem;
+    padding: 0;
+    list-style: none;
+}
+
+body .juntaplay-card__stats li {
+    font-size: 0.875rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-card__stats strong {
+    display: block;
+    font-size: 1.05rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-grid--quotas {
+    gap: 0.75rem;
+}
+
+body .juntaplay-grid__item {
+    padding: 1rem;
+    border-radius: 14px;
+    border: 1px solid var(--jp-border);
+    background: #f8fafc;
+    font-weight: 600;
+    color: var(--jp-text);
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: inset 0 0 0 1px transparent;
+}
+
+body .juntaplay-grid__item small {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--jp-muted);
+    margin-top: 0.35rem;
+    text-transform: capitalize;
+}
+
+body .juntaplay-grid__item.is-selected {
+    background: var(--jp-primary-light);
+    border-color: var(--jp-primary);
+    box-shadow: inset 0 0 0 1px var(--jp-primary);
+}
+
+body .juntaplay-grid__item.is-disabled {
+    background: #f1f5f9;
+    color: #9ca3af;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+body .juntaplay-grid__item.is-disabled small {
+    color: #c4cdd5;
+}
+
+body .juntaplay-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem 2.5rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+body .juntaplay-summary__item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+body .juntaplay-summary__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-summary__value {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-summary__legend {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-summary__legend::before {
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: currentColor;
+}
+
+body .juntaplay-selected {
+    margin-top: 1.75rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: var(--jp-radius);
+    border: 1px dashed var(--jp-border);
+    background: #fcfdff;
+    display: grid;
+    gap: 1rem;
+}
+
+body .juntaplay-selected__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+body .juntaplay-selected__header strong {
+    font-size: 1rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-selected__count-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+body .juntaplay-selected__numbers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    min-height: 2rem;
+}
+
+body .juntaplay-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+body .juntaplay-selected__empty {
+    font-size: 0.875rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-selected__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-selected__total-label {
+    font-size: 0.875rem;
+    color: var(--jp-muted);
+    font-weight: 500;
+}
+
+body .juntaplay-my-quotas table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--jp-surface);
+    border-radius: var(--jp-radius);
+    overflow: hidden;
+    box-shadow: var(--jp-shadow);
+}
+
+body .juntaplay-my-quotas thead {
+    background: linear-gradient(135deg, var(--jp-primary), var(--jp-primary-dark));
+    color: var(--jp-primary-contrast);
+}
+
+body .juntaplay-my-quotas th,
+body .juntaplay-my-quotas td {
+    padding: 1rem 1.25rem;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+body .juntaplay-my-quotas tbody tr:nth-child(even) {
+    background: #f9fbfd;
+}
+
+body .juntaplay-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    text-transform: capitalize;
+}
+
+body .juntaplay-status--paid {
+    background: #dcfce7;
+    color: #166534;
+}
+
+body .juntaplay-status--reserved {
+    background: #fef9c3;
+    color: #92400e;
+}
+
+body .juntaplay-status--available {
+    background: #e0f2fe;
+    color: #075985;
+}
+
+body .juntaplay-status--canceled,
+body .juntaplay-status--expired {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+body .juntaplay-link {
+    color: var(--jp-primary);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+body .juntaplay-table-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+}
+
+body .juntaplay-link:hover,
+body .juntaplay-link:focus {
+    color: var(--jp-primary-dark);
+    text-decoration: underline;
+}
+
+body .juntaplay-notice {
+    padding: 1rem 1.5rem;
+    border-left: 4px solid var(--jp-primary);
+    background: #fff7f7;
+    border-radius: 12px;
+    color: var(--jp-text);
+}
+
+body .juntaplay-alert {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1.25rem;
+    border-radius: 14px;
+    font-weight: 500;
+    border: 1px solid transparent;
+}
+
+body .juntaplay-alert--success {
+    background: #ecfdf3;
+    border-color: #bbf7d0;
+    color: #166534;
+}
+
+body .juntaplay-alert--error {
+    background: #fef2f2;
+    border-color: #fecaca;
+    color: #991b1b;
+}
+
+body .juntaplay-statement {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+body .juntaplay-statement__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+body .juntaplay-statement__eyebrow {
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--jp-muted);
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+}
+
+body .juntaplay-statement__header h1 {
+    font-size: clamp(2rem, 2.8vw, 2.5rem);
+    margin: 0;
+}
+
+body .juntaplay-statement__header-meta {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    font-size: 0.875rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-statement__header-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+body .juntaplay-statement__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    gap: 1.75rem;
+}
+
+body .juntaplay-statement__card .juntaplay-card__body {
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+}
+
+body .juntaplay-statement__card .juntaplay-card__footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: flex-start;
+}
+
+body .juntaplay-statement__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+body .juntaplay-statement__list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    font-size: 0.95rem;
+}
+
+body .juntaplay-statement__label {
+    color: var(--jp-muted);
+    font-weight: 500;
+}
+
+body .juntaplay-statement__value {
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-statement__value--total {
+    font-size: 1.35rem;
+    color: var(--jp-primary-dark);
+}
+
+body .juntaplay-statement__details {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+body .juntaplay-statement__details .juntaplay-card__header {
+    align-items: center;
+}
+
+body .juntaplay-statement__details .juntaplay-card__meta {
+    margin-top: 0.35rem;
+}
+
+body .juntaplay-statement__numbers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+body .juntaplay-bubble {
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    padding: 0.75rem 1rem;
+    border-radius: 999px;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+body .juntaplay-bubble strong {
+    font-size: 1.05rem;
+    line-height: 1.2;
+}
+
+body .juntaplay-bubble small {
+    margin-top: 0.3rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+@media (max-width: 1024px) {
+    body .juntaplay-grid {
+        gap: 1rem;
+    }
+
+    body .juntaplay-card,
+    body .juntaplay-grid__item-wrapper {
+        padding: 1.5rem;
+    }
+
+    body .juntaplay-statement__grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    body .juntaplay-card,
+    body .juntaplay-grid__item-wrapper {
+        padding: 1.25rem;
+    }
+
+    body .juntaplay-summary {
+        gap: 1rem 1.5rem;
+    }
+
+    body .juntaplay-selected__header,
+    body .juntaplay-selected__footer {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    body .juntaplay-statement__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    body .juntaplay-statement__card .juntaplay-card__footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    body .juntaplay-my-quotas th,
+    body .juntaplay-my-quotas td {
+        padding: 0.75rem 1rem;
+    }
+}
+
+@media (max-width: 600px) {
+    body .juntaplay-grid--quotas {
+        grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+    }
+
+    body .juntaplay-bubble {
+        min-width: 64px;
+        padding: 0.6rem 0.75rem;
+    }
+
+    body .juntaplay-my-quotas table,
+    body .juntaplay-my-quotas thead,
+    body .juntaplay-my-quotas tbody,
+    body .juntaplay-my-quotas th,
+    body .juntaplay-my-quotas td,
+    body .juntaplay-my-quotas tr {
+        display: block;
+    }
+
+    body .juntaplay-my-quotas thead tr {
+        position: absolute;
+        left: -9999px;
+        top: -9999px;
+    }
+
+    body .juntaplay-my-quotas tr {
+        margin-bottom: 1.25rem;
+        border: 1px solid var(--jp-border);
+        border-radius: var(--jp-radius);
+        overflow: hidden;
+    }
+
+    body .juntaplay-my-quotas td {
+        border-bottom: 1px solid var(--jp-border);
+        position: relative;
+        padding-left: 50%;
+    }
+
+    body .juntaplay-my-quotas td:last-child {
+        border-bottom: 0;
+    }
+
+    body .juntaplay-my-quotas td::before {
+        content: attr(data-label);
+        position: absolute;
+        left: 1rem;
+        top: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.06em;
+        color: var(--jp-muted);
+    }
+}
+
+body .juntaplay-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 2.75rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+    gap: 2.5rem;
+    padding: 2.75rem 3rem;
+    background: linear-gradient(135deg, rgba(255, 90, 95, 0.08) 0%, rgba(255, 255, 255, 0.92) 65%, rgba(255, 90, 95, 0.1) 100%);
+    border-radius: calc(var(--jp-radius) + 4px);
+    box-shadow: var(--jp-shadow);
+    align-items: center;
+}
+
+body .juntaplay-dashboard__hero-copy h1 {
+    font-size: clamp(1.75rem, 2.5vw + 1rem, 2.65rem);
+    margin-bottom: 0.75rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__lead {
+    font-size: 1.05rem;
+    margin-bottom: 0.75rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__sub {
+    color: var(--jp-text);
+    margin-bottom: 1.25rem;
+}
+
+body .juntaplay-dashboard__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    font-weight: 600;
+    margin-bottom: 1rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+}
+
+body .juntaplay-dashboard__cta {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+body .juntaplay-dashboard__hero-card {
+    background: #fff;
+    border-radius: calc(var(--jp-radius) + 12px);
+    padding: 2.5rem 2rem;
+    box-shadow: var(--jp-shadow);
+    text-align: center;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__hero-card p {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__hero-value {
+    font-size: 3rem;
+    font-weight: 800;
+    color: var(--jp-primary);
+    margin-bottom: 0.75rem;
+}
+
+body .juntaplay-dashboard__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+body .juntaplay-dashboard__nav {
+    margin-top: 2.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+body .juntaplay-dashboard__nav-card {
+    background: #fff;
+    border-radius: calc(var(--jp-radius) + 8px);
+    box-shadow: var(--jp-shadow);
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+body .juntaplay-dashboard__nav-card header h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1.2rem;
+}
+
+body .juntaplay-dashboard__nav-card header p {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__nav-card ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+body .juntaplay-dashboard__nav-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: #f8fafc;
+    border-radius: calc(var(--jp-radius) + 2px);
+    padding: 1rem 1.1rem;
+    color: inherit;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+body .juntaplay-dashboard__nav-link:hover,
+body .juntaplay-dashboard__nav-link:focus {
+    transform: translateY(-2px);
+    background: #fff;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+body .juntaplay-dashboard__nav-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+body .juntaplay-dashboard__nav-copy strong {
+    font-size: 1rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__nav-copy small {
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+
+body .juntaplay-dashboard__nav-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 12px;
+    background: rgba(255, 90, 95, 0.12);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--jp-primary);
+    flex-shrink: 0;
+    position: relative;
+}
+
+body .juntaplay-dashboard__nav-icon::before {
+    content: '';
+    display: block;
+    width: 18px;
+    height: 18px;
+    mask-size: contain;
+    mask-position: center;
+    mask-repeat: no-repeat;
+    background: currentColor;
+}
+
+body .juntaplay-dashboard__nav-icon--user-circle::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M12 12.75a5 5 0 1 0-5-5a5 5 0 0 0 5 5Zm0 1.5c-3.31 0-9 1.66-9 4.97V21a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1v-1.78c0-3.31-5.69-4.97-9-4.97Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--map::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M9 3L4 5v16l5-2.18L15 21l5-2V3l-5 2.18Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--shield::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M12 2L4 5v6c0 5.55 3.84 10.74 8 12c4.16-1.26 8-6.45 8-12V5Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--bell::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M18 16v-5a6 6 0 0 0-5-5.91V4a1 1 0 0 0-2 0v1.09A6 6 0 0 0 6 11v5l-2 2v1h16v-1Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--receipt::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M6 2a1 1 0 0 0-1 1v18l3-1.5l3 1.5l3-1.5l3 1.5l3-1.5l3 1.5V3a1 1 0 0 0-1-1Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--document::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--card::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 4H4V6h16Zm0 4H4v4h16Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-icon--ticket::before {
+    mask-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill="%23000" d="M21 5H3a1 1 0 0 0-1 1v3a2 2 0 0 1 0 4v3a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1v-3a2 2 0 0 1 0-4V6a1 1 0 0 0-1-1Z"/%3E%3C/svg%3E');
+}
+
+body .juntaplay-dashboard__nav-arrow {
+    margin-left: auto;
+    color: var(--jp-muted);
+    display: inline-flex;
+    align-items: center;
+}
+
+body .juntaplay-dashboard__nav-arrow svg {
+    display: block;
+}
+
+body .juntaplay-dashboard__stat {
+    background: #fff;
+    border-radius: calc(var(--jp-radius) + 8px);
+    padding: 1.75rem;
+    box-shadow: var(--jp-shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+body .juntaplay-dashboard__stat-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--jp-muted);
+    font-weight: 600;
+}
+
+body .juntaplay-dashboard__stat-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__stat-value--currency {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+}
+
+body .juntaplay-dashboard__stat-caption {
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+
+body .juntaplay-dashboard__stat--highlight {
+    background: linear-gradient(135deg, rgba(255, 90, 95, 0.12) 0%, rgba(255, 255, 255, 0.9) 100%);
+}
+
+body .juntaplay-dashboard__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+body .juntaplay-dashboard__action {
+    flex: 1 1 220px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem;
+    background: #fff;
+    border-radius: calc(var(--jp-radius) + 6px);
+    box-shadow: var(--jp-shadow);
+    color: var(--jp-text);
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body .juntaplay-dashboard__action:hover,
+body .juntaplay-dashboard__action:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.12);
+    color: var(--jp-primary-dark);
+}
+
+body .juntaplay-dashboard__panel {
+    background: #fff;
+    border-radius: calc(var(--jp-radius) + 8px);
+    padding: 2rem;
+    box-shadow: var(--jp-shadow);
+}
+
+body .juntaplay-dashboard__panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+    margin-bottom: 1.75rem;
+}
+
+body .juntaplay-dashboard__panel-header h2 {
+    margin: 0 0 0.35rem;
+    font-size: 1.35rem;
+}
+
+body .juntaplay-dashboard__panel-header p {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+body .juntaplay-dashboard__card {
+    background: #f8fafc;
+    border-radius: calc(var(--jp-radius) + 4px);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 100%;
+}
+
+body .juntaplay-dashboard__card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+body .juntaplay-dashboard__card h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+body .juntaplay-dashboard__card-price {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__metrics {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+body .juntaplay-dashboard__metrics span {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__metrics strong {
+    font-size: 1.1rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-dashboard__card-link {
+    margin-top: auto;
+    font-weight: 600;
+    color: var(--jp-primary);
+}
+
+body .juntaplay-dashboard__list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+body .juntaplay-dashboard__item {
+    border: 1px solid rgba(15, 23, 42, 0.06);
+    border-radius: calc(var(--jp-radius) + 2px);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+body .juntaplay-dashboard__item-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+body .juntaplay-dashboard__item-head h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+body .juntaplay-dashboard__item-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+body .juntaplay-dashboard__item-progress {
+    min-width: 220px;
+    flex: 1 1 240px;
+    color: var(--jp-muted);
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+body .juntaplay-dashboard__item-stats {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+}
+
+body .juntaplay-dashboard__item-stats span {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-dashboard__item-stats strong {
+    font-size: 1.1rem;
+}
+
+@media (max-width: 1024px) {
+    body .juntaplay-dashboard__hero {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    body .juntaplay-dashboard__cta {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 768px) {
+    body .juntaplay-dashboard__panel,
+    body .juntaplay-dashboard__hero {
+        padding: 1.75rem;
+    }
+
+    body .juntaplay-dashboard__actions {
+        flex-direction: column;
+    }
+
+    body .juntaplay-dashboard__action {
+        width: 100%;
+    }
+
+    body .juntaplay-dashboard__nav {
+        grid-template-columns: 1fr;
+    }
+
+    body .juntaplay-dashboard__nav-link {
+        align-items: flex-start;
+    }
+
+    body .juntaplay-dashboard__item-stats {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+body .juntaplay-profile {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+body .juntaplay-profile__hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+body .juntaplay-profile__eyebrow {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-profile__hero h1 {
+    font-size: clamp(2rem, 3vw, 2.5rem);
+    margin: 0;
+    color: var(--jp-text);
+}
+
+body .juntaplay-profile__hero p {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-profile__alerts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+body .juntaplay-profile__group {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+}
+
+body .juntaplay-profile__group:last-child {
+    margin-bottom: 0;
+}
+
+body .juntaplay-profile__group-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+body .juntaplay-profile__group-title {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--jp-text);
+    margin: 0;
+}
+
+body .juntaplay-profile__group-description {
+    margin: 0;
+    color: var(--jp-muted);
+    max-width: 48rem;
+}
+
+body .juntaplay-profile__group .juntaplay-profile__alerts {
+    margin-bottom: 0.5rem;
+}
+
+body .juntaplay-profile__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+body .juntaplay-profile__summary-item {
+    background: #f7f8fc;
+    border: 1px solid var(--jp-border);
+    border-radius: 18px;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    box-shadow: 0 18px 32px rgba(17, 24, 39, 0.05);
+}
+
+body .juntaplay-profile__summary-item--positive {
+    background: var(--jp-primary-light);
+    border-color: rgba(255, 90, 95, 0.3);
+}
+
+body .juntaplay-profile__summary-item--warning {
+    background: #fff7ed;
+    border-color: rgba(249, 115, 22, 0.25);
+}
+
+body .juntaplay-profile__summary-item--accent {
+    background: #f2f5ff;
+    border-color: rgba(99, 102, 241, 0.25);
+}
+
+body .juntaplay-profile__summary-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-profile__summary-value {
+    font-size: clamp(1.45rem, 2.5vw, 1.8rem);
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-profile__summary-hint {
+    font-size: 0.85rem;
+    color: var(--jp-muted);
+}
+
+@media (max-width: 640px) {
+    body .juntaplay-profile__summary {
+        grid-template-columns: 1fr;
+    }
+    body .juntaplay-form__grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+body .juntaplay-profile__card .juntaplay-card__body {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+}
+
+body .juntaplay-profile__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+body .juntaplay-profile__row {
+    border: 1px solid var(--jp-border);
+    border-radius: 18px;
+    padding: 1.25rem 1.5rem;
+    background: #fff;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem 1.5rem;
+    position: relative;
+}
+
+body .juntaplay-profile__row--action {
+    border-color: rgba(220, 38, 38, 0.25);
+    background: linear-gradient(180deg, #ffffff 0%, rgba(254, 226, 226, 0.55) 100%);
+}
+
+body .juntaplay-profile__row--action .juntaplay-profile__label {
+    color: var(--jp-danger-dark);
+}
+
+body .juntaplay-profile__row--action .juntaplay-profile__value {
+    color: var(--jp-danger-dark);
+}
+
+body .juntaplay-profile__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+body .juntaplay-profile__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-profile__value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-profile__empty {
+    color: var(--jp-muted);
+    font-weight: 500;
+}
+
+body .juntaplay-profile__description {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+
+body .juntaplay-profile__actions {
+    display: flex;
+    align-items: flex-start;
+}
+
+body .juntaplay-profile__edit {
+    appearance: none;
+    border: none;
+    background: none;
+    color: var(--jp-primary);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    transition: color 0.2s ease;
+}
+
+body .juntaplay-profile__edit:hover,
+body .juntaplay-profile__edit:focus {
+    color: var(--jp-primary-dark);
+    text-decoration: underline;
+}
+
+body .juntaplay-profile__form {
+    grid-column: 1 / -1;
+    display: none;
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--jp-border);
+    margin-top: 0.5rem;
+}
+
+body .juntaplay-profile__row.is-editing .juntaplay-profile__form {
+    display: block;
+}
+
+body .juntaplay-profile__row--custom {
+    border: none;
+    padding: 0;
+    background: transparent;
+    grid-template-columns: 1fr;
+}
+
+body .juntaplay-profile__row--custom .juntaplay-profile__content {
+    padding: 0 1.5rem;
+}
+
+body .juntaplay-profile__custom {
+    margin: 0;
+    padding: 1.5rem;
+    border: 1px solid var(--jp-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 20px 34px rgba(15, 23, 42, 0.06);
+}
+
+body .juntaplay-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+body .juntaplay-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+body .juntaplay-form__group label {
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-form__help {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+body .juntaplay-form__hint {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+body .juntaplay-form__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+body .juntaplay-form__group--inline {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+body .juntaplay-form__group--cover {
+    display: flex;
+    flex-direction: column;
+}
+
+body .juntaplay-cover-picker {
+    background: #fff;
+    border: 1px dashed rgba(7, 20, 55, 0.18);
+    border-radius: 20px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+body .juntaplay-cover-picker__media {
+    width: 100%;
+    padding-bottom: 74.75%;
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+    background: #0d1732;
+    background-size: cover;
+    background-position: center;
+    box-shadow: inset 0 0 0 1px rgba(7, 20, 55, 0.08);
+}
+
+body .juntaplay-cover-picker__media img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+body .juntaplay-cover-picker__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+body .juntaplay-cover-picker__actions .juntaplay-button--subtle {
+    background: transparent;
+    border: 1px solid rgba(7, 20, 55, 0.12);
+}
+body .juntaplay-form__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+body .juntaplay-form__checkbox input {
+    width: 1.1rem;
+    height: 1.1rem;
+}
+body .juntaplay-groups__price-preview {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--jp-primary-dark);
+    padding: 0.65rem 0.75rem;
+    border-radius: 10px;
+    margin-top: 0.35rem;
+}
+body .juntaplay-groups__price-preview.is-hidden {
+    display: none;
+}
+body .juntaplay-admin-group__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+body .juntaplay-admin-group__meta span {
+    display: block;
+}
+body .juntaplay-admin-group__meta a {
+    color: var(--jp-primary);
+}
+
+body .juntaplay-form__input,
+body .juntaplay-form__input:focus {
+    border-radius: 12px;
+    border: 1px solid var(--jp-border);
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    width: 100%;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body .juntaplay-form__input:focus {
+    outline: none;
+    border-color: var(--jp-primary);
+    box-shadow: 0 0 0 3px rgba(255, 90, 95, 0.15);
+}
+
+body .juntaplay-form__errors {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: #991b1b;
+    font-size: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+body .juntaplay-form__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+body .juntaplay-button--ghost {
+    background: transparent;
+    border-color: var(--jp-border);
+    color: var(--jp-text);
+}
+
+body .juntaplay-button--ghost:hover,
+body .juntaplay-button--ghost:focus {
+    border-color: var(--jp-primary);
+    color: var(--jp-primary);
+}
+
+body .juntaplay-profile__row.is-editing {
+    border-color: rgba(255, 90, 95, 0.4);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+body .juntaplay-profile__row.is-editing .juntaplay-profile__label {
+    color: var(--jp-primary);
+}
+
+@media (max-width: 767px) {
+    body .juntaplay-profile__row {
+        grid-template-columns: 1fr;
+        padding: 1.25rem;
+    }
+
+    body .juntaplay-profile__actions {
+        justify-content: flex-start;
+    }
+
+    body .juntaplay-profile__edit {
+        padding-top: 0;
+    }
+
+    body .juntaplay-profile__form {
+        padding-top: 1rem;
+    }
+}
+body .juntaplay-groups {
+    display: grid;
+    gap: 2rem;
+}
+
+body .juntaplay-groups__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+body .juntaplay-groups__status-filter {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-width: 280px;
+}
+
+body .juntaplay-groups__status-filter label {
+    font-weight: 600;
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+
+body .juntaplay-groups__filters .juntaplay-chip {
+    background: #f3f4f6;
+    color: var(--jp-muted);
+    border: 1px solid transparent;
+    font-weight: 600;
+    transition: all 0.2s ease;
+}
+
+body .juntaplay-groups__filters .juntaplay-chip:hover,
+body .juntaplay-groups__filters .juntaplay-chip:focus {
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+}
+
+body .juntaplay-groups__filters .juntaplay-chip.is-active {
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    border-color: rgba(255, 90, 95, 0.35);
+}
+
+body .juntaplay-groups__list {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+body .juntaplay-group-card {
+    border: 1px solid var(--jp-border);
+    border-radius: 20px;
+    background: #fff;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    box-shadow: 0 22px 35px rgba(15, 23, 42, 0.06);
+    position: relative;
+}
+
+body .juntaplay-group-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+body .juntaplay-group-card__title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__meta {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+body .juntaplay-group-card__created {
+    font-size: 0.85rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__reviewed {
+    font-size: 0.82rem;
+    color: var(--jp-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+body .juntaplay-group-card__details {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__details strong {
+    color: var(--jp-text);
+    font-weight: 600;
+    margin-right: 0.35rem;
+}
+
+body .juntaplay-group-card__enrollment {
+    border: 1px dashed var(--jp-border);
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.03);
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+body .juntaplay-group-card__enrollment-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--jp-muted);
+    font-weight: 600;
+}
+
+body .juntaplay-group-card__enrollment-value {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__enrollment-note {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__members {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+body .juntaplay-group-card__members h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__members ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+body .juntaplay-group-card__members li {
+    background: rgba(14, 165, 233, 0.08);
+    border-radius: 999px;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.85rem;
+    color: var(--jp-text);
+    font-weight: 500;
+}
+
+body .juntaplay-group-card__members-more {
+    background: rgba(255, 90, 95, 0.08) !important;
+    color: var(--jp-primary-dark) !important;
+}
+
+body .juntaplay-group-card__share {
+    border: 1px solid var(--jp-border);
+    border-radius: 16px;
+    padding: 0.9rem 1rem;
+    background: #f8fafc;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+body .juntaplay-group-card__share header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+body .juntaplay-group-card__share-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__share-domain {
+    font-size: 0.8rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__share-snippet {
+    margin: 0;
+    font-family: "Fira Code", "JetBrains Mono", monospace;
+    font-size: 0.8rem;
+    line-height: 1.55;
+    background: #fff;
+    border: 1px solid var(--jp-border);
+    border-radius: 12px;
+    padding: 0.75rem;
+    white-space: pre-wrap;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__share-text {
+    display: none;
+}
+
+body .juntaplay-group-card__complaint {
+    margin-top: 24px;
+    padding: 20px;
+    border-radius: 12px;
+    border: 1px dashed var(--jp-primary-light);
+    background: rgba(255, 90, 95, 0.06);
+}
+
+body .juntaplay-group-card__complaint-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+body .juntaplay-group-card__complaint-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__complaint-summary {
+    margin: 0 0 8px;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__complaint-note {
+    margin: 0 0 8px;
+    color: #555f6d;
+}
+
+body .juntaplay-group-card__complaint-open {
+    margin: 0 0 12px;
+    color: var(--jp-primary);
+    font-weight: 600;
+}
+
+body .juntaplay-group-card__complaint-description {
+    margin: 0 0 16px;
+    color: #4a4a4a;
+}
+
+body .juntaplay-group-complaint__form {
+    margin-top: 16px;
+    padding: 16px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+body .juntaplay-group-complaint__form.is-hidden {
+    display: none;
+}
+
+body .juntaplay-group-complaint__form.is-open {
+    display: block;
+    animation: juntaplay-fade-in 0.25s ease;
+}
+
+body .juntaplay-group-complaint__files {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+body .juntaplay-group-complaint__files li {
+    background: #f4f6fb;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 0.875rem;
+    color: #495261;
+    word-break: break-word;
+}
+
+body .juntaplay-group-complaint__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 16px;
+}
+
+body .juntaplay-group-card__complaint .juntaplay-alert {
+    margin-bottom: 12px;
+}
+
+@media (max-width: 767px) {
+    body .juntaplay-group-card__complaint {
+        padding: 16px;
+    }
+
+    body .juntaplay-group-card__complaint-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+body .juntaplay-group-card__faq {
+    border-top: 1px solid var(--jp-border);
+    padding-top: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+body .juntaplay-group-card__faq h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+body .juntaplay-accordion__item {
+    border: 1px solid var(--jp-border);
+    border-radius: 14px;
+    background: #fff;
+    overflow: hidden;
+}
+
+body .juntaplay-accordion__summary {
+    list-style: none;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.92rem;
+    padding: 0.75rem 1rem;
+    color: var(--jp-text);
+    position: relative;
+}
+
+body .juntaplay-accordion__summary::-webkit-details-marker {
+    display: none;
+}
+
+body .juntaplay-accordion__summary::after {
+    content: "+";
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--jp-primary);
+    font-weight: 700;
+    transition: transform 0.2s ease;
+}
+
+body .juntaplay-accordion__item[open] .juntaplay-accordion__summary::after {
+    content: "–";
+}
+
+body .juntaplay-accordion__content {
+    margin: 0;
+    padding: 0 1rem 0.85rem;
+    font-size: 0.88rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__extras {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.88rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-group-card__extras span {
+    font-weight: 600;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__message {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: #f8fafc;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+
+body .juntaplay-group-card__rules {
+    border-left: 3px solid rgba(14, 165, 233, 0.45);
+    background: rgba(14, 165, 233, 0.08);
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+body .juntaplay-group-card__rules strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--jp-text);
+}
+
+body .juntaplay-group-card__review {
+    border-left: 3px solid var(--jp-primary-light);
+    background: rgba(255, 90, 95, 0.06);
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+
+body .juntaplay-group-card__review strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--jp-primary-dark);
+}
+
+body .juntaplay-group-card__note {
+    color: var(--jp-muted);
+    font-size: 0.85rem;
+}
+
+body .juntaplay-group-card__footer {
+    margin-top: auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+body .juntaplay-groups__create {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+body .juntaplay-groups__create h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-groups__create > p {
+    margin: 0;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-groups__ideas {
+    border: 1px solid var(--jp-border);
+    border-radius: 18px;
+    padding: 1.25rem;
+    background: rgba(15, 23, 42, 0.02);
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+body .juntaplay-groups__ideas h4 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-groups__ideas-description {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.92rem;
+}
+
+body .juntaplay-groups__ideas-list {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+body .juntaplay-groups__idea {
+    background: #ffffff;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 16px;
+    padding: 1rem;
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body .juntaplay-groups__idea:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+body .juntaplay-groups__idea-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+body .juntaplay-groups__idea-category {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    color: var(--jp-primary, #ff5a5f);
+}
+
+body .juntaplay-groups__idea-price {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--jp-primary-dark, #e11d48);
+}
+
+body .juntaplay-groups__idea-description {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+    line-height: 1.45;
+}
+
+body .juntaplay-groups__idea .juntaplay-button {
+    align-self: flex-start;
+}
+
+body .juntaplay-groups__empty {
+    margin: 0;
+    padding: 0.5rem 0;
+    color: var(--jp-muted);
+    font-style: italic;
+    grid-column: 1 / -1;
+}
+
+body .juntaplay-groups__empty.is-hidden {
+    display: none;
+}
+
+body .juntaplay-groups__form {
+    max-width: 640px;
+}
+
+body .juntaplay-form__group--toggle {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    gap: 0.35rem;
+}
+
+body .juntaplay-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+body .juntaplay-toggle input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+body .juntaplay-toggle__slider {
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.25);
+    position: relative;
+    transition: background 0.2s ease;
+}
+
+body .juntaplay-toggle__slider::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    background: #ffffff;
+    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.25);
+    transition: transform 0.2s ease;
+}
+
+body .juntaplay-toggle input:checked + .juntaplay-toggle__slider {
+    background: var(--jp-primary, #ff5a5f);
+}
+
+body .juntaplay-toggle input:checked + .juntaplay-toggle__slider::after {
+    transform: translateX(20px);
+}
+
+body .juntaplay-toggle__caption {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--jp-muted);
+}
+
+body .juntaplay-toggle input:checked + .juntaplay-toggle__slider + .juntaplay-toggle__caption {
+    color: var(--jp-primary-dark, #c41e3a);
+}
+
+body .juntaplay-groups__share {
+    margin-top: 2rem;
+    border: 1px solid var(--jp-border);
+    border-radius: 20px;
+    padding: 1.75rem;
+    background: #ffffff;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+body .juntaplay-groups__share h4 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--jp-text);
+}
+
+body .juntaplay-groups__share-intro {
+    margin: 0;
+    color: var(--jp-muted);
+    font-size: 0.95rem;
+}
+
+body .juntaplay-groups__share-card {
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    border-radius: 16px;
+    padding: 1.25rem;
+    background: linear-gradient(135deg, rgba(255, 90, 95, 0.08), rgba(59, 130, 246, 0.05));
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+body .juntaplay-groups__share-domain {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--jp-primary-dark);
+    font-weight: 700;
+}
+
+body .juntaplay-groups__share-list {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+body .juntaplay-groups__share-row {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 0.75rem;
+    align-items: start;
+}
+
+body .juntaplay-groups__share-row dt {
+    margin: 0;
+    font-weight: 600;
+    color: var(--jp-muted);
+    font-size: 0.9rem;
+}
+
+body .juntaplay-groups__share-row dd {
+    margin: 0;
+    color: var(--jp-text);
+    font-size: 0.98rem;
+    line-height: 1.4;
+}
+
+body .juntaplay-groups__share-snippet {
+    margin: 0;
+    background: #0f172a;
+    color: #f8fafc;
+    border-radius: 16px;
+    padding: 1.25rem;
+    font-size: 0.92rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    font-family: "Figtree", "Fredoka", "Segoe UI", sans-serif;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+body .juntaplay-groups__share-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+body .juntaplay-groups__share-text {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+body .juntaplay-button.is-success {
+    border-color: var(--jp-primary);
+    color: var(--jp-primary);
+}
+
+@media (max-width: 768px) {
+    body .juntaplay-group-card {
+        padding: 1.25rem;
+    }
+
+    body .juntaplay-profile__custom {
+        padding: 1.25rem;
+    }
+
+    body .juntaplay-groups__status-filter {
+        max-width: 100%;
+    }
+
+    body .juntaplay-groups__share {
+        padding: 1.5rem;
+    }
+
+    body .juntaplay-groups__share-row {
+        grid-template-columns: 1fr;
+    }
+
+    body .juntaplay-groups__ideas-list {
+        grid-template-columns: 1fr;
+    }
+}
+body [data-group-item].is-hidden {
+    display: none !important;
+}
+
+/* Wallet dashboard */
+.juntaplay-wallet {
+    background: #ffffff;
+    border-radius: 20px;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
+    padding: 32px;
+    margin-top: 32px;
+    position: relative;
+}
+
+.juntaplay-wallet__header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 32px;
+}
+
+.juntaplay-wallet__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    flex: 1 1 360px;
+}
+
+.juntaplay-wallet__card {
+    background: var(--jp-primary-light, #ffe6e7);
+    border-radius: 16px;
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.juntaplay-wallet__card:nth-child(2) {
+    background: #f4f6fb;
+}
+
+.juntaplay-wallet__card:nth-child(3) {
+    background: #fff4e6;
+}
+
+.juntaplay-wallet__card:nth-child(4) {
+    background: #fff7f0;
+}
+
+.juntaplay-wallet__card-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: #475569;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.juntaplay-wallet__card-value {
+    font-size: 20px;
+    font-weight: 700;
+    color: #111827;
+}
+
+.juntaplay-wallet__card-value--muted {
+    color: #475569;
+}
+
+.juntaplay-wallet__card-value--accent {
+    color: var(--jp-primary, #ff5a5f);
+}
+
+.juntaplay-wallet__card-value--warning {
+    color: #f97316;
+}
+
+.juntaplay-wallet__actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-end;
+    flex: 0 0 220px;
+}
+
+.juntaplay-wallet__hint {
+    font-size: 13px;
+    color: #64748b;
+}
+
+.juntaplay-wallet__hint--cta {
+    display: block;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #475569;
+}
+
+.juntaplay-wallet__deposit {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 9999;
+}
+
+.juntaplay-wallet__deposit[hidden] {
+    display: none;
+}
+
+.juntaplay-wallet__deposit-card {
+    background: #ffffff;
+    border-radius: 20px;
+    padding: 32px;
+    max-width: 420px;
+    width: 100%;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+    position: relative;
+}
+
+.juntaplay-wallet__deposit-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 18px;
+}
+
+.juntaplay-wallet__deposit-header h3 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__deposit-close {
+    background: transparent;
+    border: none;
+    font-size: 28px;
+    line-height: 1;
+    cursor: pointer;
+    color: #94a3b8;
+}
+
+.juntaplay-wallet__deposit-close:hover,
+.juntaplay-wallet__deposit-close:focus {
+    color: #1e293b;
+}
+
+.juntaplay-wallet__deposit-form {
+    display: grid;
+    gap: 18px;
+}
+
+.juntaplay-wallet__deposit-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.juntaplay-wallet__deposit-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.juntaplay-wallet__deposit .juntaplay-button {
+    min-width: 0;
+}
+
+@media (max-width: 640px) {
+    .juntaplay-wallet__deposit-card {
+        padding: 24px;
+    }
+
+    .juntaplay-wallet__deposit-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+.juntaplay-wallet__content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 32px;
+}
+
+.juntaplay-wallet__withdraw {
+    background: #f8fafc;
+    border-radius: 16px;
+    padding: 24px;
+    margin-bottom: 32px;
+}
+
+.juntaplay-wallet__withdraw h3 {
+    margin: 0 0 12px;
+    font-size: 18px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__alert {
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 14px;
+    margin-bottom: 16px;
+}
+
+.juntaplay-wallet__alert--warning {
+    background: #fff7ed;
+    color: #c2410c;
+}
+
+.juntaplay-wallet__form {
+    display: grid;
+    gap: 18px;
+}
+
+.juntaplay-field__label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.juntaplay-field__input {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid #cbd5f5;
+    background: #fff;
+    padding: 12px 14px;
+    font-size: 15px;
+    color: #0f172a;
+}
+
+.juntaplay-field__input-wrapper {
+    display: flex;
+    align-items: center;
+    border-radius: 12px;
+    border: 1px solid #cbd5f5;
+    background: #fff;
+    overflow: hidden;
+}
+
+.juntaplay-field__prefix {
+    padding: 12px 14px;
+    font-weight: 600;
+    color: #64748b;
+    background: #f8fafc;
+}
+
+.juntaplay-field__input-wrapper .juntaplay-field__input {
+    border: none;
+    border-radius: 0;
+    padding: 12px 14px;
+}
+
+.juntaplay-field__input:disabled {
+    background: #f1f5f9;
+    cursor: not-allowed;
+}
+
+.juntaplay-field__hint {
+    margin: 6px 0 0;
+    font-size: 13px;
+    color: #64748b;
+}
+
+.juntaplay-wallet__transactions,
+.juntaplay-wallet__history {
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 15px 40px rgba(15, 23, 42, 0.05);
+}
+
+.juntaplay-wallet__section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.juntaplay-wallet__section-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__section-header p {
+    margin: 4px 0 0;
+    font-size: 14px;
+    color: #64748b;
+}
+
+.juntaplay-wallet__total {
+    font-size: 13px;
+    font-weight: 600;
+    color: #6366f1;
+    background: rgba(99, 102, 241, 0.08);
+    padding: 6px 12px;
+    border-radius: 999px;
+}
+
+.juntaplay-wallet__list,
+.juntaplay-wallet__history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 14px;
+}
+
+.juntaplay-wallet__item,
+.juntaplay-wallet__history-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 14px 16px;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: #f8fafc;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.juntaplay-wallet__item:hover,
+.juntaplay-wallet__history-item:hover {
+    background: #eef2ff;
+    transform: translateY(-2px);
+}
+
+.juntaplay-wallet__item-title {
+    font-size: 15px;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__item-meta,
+.juntaplay-wallet__history-meta,
+.juntaplay-wallet__history-ref,
+.juntaplay-wallet__history-destination {
+    display: block;
+    font-size: 13px;
+    color: #64748b;
+    margin-top: 2px;
+}
+
+.juntaplay-wallet__item-status,
+.juntaplay-wallet__history-status {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #475569;
+}
+
+.juntaplay-wallet__item-amount {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__more {
+    width: 100%;
+    margin-top: 18px;
+}
+
+.juntaplay-wallet__empty {
+    font-size: 14px;
+    color: #64748b;
+    text-align: center;
+    padding: 24px 0;
+}
+
+.juntaplay-wallet__history {
+    max-height: 100%;
+    overflow-y: auto;
+}
+
+.juntaplay-wallet__details {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+    z-index: 999;
+}
+
+.juntaplay-wallet__details[hidden] {
+    display: none;
+}
+
+.juntaplay-wallet__details-card {
+    background: #ffffff;
+    border-radius: 16px;
+    width: min(520px, 100%);
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
+}
+
+.juntaplay-wallet__details-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 24px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.juntaplay-wallet__details-header h4 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__details-close {
+    background: transparent;
+    border: none;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    color: #475569;
+}
+
+.juntaplay-wallet__details-body {
+    padding: 20px 24px 24px;
+    display: grid;
+    gap: 12px;
+}
+
+.juntaplay-wallet__details-body dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 8px 16px;
+    font-size: 14px;
+}
+
+.juntaplay-wallet__details-body dt {
+    color: #64748b;
+    font-weight: 600;
+}
+
+.juntaplay-wallet__details-body dd {
+    margin: 0;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__history-item strong {
+    display: block;
+    font-size: 15px;
+    color: #0f172a;
+}
+
+.juntaplay-wallet__history-status::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: currentColor;
+    margin-right: 6px;
+}
+
+.juntaplay-wallet__details-card .juntaplay-wallet__empty {
+    padding: 16px 0;
+}
+
+.juntaplay-wallet__history::-webkit-scrollbar {
+    width: 6px;
+}
+
+.juntaplay-wallet__history::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.6);
+    border-radius: 999px;
+}
+
+.juntaplay-wallet__history::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+@media (max-width: 1024px) {
+    .juntaplay-wallet {
+        padding: 24px;
+    }
+
+    .juntaplay-wallet__content {
+        grid-template-columns: 1fr;
+    }
+
+    .juntaplay-wallet__history {
+        order: -1;
+        max-height: none;
+    }
+}
+
+@media (max-width: 640px) {
+    .juntaplay-wallet__header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .juntaplay-wallet__actions {
+        align-items: flex-start;
+    }
+}
+
+.juntaplay-notification-bell {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: #ffffff;
+    cursor: pointer;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.juntaplay-dashboard__toolbar,
+.juntaplay-profile__toolbar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    position: relative;
+}
+
+.juntaplay-profile__toolbar {
+    margin-top: -8px;
+}
+
+.juntaplay-notification-bell:hover,
+.juntaplay-notification-bell.is-active {
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+    transform: translateY(-1px);
+}
+
+.juntaplay-notification-bell svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: #0f172a;
+}
+
+.juntaplay-notification-bell[data-count]::after {
+    content: attr(data-count);
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--jp-primary, #ff5a5f);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+}
+
+.juntaplay-notifications {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 12px;
+    width: min(320px, 90vw);
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 25px 60px rgba(15, 23, 42, 0.18);
+    z-index: 998;
+    display: none;
+    overflow: hidden;
+}
+
+.juntaplay-notifications.is-open {
+    display: block;
+}
+
+.juntaplay-notifications__header {
+    padding: 16px 20px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.juntaplay-notifications__header h4 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.juntaplay-notifications__list {
+    max-height: 320px;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.juntaplay-notifications__item {
+    padding: 14px 20px;
+    border-bottom: 1px solid #f1f5f9;
+    font-size: 14px;
+    display: block;
+    text-decoration: none;
+    color: #0f172a;
+}
+
+.juntaplay-notifications__item:hover {
+    background: #f8fafc;
+}
+
+.juntaplay-notifications__item-title {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.juntaplay-notifications__item-message {
+    color: #475569;
+    line-height: 1.4;
+}
+
+.juntaplay-notifications__item-time {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #94a3b8;
+}
+
+.juntaplay-notifications__empty {
+    padding: 24px 20px;
+    text-align: center;
+    color: #64748b;
+    font-size: 14px;
+}
+
+.juntaplay-notifications__footer {
+    padding: 12px 20px;
+    background: #f8fafc;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.juntaplay-notifications__footer button {
+    font-size: 13px;
+    color: #475569;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+}
+
+.juntaplay-grid-wrap {
+    margin-top: 1.5rem;
+    position: relative;
+}
+
+.juntaplay-grid__actions {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: center;
+}
+
+.juntaplay-feedback {
+    display: none;
+    margin-top: 1rem;
+    color: #ff5a5f;
+    text-align: center;
+}
+
+.juntaplay-feedback.is-visible {
+    display: block;
+}
+
+.juntaplay-pool-catalog {
+    position: relative;
+}
+
+.juntaplay-pool-catalog.is-loading::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.65);
+    backdrop-filter: blur(1px);
+    z-index: 2;
+}
+
+.juntaplay-catalog__header {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.juntaplay-catalog__title {
+    font-size: 1.75rem;
+    margin-bottom: 0.25rem;
+}
+
+.juntaplay-catalog__subtitle {
+    margin: 0;
+    color: #6b7280;
+}
+
+.juntaplay-catalog__meta {
+    align-self: flex-end;
+    font-weight: 600;
+    color: #111827;
+}
+
+.juntaplay-catalog__results {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.juntaplay-pool-card {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    overflow: hidden;
+    background: #fff;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.juntaplay-pool-card:hover,
+.juntaplay-pool-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.juntaplay-pool-card__cover {
+    aspect-ratio: 16 / 9;
+    background: #f3f4f6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.juntaplay-pool-card__cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.juntaplay-pool-card__cover.is-placeholder span {
+    font-weight: 600;
+    color: #6b7280;
+}
+
+.juntaplay-pool-card__body {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.juntaplay-pool-card__title {
+    font-size: 1.25rem;
+    margin: 0;
+    color: #111827;
+}
+
+.juntaplay-pool-card__title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.juntaplay-pool-card__excerpt {
+    margin: 0;
+    color: #6b7280;
+    min-height: 3.5rem;
+}
+
+.juntaplay-pool-card__price {
+    font-weight: 600;
+    color: #111827;
+}
+
+.juntaplay-pool-card__meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.juntaplay-pool-card__badge {
+    align-self: flex-start;
+    background: var(--jp-primary-light);
+    color: var(--jp-primary-dark);
+    font-weight: 600;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+}
+
+.juntaplay-catalog__actions {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: center;
+}
+
+.juntaplay-filters--catalog {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.juntaplay-filters__actions {
+    display: flex;
+    align-items: flex-end;
+}
+
+@media (max-width: 768px) {
+    .juntaplay-catalog__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .juntaplay-pool-card__excerpt {
+        min-height: auto;
+    }
+}
+/* Groups directory */
+.juntaplay-groups {
+    background: #fff;
+    border-radius: 24px;
+    box-shadow: 0 24px 70px -30px rgba(10, 31, 68, 0.2);
+    padding: 48px clamp(24px, 5vw, 56px);
+    margin-bottom: 64px;
+}
+
+.juntaplay-groups__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 32px;
+}
+
+.juntaplay-groups__header h1 {
+    font-size: clamp(1.75rem, 2.3vw, 2.4rem);
+    color: var(--juntaplay-heading, #071437);
+    margin: 0;
+}
+
+.juntaplay-groups__header p {
+    margin: 0;
+    color: var(--juntaplay-muted, #5b6987);
+}
+
+.juntaplay-filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px 24px;
+    margin-bottom: 32px;
+    align-items: flex-end;
+}
+
+.juntaplay-filters__group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.juntaplay-filters__group--search {
+    grid-column: 1 / -1;
+}
+
+.juntaplay-filters__group--inline {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+}
+
+.juntaplay-filters__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--juntaplay-muted-strong, #2a3553);
+}
+
+.juntaplay-filters__input {
+    border: 1px solid rgba(15, 39, 92, 0.12);
+    border-radius: 12px;
+    background: #f8fafd;
+    padding: 12px 16px;
+    font-size: 0.95rem;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.juntaplay-filters__input:focus {
+    outline: none;
+    border-color: var(--juntaplay-primary, #4361ee);
+    box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.15);
+    background: #fff;
+}
+
+.juntaplay-filters__actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.juntaplay-groups__body {
+    position: relative;
+}
+
+.juntaplay-groups__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 28px;
+}
+
+.juntaplay-groups__empty,
+.juntaplay-groups__noscript {
+    margin-top: 24px;
+    color: var(--juntaplay-muted, #5b6987);
+    text-align: center;
+}
+
+.juntaplay-groups__footer {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
+    margin-top: 40px;
+}
+
+.juntaplay-groups__total {
+    font-weight: 600;
+    color: var(--juntaplay-heading, #071437);
+}
+
+.juntaplay-groups.is-loading {
+    position: relative;
+}
+
+.juntaplay-groups.is-loading::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.6);
+    border-radius: 24px;
+    backdrop-filter: blur(2px);
+    z-index: 1;
+}
+
+.juntaplay-group-card {
+    display: flex;
+    flex-direction: column;
+    background: #fefefe;
+    border-radius: 20px;
+    overflow: hidden;
+    border: 1px solid rgba(11, 27, 61, 0.05);
+    box-shadow: 0 20px 45px -25px rgba(15, 39, 92, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    min-height: 100%;
+}
+
+.juntaplay-group-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 60px -25px rgba(15, 39, 92, 0.35);
+}
+
+.juntaplay-group-card__cover {
+    position: relative;
+    aspect-ratio: 495 / 370;
+    background: linear-gradient(135deg, rgba(67, 97, 238, 0.18), rgba(67, 97, 238, 0.05));
+    display: grid;
+    place-items: center;
+}
+
+.juntaplay-group-card__cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.juntaplay-group-card__cover.is-placeholder span {
+    color: var(--juntaplay-muted, #5b6987);
+    font-weight: 600;
+}
+
+.juntaplay-group-card__body {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1 1 auto;
+}
+
+.juntaplay-group-card__badge {
+    align-self: flex-start;
+    background: linear-gradient(120deg, var(--juntaplay-primary, #4361ee), #6c5ce7);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.juntaplay-group-card__title {
+    margin: 0;
+    font-size: 1.15rem;
+    line-height: 1.3;
+}
+
+.juntaplay-group-card__title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.juntaplay-group-card__title a:hover,
+.juntaplay-group-card__title a:focus {
+    color: var(--juntaplay-primary, #4361ee);
+}
+
+.juntaplay-group-card__service {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--juntaplay-muted, #5b6987);
+}
+
+.juntaplay-group-card__description {
+    margin: 0;
+    font-size: 0.92rem;
+    color: var(--juntaplay-muted-strong, #2a3553);
+}
+
+.juntaplay-group-card__meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+    margin: 12px 0 4px;
+    font-size: 0.85rem;
+    color: var(--juntaplay-muted, #5b6987);
+}
+
+.juntaplay-group-card__meta dt {
+    font-weight: 600;
+    color: var(--juntaplay-muted-strong, #2a3553);
+}
+
+.juntaplay-group-card__price {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--juntaplay-heading, #071437);
+}
+
+.juntaplay-group-card__footer {
+    margin-top: auto;
+    padding: 0 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.juntaplay-group-card__owner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--juntaplay-muted, #5b6987);
+    font-size: 0.85rem;
+}
+
+.juntaplay-group-card__owner img {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow: 0 10px 25px -20px rgba(10, 31, 68, 0.7);
+}
+
+.juntaplay-group-card__owner time {
+    font-size: 0.8rem;
+    color: rgba(7, 20, 55, 0.6);
+}
+
+.juntaplay-group-card--spotlight {
+    position: relative;
+    border-radius: 28px;
+    overflow: hidden;
+    background: linear-gradient(160deg, #101a33 0%, #060b18 100%);
+    box-shadow: 0 28px 64px -30px rgba(7, 20, 55, 0.8);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    min-height: 100%;
+    color: #f1f5ff;
+}
+
+.juntaplay-group-card--spotlight:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 36px 82px -34px rgba(12, 27, 66, 0.9);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__frame {
+    position: relative;
+    width: 100%;
+    padding-bottom: 74.75%;
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__frame > img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.6s ease;
+}
+
+.juntaplay-group-card--spotlight:hover .juntaplay-group-card__frame > img {
+    transform: scale(1.04);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 32px;
+    background: linear-gradient(180deg, rgba(4, 9, 24, 0.05) 10%, rgba(4, 9, 24, 0.85) 65%, rgba(4, 9, 24, 0.95) 100%);
+    gap: 16px;
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__category {
+    position: absolute;
+    top: 24px;
+    left: 24px;
+    background: rgba(241, 245, 255, 0.12);
+    color: #f1f5ff;
+    font-weight: 600;
+    font-size: 0.78rem;
+    padding: 6px 14px;
+    border-radius: 999px;
+    backdrop-filter: blur(6px);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__instant {
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    background: linear-gradient(135deg, #ff8b4d, #ff5660);
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.75rem;
+    padding: 6px 16px;
+    border-radius: 999px;
+    box-shadow: 0 10px 25px -15px rgba(255, 94, 88, 0.7);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__service {
+    margin: 0;
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(241, 245, 255, 0.72);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__title {
+    margin: 0;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    color: #fff;
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__excerpt {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(241, 245, 255, 0.82);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: rgba(241, 245, 255, 0.74);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__price {
+    font-weight: 700;
+    font-size: 1rem;
+    color: #ffffff;
+}
+
+.juntaplay-group-card--spotlight .juntaplay-group-card__slots,
+.juntaplay-group-card--spotlight .juntaplay-group-card__members {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(241, 245, 255, 0.12);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-button {
+    align-self: flex-start;
+    padding-inline: 22px;
+    padding-block: 12px;
+    font-weight: 700;
+    box-shadow: 0 16px 36px -18px rgba(255, 138, 76, 0.8);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-button:hover {
+    transform: translateY(-1px);
+}
+
+.juntaplay-group-card--spotlight .juntaplay-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 3px;
+}
+
+.juntaplay-group-rotator {
+    position: relative;
+    padding: 48px;
+    margin: 32px 0 56px;
+    border-radius: 32px;
+    background: linear-gradient(140deg, #0d152b 0%, #131f3a 40%, #060b18 100%);
+    color: #f1f5ff;
+    overflow: hidden;
+}
+
+.juntaplay-group-rotator__header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 28px;
+}
+
+.juntaplay-group-rotator__header h2 {
+    font-size: 2rem;
+    margin: 0;
+    color: #fff;
+}
+
+.juntaplay-group-rotator__header p {
+    margin: 0;
+    color: rgba(241, 245, 255, 0.72);
+    max-width: 620px;
+}
+
+.juntaplay-group-rotator__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.juntaplay-group-rotator__filters button {
+    border: none;
+    background: rgba(241, 245, 255, 0.12);
+    color: rgba(241, 245, 255, 0.82);
+    font-weight: 600;
+    padding: 8px 16px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.juntaplay-group-rotator__filters button.is-active,
+.juntaplay-group-rotator__filters button:hover,
+.juntaplay-group-rotator__filters button:focus-visible {
+    background: rgba(241, 245, 255, 0.22);
+    color: #fff;
+}
+
+.juntaplay-group-rotator__viewport {
+    position: relative;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding-bottom: 8px;
+}
+
+.juntaplay-group-rotator__track {
+    display: flex;
+    gap: 24px;
+}
+
+.juntaplay-group-rotator__track .juntaplay-group-card {
+    flex: 0 0 495px;
+    scroll-snap-align: start;
+}
+
+.juntaplay-group-rotator__nav {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    display: flex;
+    justify-content: space-between;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.juntaplay-group-rotator__nav button {
+    pointer-events: all;
+    border: none;
+    background: rgba(8, 12, 24, 0.7);
+    color: #fff;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.juntaplay-group-rotator__nav button:hover,
+.juntaplay-group-rotator__nav button:focus-visible {
+    background: rgba(8, 12, 24, 0.9);
+    transform: translateY(-2px);
+}
+
+.juntaplay-group-rotator__nav button.is-hidden {
+    visibility: hidden;
+    opacity: 0;
+}
+
+.juntaplay-group-rotator__empty {
+    margin-top: 24px;
+    color: rgba(241, 245, 255, 0.7);
+    text-align: center;
+}
+
+@media (max-width: 1024px) {
+    .juntaplay-group-rotator {
+        padding: 36px 24px 48px;
+    }
+
+    .juntaplay-group-rotator__track .juntaplay-group-card {
+        flex-basis: 85%;
+    }
+}
+
+@media (max-width: 640px) {
+    .juntaplay-group-rotator {
+        border-radius: 24px;
+        padding: 32px 20px 44px;
+    }
+
+    .juntaplay-group-card--spotlight .juntaplay-group-card__overlay {
+        padding: 24px;
+    }
+
+    .juntaplay-group-card--spotlight .juntaplay-group-card__title {
+        font-size: 1.35rem;
+    }
+
+    .juntaplay-group-rotator__filters {
+        gap: 8px;
+    }
+}
+
+@media (max-width: 767px) {
+    .juntaplay-groups {
+        padding: 32px 20px;
+    }
+
+    .juntaplay-filters {
+        grid-template-columns: 1fr;
+    }
+
+    .juntaplay-group-card__footer {
+        padding: 0 20px 20px;
+    }
+}
+
+/* Two-factor */
+.juntaplay-two-factor {
+    max-width: 480px;
+    margin: clamp(32px, 8vw, 64px) auto;
+    padding: 0 16px;
+}
+
+.juntaplay-two-factor__card {
+    background: #fff;
+    border-radius: 24px;
+    padding: clamp(32px, 6vw, 48px);
+    box-shadow: 0 26px 60px -32px rgba(15, 39, 92, 0.35);
+    display: grid;
+    gap: 18px;
+}
+
+.juntaplay-two-factor__card h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    color: var(--juntaplay-heading, #071437);
+}
+
+.juntaplay-two-factor__card p {
+    margin: 0;
+    color: var(--juntaplay-muted, #5b6987);
+    line-height: 1.6;
+}
+
+.juntaplay-two-factor__alert {
+    border-radius: 14px;
+    padding: 14px 18px;
+    background: rgba(230, 30, 77, 0.08);
+    border: 1px solid rgba(230, 30, 77, 0.2);
+}
+
+.juntaplay-two-factor__alert ul {
+    margin: 0;
+    padding-left: 20px;
+    color: #d72658;
+}
+
+.juntaplay-two-factor__notice {
+    background: rgba(67, 97, 238, 0.08);
+    border-radius: 12px;
+    padding: 12px 16px;
+    color: var(--juntaplay-primary, #4361ee);
+}
+
+.juntaplay-two-factor__form {
+    display: grid;
+    gap: 12px;
+}
+
+.juntaplay-two-factor__label {
+    font-weight: 600;
+    color: var(--juntaplay-muted-strong, #2a3553);
+}
+
+.juntaplay-two-factor__input {
+    border-radius: 16px;
+    border: 1px solid rgba(15, 39, 92, 0.12);
+    padding: 14px 18px;
+    font-size: 1.4rem;
+    text-align: center;
+    letter-spacing: 0.4em;
+    background: #f8fafd;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.juntaplay-two-factor__input:focus {
+    outline: none;
+    border-color: var(--juntaplay-primary, #4361ee);
+    box-shadow: 0 0 0 3px rgba(67, 97, 238, 0.15);
+    background: #fff;
+}
+
+.juntaplay-two-factor__meta {
+    display: grid;
+    gap: 10px;
+    justify-items: center;
+    font-size: 0.9rem;
+    color: var(--juntaplay-muted, #5b6987);
+}
+
+.juntaplay-two-factor__resend {
+    display: contents;
+}
+
+.juntaplay-two-factor__back {
+    text-align: center;
+}
+
+.juntaplay-two-factor__back .juntaplay-link {
+    font-weight: 600;
+}
+
+@media (max-width: 480px) {
+    .juntaplay-two-factor__input {
+        font-size: 1.2rem;
+        letter-spacing: 0.3em;
+    }
+}
+
+.juntaplay-search-hero {
+    position: relative;
+    margin: 0 auto 64px;
+    padding: 64px clamp(24px, 6vw, 72px);
+    border-radius: 32px;
+    background: radial-gradient(120% 120% at 0% 0%, rgba(50, 213, 173, 0.25) 0%, rgba(15, 88, 245, 0.12) 48%, rgba(255, 255, 255, 0.92) 100%), #f4fbff;
+    overflow: hidden;
+    box-shadow: 0 24px 80px rgba(12, 32, 67, 0.12);
+}
+
+.juntaplay-search-hero::after {
+    content: '';
+    position: absolute;
+    inset-inline-end: -120px;
+    top: -160px;
+    width: 360px;
+    height: 360px;
+    background: radial-gradient(70% 70% at 50% 50%, rgba(0, 180, 255, 0.45) 0%, rgba(0, 180, 255, 0) 100%);
+    pointer-events: none;
+}
+
+.juntaplay-search-hero__content {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+    align-items: center;
+    gap: clamp(32px, 6vw, 72px);
+    z-index: 1;
+}
+
+.juntaplay-search-hero__copy {
+    max-width: 600px;
+}
+
+.juntaplay-search-hero__tagline {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(15, 88, 245, 0.08);
+    color: #0f58f5;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.juntaplay-search-hero__title {
+    margin: 18px 0 12px;
+    font-size: clamp(32px, 4vw, 48px);
+    font-weight: 700;
+    color: #0b1f33;
+    line-height: 1.1;
+}
+
+.juntaplay-search-hero__description {
+    margin: 0 0 28px;
+    font-size: 1.05rem;
+    color: rgba(11, 31, 51, 0.72);
+    max-width: 520px;
+}
+
+.juntaplay-search-hero__form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 16px 40px rgba(12, 32, 67, 0.08);
+}
+
+.juntaplay-search-hero__field {
+    position: relative;
+    flex: 1 1 220px;
+}
+
+.juntaplay-search-hero__field input,
+.juntaplay-search-hero__field select {
+    width: 100%;
+    height: 52px;
+    padding: 0 18px;
+    border-radius: 14px;
+    border: 1px solid rgba(9, 21, 56, 0.08);
+    background: #f8fbff;
+    color: #0b1f33;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.juntaplay-search-hero__field input:focus,
+.juntaplay-search-hero__field select:focus {
+    outline: none;
+    border-color: rgba(15, 88, 245, 0.55);
+    box-shadow: 0 0 0 3px rgba(15, 88, 245, 0.18);
+    background: #fff;
+}
+
+.juntaplay-search-hero__field--select::after {
+    content: '\25BC';
+    position: absolute;
+    inset-inline-end: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: rgba(11, 31, 51, 0.45);
+    pointer-events: none;
+}
+
+.juntaplay-search-hero__field--select select {
+    appearance: none;
+    padding-inline-end: 48px;
+}
+
+.juntaplay-search-hero__actions {
+    display: flex;
+    align-items: center;
+}
+
+.juntaplay-search-hero__submit {
+    padding-inline: 32px;
+    height: 52px;
+    border-radius: 14px;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.juntaplay-search-hero__stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 16px;
+    margin: 32px 0 0;
+    padding: 0;
+}
+
+.juntaplay-search-hero__stats div {
+    padding: 16px 18px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.75);
+    box-shadow: inset 0 0 0 1px rgba(15, 88, 245, 0.05);
+}
+
+.juntaplay-search-hero__stats dt {
+    margin: 0;
+    font-weight: 700;
+    font-size: 1.3rem;
+    color: #0b1f33;
+}
+
+.juntaplay-search-hero__stats dd {
+    margin: 4px 0 0;
+    font-size: 0.85rem;
+    color: rgba(11, 31, 51, 0.58);
+}
+
+.juntaplay-search-hero__media {
+    position: relative;
+    display: grid;
+    gap: 24px;
+    justify-items: center;
+}
+
+.juntaplay-search-hero__card {
+    padding: 20px 24px;
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 18px 50px rgba(12, 32, 67, 0.15);
+    text-align: left;
+    color: #0b1f33;
+    max-width: 280px;
+}
+
+.juntaplay-search-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(15, 88, 245, 0.12);
+    color: #0f58f5;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.juntaplay-search-hero__card p {
+    margin: 14px 0 0;
+    font-size: 0.95rem;
+    color: rgba(11, 31, 51, 0.68);
+}
+
+.juntaplay-search-hero__illustration {
+    width: clamp(220px, 28vw, 320px);
+    height: clamp(220px, 28vw, 320px);
+    border-radius: 50%;
+    background: linear-gradient(140deg, rgba(15, 88, 245, 0.95) 0%, rgba(0, 183, 255, 0.75) 60%, rgba(50, 213, 173, 0.8) 100%);
+    box-shadow: 0 24px 60px rgba(12, 32, 67, 0.25);
+    position: relative;
+}
+
+.juntaplay-search-hero__illustration::after {
+    content: '';
+    position: absolute;
+    inset: 20%;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 1024px) {
+    .juntaplay-search-hero {
+        padding: 48px clamp(20px, 6vw, 48px);
+    }
+
+    .juntaplay-search-hero__content {
+        grid-template-columns: 1fr;
+        justify-items: stretch;
+    }
+
+    .juntaplay-search-hero__media {
+        order: -1;
+    }
+
+    .juntaplay-search-hero__form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .juntaplay-search-hero__actions {
+        width: 100%;
+    }
+
+    .juntaplay-search-hero__submit {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .juntaplay-search-hero__stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .juntaplay-search-hero {
+        padding: 36px 20px;
+        border-radius: 24px;
+    }
+
+    .juntaplay-search-hero__stats {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+
+    .juntaplay-search-hero__field input,
+    .juntaplay-search-hero__field select,
+    .juntaplay-search-hero__submit {
+        height: 48px;
+    }
+}

--- a/juntaplay/assets/js/juntaplay.js
+++ b/juntaplay/assets/js/juntaplay.js
@@ -1,0 +1,2361 @@
+(function ($) {
+    'use strict';
+
+    var i18n = (window.wp && window.wp.i18n) ? window.wp.i18n : null;
+
+    function __(text, domain) {
+        if (i18n && typeof i18n.__ === 'function') {
+            return i18n.__.apply(i18n, arguments);
+        }
+        return text;
+    }
+
+    function _n(single, plural, number, domain) {
+        if (i18n && typeof i18n._n === 'function') {
+            return i18n._n.apply(i18n, arguments);
+        }
+        return number === 1 ? single : plural;
+    }
+
+    function collectNumbers($scope) {
+        var numbers = [];
+        $scope.find('.juntaplay-grid__item.is-selected').each(function () {
+            numbers.push($(this).data('number'));
+        });
+        return numbers;
+    }
+
+    function formatCurrency(amount, currency, locale) {
+        var value = isFinite(amount) ? amount : 0;
+        try {
+            return new Intl.NumberFormat(locale || 'pt-BR', {
+                style: 'currency',
+                currency: currency || 'BRL',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            }).format(value);
+        } catch (e) {
+            return (currency || 'R$') + ' ' + value.toFixed(2);
+        }
+    }
+
+    function escapeHtml(value) {
+        return String(value === null || typeof value === 'undefined' ? '' : value).replace(/[&<>"']/g, function (char) {
+            switch (char) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#039;';
+                default:
+                    return char;
+            }
+        });
+    }
+
+    function truncate(text, length) {
+        var value = String(text || '');
+        if (value.length <= length) {
+            return value;
+        }
+
+        return value.slice(0, Math.max(0, length - 1)) + '…';
+    }
+
+    var coverPlaceholder = (window.JuntaPlay && window.JuntaPlay.assets && window.JuntaPlay.assets.groupCoverPlaceholder)
+        ? window.JuntaPlay.assets.groupCoverPlaceholder.toString()
+        : '';
+
+    function refreshSelected($container) {
+        var numbers = collectNumbers($container);
+        var $numbersWrapper = $container.find('.juntaplay-selected__numbers');
+        var $count = $container.find('.juntaplay-selected__count');
+        var $total = $container.find('.juntaplay-selected__total-value');
+        var $form = $container.find('.juntaplay-quota-form');
+        var emptyLabel = $numbersWrapper.data('empty') || '';
+        var totalEmpty = $total.data('empty') || '';
+        var currency = $form.data('currency');
+        var locale = $form.data('locale');
+        var price = parseFloat($form.data('price')) || 0;
+
+        if (numbers.length) {
+            var chips = numbers.map(function (number) {
+                return '<span class="juntaplay-chip">' + number + '</span>';
+            });
+            $numbersWrapper.html(chips.join(''));
+            $count.text(numbers.length);
+            $total.text(formatCurrency(numbers.length * price, currency, locale));
+        } else {
+            $numbersWrapper.html('<span class="juntaplay-selected__empty">' + emptyLabel + '</span>');
+            $count.text('0');
+            $total.text(totalEmpty);
+        }
+    }
+
+    function toggleQuota($item) {
+        if ($item.hasClass('is-disabled')) {
+            return;
+        }
+
+        $item.toggleClass('is-selected');
+    }
+
+    $(document).on('click', '.juntaplay-grid__item', function () {
+        var $item = $(this);
+        var $container = $item.closest('.juntaplay-quota-selector');
+        toggleQuota($item);
+        $container.data('selectedNumbers', collectNumbers($container));
+        refreshSelected($container);
+    });
+
+    $(document).on('submit', '.juntaplay-quota-form', function (event) {
+        var $form = $(this);
+        var $container = $form.closest('.juntaplay-quota-selector');
+        var numbers = collectNumbers($container);
+
+        if (!numbers.length) {
+            event.preventDefault();
+            alert($form.data('message-empty'));
+            return false;
+        }
+
+        $form.find('input[name="jp_numbers[]"]').remove();
+
+        numbers.forEach(function (number) {
+            $('<input />', {
+                type: 'hidden',
+                name: 'jp_numbers[]',
+                value: number
+            }).appendTo($form);
+        });
+
+        return true;
+    });
+
+    function quotaStatusLabel(status) {
+        switch (status) {
+            case 'reserved':
+                return __('Reservada', 'juntaplay');
+            case 'paid':
+                return __('Paga', 'juntaplay');
+            case 'canceled':
+                return __('Cancelada', 'juntaplay');
+            case 'expired':
+                return __('Expirada', 'juntaplay');
+            default:
+                return __('Disponível', 'juntaplay');
+        }
+    }
+
+    function renderQuotaItem(item, selected) {
+        var status = item.status || 'available';
+        var classes = ['juntaplay-grid__item'];
+
+        if (status !== 'available') {
+            classes.push('is-disabled');
+            classes.push('status-' + status);
+        }
+
+        if (selected) {
+            classes.push('is-selected');
+        }
+
+        var badge = '';
+        if (status !== 'available') {
+            badge = '<span class="juntaplay-grid__badge">' + quotaStatusLabel(status) + '</span>';
+        }
+
+        return '<button type="button" class="' + classes.join(' ') + '" data-number="' + item.number + '" data-status="' + status + '">' +
+            '<span class="juntaplay-grid__number">' + item.number + '</span>' + badge +
+            '</button>';
+    }
+
+    function initQuotaSelector($container) {
+        var state = {
+            poolId: parseInt($container.data('pool'), 10) || 0,
+            perPage: parseInt($container.data('perPage'), 10) || 120,
+            page: 1,
+            status: ($container.data('status') || 'available').toString(),
+            search: '',
+            sort: ($container.data('sort') || 'ASC').toString(),
+            loading: false,
+            hasMore: true
+        };
+
+        var $grid = $container.find('.juntaplay-grid');
+        var $load = $container.find('[data-quota-load]');
+        var $feedback = $container.find('[data-quota-feedback]');
+        var $filters = $container.find('.juntaplay-quota-filter');
+
+        $container.data('selectedNumbers', collectNumbers($container));
+
+        function toggleLoading(isLoading) {
+            state.loading = isLoading;
+            $container.toggleClass('is-loading', isLoading);
+            if (isLoading) {
+                $load.prop('disabled', true).text(__('Carregando...', 'juntaplay'));
+            } else {
+                $load.prop('disabled', false).text(state.hasMore ? __('Ver mais números', 'juntaplay') : __('Todos os números carregados', 'juntaplay'));
+            }
+        }
+
+        function fetchQuotas(reset) {
+            if (state.loading || !state.poolId) {
+                return;
+            }
+
+            toggleLoading(true);
+
+            if (reset) {
+                state.page = 1;
+                state.hasMore = true;
+            }
+
+            $.ajax({
+                url: JuntaPlay.ajax,
+                dataType: 'json',
+                method: 'GET',
+                data: {
+                    action: 'juntaplay_pool_numbers',
+                    nonce: JuntaPlay.nonce,
+                    pool_id: state.poolId,
+                    page: state.page,
+                    per_page: state.perPage,
+                    status: state.status,
+                    search: state.search,
+                    sort: state.sort
+                }
+            }).done(function (response) {
+                if (!response || !response.success) {
+                    $feedback.text(response && response.data && response.data.message ? response.data.message : __('Não foi possível carregar as cotas agora.', 'juntaplay')).addClass('is-visible');
+                    return;
+                }
+
+                var data = response.data || {};
+                var items = data.items || [];
+
+                if (reset) {
+                    $grid.empty();
+                }
+
+                if (!items.length && reset) {
+                    $feedback.text(__('Nenhum número encontrado para os filtros selecionados.', 'juntaplay')).addClass('is-visible');
+                } else {
+                    $feedback.removeClass('is-visible').text('');
+                }
+
+                var selected = $container.data('selectedNumbers') || [];
+
+                if (items.length) {
+                    var markup = items.map(function (item) {
+                        return renderQuotaItem(item, selected.indexOf(item.number) !== -1);
+                    });
+                    $grid.append(markup.join(''));
+                }
+
+                state.page = (data.page || 1) + 1;
+                state.hasMore = (data.page || 1) < (data.pages || 1);
+
+                if (!state.hasMore) {
+                    $load.attr('disabled', true).text(__('Todos os números carregados', 'juntaplay'));
+                } else {
+                    $load.attr('disabled', false).text(__('Ver mais números', 'juntaplay'));
+                }
+
+                refreshSelected($container);
+            }).fail(function () {
+                $feedback.text(__('Não foi possível carregar as cotas agora.', 'juntaplay')).addClass('is-visible');
+            }).always(function () {
+                toggleLoading(false);
+            });
+        }
+
+        $filters.on('submit', function (event) {
+            event.preventDefault();
+            state.status = ($filters.find('[name="status"]').val() || 'available').toString();
+            state.search = ($filters.find('[name="search"]').val() || '').toString();
+            state.sort = ($filters.find('[name="sort"]').val() || 'ASC').toString();
+            fetchQuotas(true);
+        });
+
+        $load.on('click', function (event) {
+            event.preventDefault();
+            if (!state.hasMore || state.loading) {
+                return;
+            }
+            fetchQuotas(false);
+        });
+
+        fetchQuotas(true);
+    }
+
+    function renderPoolCard(pool) {
+        var badge = pool.is_featured ? '<span class="juntaplay-pool-card__badge">' + __('Destaque', 'juntaplay') + '</span>' : '';
+        var category = pool.categoryLabel ? '<span class="juntaplay-badge">' + pool.categoryLabel + '</span>' : '';
+        var progress = '<div class="juntaplay-progress"><span class="juntaplay-progress__bar" style="width:' + (pool.progress || 0) + '%"></span></div>';
+        var quotaMeta = '<div class="juntaplay-pool-card__meta">' +
+            '<span>' + __('Disponíveis', 'juntaplay') + ': ' + pool.quotasFree + '</span>' +
+            '<span>' + __('Vendidas', 'juntaplay') + ': ' + pool.quotasPaid + '</span>' +
+            '</div>';
+        var cover = pool.thumbnail ? '<div class="juntaplay-pool-card__cover"><img src="' + pool.thumbnail + '" alt="' + pool.title + '" /></div>' : '<div class="juntaplay-pool-card__cover is-placeholder"><span>' + __('Campanha', 'juntaplay') + '</span></div>';
+
+        return '<article class="juntaplay-pool-card">' +
+            cover +
+            '<div class="juntaplay-pool-card__body">' + badge +
+            '<h3 class="juntaplay-pool-card__title"><a href="' + pool.permalink + '">' + pool.title + '</a></h3>' +
+            category +
+            '<p class="juntaplay-pool-card__excerpt">' + pool.excerpt + '</p>' +
+            '<div class="juntaplay-pool-card__price">' + __('Rifa a partir de', 'juntaplay') + ' <strong>' + pool.priceLabel + '</strong></div>' +
+            progress +
+            quotaMeta +
+            '<a class="juntaplay-button juntaplay-button--primary" href="' + pool.permalink + '">' + __('Participar agora', 'juntaplay') + '</a>' +
+            '</div>' +
+            '</article>';
+    }
+
+    function initPoolCatalog($catalog) {
+        var state = {
+            page: 1,
+            perPage: parseInt($catalog.data('perPage'), 10) || 12,
+            category: ($catalog.data('category') || '').toString(),
+            orderby: ($catalog.data('orderby') || 'created_at').toString(),
+            order: ($catalog.data('order') || 'desc').toString(),
+            featured: ($catalog.data('featured') || '').toString(),
+            minPrice: '',
+            maxPrice: '',
+            search: '',
+            loading: false,
+            hasMore: true
+        };
+
+        var $results = $catalog.find('[data-pool-results]');
+        var $meta = $catalog.find('[data-pool-meta]');
+        var $empty = $catalog.find('[data-pool-empty]');
+        var $load = $catalog.find('[data-pools-load]');
+        var $form = $catalog.find('form.juntaplay-pool-filters');
+
+        function togglePoolsLoading(isLoading) {
+            state.loading = isLoading;
+            $catalog.toggleClass('is-loading', isLoading);
+            if (isLoading) {
+                $load.prop('disabled', true).text(__('Carregando...', 'juntaplay'));
+            } else {
+                $load.prop('disabled', false).text(state.hasMore ? __('Carregar mais campanhas', 'juntaplay') : __('Tudo carregado', 'juntaplay'));
+            }
+        }
+
+        function updateMeta(total) {
+            if (!$meta.length) {
+                return;
+            }
+            $meta.text(total ? __('Exibindo', 'juntaplay') + ' ' + total : '');
+        }
+
+        function fetchPools(reset) {
+            if (state.loading) {
+                return;
+            }
+
+            togglePoolsLoading(true);
+
+            if (reset) {
+                state.page = 1;
+                state.hasMore = true;
+            }
+
+            $.ajax({
+                url: JuntaPlay.ajax,
+                dataType: 'json',
+                method: 'GET',
+                data: {
+                    action: 'juntaplay_pools',
+                    nonce: JuntaPlay.nonce,
+                    page: state.page,
+                    per_page: state.perPage,
+                    category: state.category,
+                    search: state.search,
+                    min_price: state.minPrice,
+                    max_price: state.maxPrice,
+                    orderby: state.orderby,
+                    order: state.order,
+                    featured: state.featured
+                }
+            }).done(function (response) {
+                if (!response || !response.success) {
+                    $empty.text(response && response.data && response.data.message ? response.data.message : __('Não foi possível carregar as campanhas.', 'juntaplay')).addClass('is-visible');
+                    return;
+                }
+
+                var data = response.data || {};
+                var items = data.items || [];
+
+                if (reset) {
+                    $results.empty();
+                }
+
+                if (!items.length && reset) {
+                    $empty.text(__('Nenhuma campanha encontrada com os filtros selecionados.', 'juntaplay')).addClass('is-visible');
+                } else {
+                    $empty.removeClass('is-visible').text('');
+                }
+
+                if (items.length) {
+                    var markup = items.map(renderPoolCard);
+                    $results.append(markup.join(''));
+                }
+
+                state.page = (data.page || 1) + 1;
+                state.hasMore = (data.page || 1) < (data.pages || 1);
+                if (!state.hasMore) {
+                    $load.attr('disabled', true).text(__('Tudo carregado', 'juntaplay'));
+                } else {
+                    $load.attr('disabled', false).text(__('Carregar mais campanhas', 'juntaplay'));
+                }
+
+                updateMeta(data.total || 0);
+            }).fail(function () {
+                $empty.text(__('Não foi possível carregar as campanhas.', 'juntaplay')).addClass('is-visible');
+            }).always(function () {
+                togglePoolsLoading(false);
+            });
+        }
+
+        $form.on('submit', function (event) {
+            event.preventDefault();
+            state.category = ($form.find('[name="category"]').val() || '').toString();
+            state.search = ($form.find('[name="search"]').val() || '').toString();
+            state.orderby = ($form.find('[name="orderby"]').val() || 'created_at').toString();
+            state.order = ($form.find('[name="order"]').val() || 'desc').toString();
+            state.minPrice = ($form.find('[name="min_price"]').val() || '').toString();
+            state.maxPrice = ($form.find('[name="max_price"]').val() || '').toString();
+            fetchPools(true);
+        });
+
+        $load.on('click', function (event) {
+            event.preventDefault();
+            if (!state.hasMore || state.loading) {
+                return;
+            }
+            fetchPools(false);
+        });
+
+        fetchPools(true);
+    }
+
+    $(function () {
+        $('.juntaplay-quota-selector').each(function () {
+            initQuotaSelector($(this));
+        });
+
+        $('.juntaplay-pool-catalog').each(function () {
+            initPoolCatalog($(this));
+        });
+
+        $('[data-jp-two-factor]').each(function () {
+            initTwoFactor($(this));
+        });
+
+        $('.juntaplay-groups[data-jp-groups]').each(function () {
+            initGroupsDirectory($(this));
+        });
+
+        $('[data-group-cover]').each(function () {
+            initGroupCoverPicker($(this));
+        });
+
+        $('.juntaplay-group-rotator').each(function () {
+            initGroupRotator($(this));
+        });
+    });
+
+    function applyGroupFilters($scope) {
+        var $list = $scope.find('[data-group-list]');
+        var $items = $list.find('[data-group-item]');
+        var roleFilter = ($scope.data('role-filter') || 'all').toString();
+        var statusFilter = ($scope.data('status-filter') || 'all').toString();
+        var visibleCount = 0;
+
+        $items.each(function () {
+            var $item = $(this);
+            var role = ($item.data('group-role') || '').toString();
+            var status = ($item.data('group-status') || '').toString();
+            var hide = false;
+
+            if (roleFilter === 'owned' && role !== 'owner' && role !== 'manager') {
+                hide = true;
+            } else if (roleFilter === 'member' && (role === 'owner' || role === 'manager')) {
+                hide = true;
+            }
+
+            if (!hide && statusFilter !== 'all' && status !== statusFilter) {
+                hide = true;
+            }
+
+            $item.toggleClass('is-hidden', hide);
+
+            if (!hide) {
+                visibleCount++;
+            }
+        });
+
+        var $empty = $list.find('[data-group-empty]');
+        if ($empty.length) {
+            if (visibleCount === 0) {
+                $empty.removeClass('is-hidden');
+            } else {
+                $empty.addClass('is-hidden');
+            }
+        }
+    }
+
+    $(document).on('click', '[data-group-filter]', function (event) {
+        event.preventDefault();
+
+        var $button = $(this);
+        var filter = ($button.data('group-filter') || 'all').toString();
+        var $groups = $button.closest('[data-groups]');
+
+        if (!$groups.length) {
+            return;
+        }
+
+        $button.addClass('is-active').attr('aria-selected', 'true');
+        $button.siblings('[data-group-filter]').removeClass('is-active').attr('aria-selected', 'false');
+
+        $groups.data('role-filter', filter);
+        applyGroupFilters($groups);
+    });
+
+    $(document).on('change', '[data-group-status-filter]', function () {
+        var $select = $(this);
+        var status = ($select.val() || 'all').toString();
+        var $groups = $select.closest('[data-groups]');
+
+        if (!$groups.length) {
+            return;
+        }
+
+        $groups.data('status-filter', status);
+        applyGroupFilters($groups);
+    });
+
+    function parseMoneyInput(value) {
+        if (value === null || typeof value === 'undefined') {
+            return 0;
+        }
+
+        var normalized = value.toString().trim();
+        if (!normalized) {
+            return 0;
+        }
+
+        normalized = normalized.replace(/[^0-9,\.\-]/g, '');
+        if (!normalized || normalized === '-') {
+            return 0;
+        }
+
+        if (normalized.indexOf(',') !== -1 && normalized.indexOf('.') !== -1) {
+            normalized = normalized.replace(/\./g, '').replace(',', '.');
+        } else if (normalized.indexOf(',') !== -1) {
+            normalized = normalized.replace(',', '.');
+        }
+
+        var amount = parseFloat(normalized);
+        return isNaN(amount) ? 0 : amount;
+    }
+
+    function toLocaleDecimal(amount) {
+        if (!isFinite(amount) || amount <= 0) {
+            return '';
+        }
+
+        try {
+            return amount.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        } catch (e) {
+            return amount.toFixed(2);
+        }
+    }
+
+    function gatherGroupShareData($form) {
+        var $categoryField = $form.find('[name="jp_profile_group_category"]');
+        var categoryValue = $.trim(($categoryField.val() || '').toString());
+        var categoryLabel = $.trim(($categoryField.find('option:selected').text() || '').toString());
+
+        return {
+            name: $.trim(($form.find('[name="jp_profile_group_name"]').val() || '').toString()),
+            service: $.trim(($form.find('[name="jp_profile_group_service"]').val() || '').toString()),
+            serviceUrl: $.trim(($form.find('[name="jp_profile_group_service_url"]').val() || '').toString()),
+            rules: $.trim(($form.find('[name="jp_profile_group_rules"]').val() || '').toString()),
+            description: $.trim(($form.find('[name="jp_profile_group_description"]').val() || '').toString()),
+            price: parseMoneyInput($form.find('[name="jp_profile_group_price"]').val()),
+            promoEnabled: $form.find('[data-group-promo-toggle]').is(':checked'),
+            promo: parseMoneyInput($form.find('[name="jp_profile_group_price_promo"]').val()),
+            slotsTotal: parseInt(($form.find('[name="jp_profile_group_slots_total"]').val() || '0').toString(), 10) || 0,
+            slotsReserved: parseInt(($form.find('[name="jp_profile_group_slots_reserved"]').val() || '0').toString(), 10) || 0,
+            memberPrice: parseMoneyInput($form.find('[name="jp_profile_group_member_price"]').val()),
+            support: $.trim(($form.find('[name="jp_profile_group_support"]').val() || '').toString()),
+            delivery: $.trim(($form.find('[name="jp_profile_group_delivery"]').val() || '').toString()),
+            access: $.trim(($form.find('[name="jp_profile_group_access"]').val() || '').toString()),
+            category: categoryValue,
+            categoryLabel: categoryLabel,
+            instantAccess: $form.find('[name="jp_profile_group_instant"]').is(':checked')
+        };
+    }
+
+    function updateGroupSharePreview($form) {
+        if (!$form.length) {
+            return;
+        }
+
+        var $share = $form.find('[data-group-share]');
+        if (!$share.length) {
+            return;
+        }
+
+        var data = gatherGroupShareData($form);
+        var domain = ($share.data('domain') || '').toString();
+        var fallbackPromo = ($share.find('[data-group-share-field="promo"]').data('fallback') || '').toString();
+        var fallbackCategory = ($share.find('[data-group-share-field="category"]').data('empty') || '').toString();
+        var fallbackInstant = ($share.find('[data-group-share-field="instant_access"]').data('fallback') || '').toString();
+
+        var priceText = data.price > 0 ? formatCurrency(data.price, 'BRL', 'pt-BR') : '';
+        var promoText = data.promoEnabled && data.promo > 0 ? formatCurrency(data.promo, 'BRL', 'pt-BR') : '';
+        var memberText = data.memberPrice > 0 ? formatCurrency(data.memberPrice, 'BRL', 'pt-BR') : '';
+        var reservedText = data.slotsReserved > 0 ? data.slotsReserved.toString() : '';
+        var promoLabel = promoText || fallbackPromo || 'Não';
+        var promoFlag = (data.promoEnabled && data.promo > 0) ? 'Sim' : 'Não';
+        var categoryText = data.categoryLabel || fallbackCategory;
+        var instantText = data.instantAccess ? 'Ativado' : (fallbackInstant || 'Desativado');
+
+        var fieldMap = {
+            service: data.service,
+            name: data.name,
+            category: categoryText,
+            service_url: data.serviceUrl,
+            rules: data.rules,
+            description: data.description,
+            price: priceText,
+            promo_flag: promoFlag,
+            promo: promoLabel,
+            slots_total: data.slotsTotal > 0 ? data.slotsTotal.toString() : '',
+            slots_reserved: reservedText || '0',
+            member_price: memberText,
+            support: data.support,
+            delivery: data.delivery,
+            access: data.access,
+            instant_access: instantText
+        };
+
+        $.each(fieldMap, function (key, value) {
+            var $target = $share.find('[data-group-share-field="' + key + '"]');
+            if (!$target.length) {
+                return;
+            }
+
+            var fallback = ($target.data('empty') || $target.data('fallback') || '').toString();
+            var output = value;
+
+            if (typeof output === 'string') {
+                output = output.trim();
+            }
+
+            if (output) {
+                $target.text(output);
+            } else if (fallback) {
+                $target.text(fallback);
+            } else {
+                $target.text('—');
+            }
+        });
+
+        var lines = [];
+
+        if (domain) {
+            lines.push(domain);
+        }
+        if (data.service) {
+            lines.push('Serviço: ' + data.service);
+        }
+        if (data.name) {
+            lines.push('Nome do grupo: ' + data.name);
+        }
+        lines.push('Tipo: Público');
+        if (categoryText) {
+            lines.push('Categoria: ' + categoryText);
+        }
+        if (data.serviceUrl) {
+            lines.push('Site: ' + data.serviceUrl);
+        }
+        if (data.rules) {
+            lines.push('Regras: ' + data.rules);
+        }
+        if (data.description) {
+            lines.push('Descrição: ' + data.description);
+        }
+        if (priceText) {
+            lines.push('Valor do serviço: ' + priceText);
+        }
+        lines.push('É valor promocional?: ' + promoFlag);
+        lines.push('Valor promocional: ' + promoLabel);
+        if (data.slotsTotal > 0) {
+            lines.push('Vagas totais: ' + data.slotsTotal);
+        }
+        if (data.slotsReserved > 0) {
+            lines.push('Reservadas para você: ' + data.slotsReserved);
+        }
+        if (memberText) {
+            lines.push('Os membros vão pagar: ' + memberText);
+        }
+        if (data.support) {
+            lines.push('Suporte aos membros: ' + data.support);
+        }
+        if (data.delivery) {
+            lines.push('Envio de acesso: ' + data.delivery);
+        }
+        if (data.access) {
+            lines.push('Forma de acesso: ' + data.access);
+        }
+        lines.push('Acesso instantâneo: ' + instantText);
+
+        var shareText = lines.join('\n');
+        if (!shareText) {
+            shareText = ($share.data('empty') || '').toString();
+        }
+
+        var $snippet = $share.find('[data-group-share-snippet]');
+        if ($snippet.length) {
+            $snippet.text(shareText);
+        }
+
+        var $textarea = $share.find('[data-group-share-text]');
+        if ($textarea.length) {
+            $textarea.val(shareText);
+        }
+    }
+
+    function updateGroupPricePreview($form) {
+        if (!$form.length) {
+            return;
+        }
+
+        var price = parseMoneyInput($form.find('[name="jp_profile_group_price"]').val());
+        var $promoToggle = $form.find('[data-group-promo-toggle]');
+        var promoEnabled = $promoToggle.is(':checked');
+        var promo = promoEnabled ? parseMoneyInput($form.find('[name="jp_profile_group_price_promo"]').val()) : 0;
+        var total = parseInt($form.find('[name="jp_profile_group_slots_total"]').val(), 10) || 0;
+        var reserved = parseInt($form.find('[name="jp_profile_group_slots_reserved"]').val(), 10) || 0;
+        var available = Math.max(1, total - reserved);
+        var basis = promo > 0 ? promo : price;
+        var suggestion = basis > 0 ? (basis / available) : 0;
+        var $member = $form.find('[data-group-member-input]');
+        var $preview = $form.find('[data-group-price-preview]');
+        var memberDirty = $member.data('jpDirty') === true;
+        var memberGenerated = $member.data('group-member-generated') === 'yes';
+
+        if ($member.length) {
+            if (!memberDirty && suggestion > 0) {
+                var formatted = toLocaleDecimal(suggestion);
+                if (formatted) {
+                    $member.val(formatted);
+                    $member.data('group-member-generated', 'yes');
+                }
+            } else if (!memberDirty && suggestion <= 0 && memberGenerated) {
+                $member.val('');
+            }
+        }
+
+        if ($preview.length) {
+            var previewAmount = parseMoneyInput($member.val());
+            if (previewAmount <= 0 && suggestion > 0) {
+                previewAmount = suggestion;
+            }
+
+            if (previewAmount > 0) {
+                var suffix = ($preview.data('suffix') || '').toString().trim();
+                var message = formatCurrency(previewAmount, 'BRL', 'pt-BR');
+                if (suffix) {
+                    message += ' ' + suffix;
+                }
+                $preview.text(message).removeClass('is-hidden');
+            } else {
+                var emptyMessage = ($preview.data('empty') || '').toString();
+                if (emptyMessage) {
+                    $preview.text(emptyMessage).removeClass('is-hidden');
+                } else {
+                    $preview.addClass('is-hidden');
+                }
+            }
+        }
+
+        updateGroupSharePreview($form);
+    }
+
+    function togglePromoField($toggle) {
+        var $form = $toggle.closest('form');
+        var $wrapper = $form.find('[data-group-promo-field]');
+
+        if ($toggle.is(':checked')) {
+            $wrapper.removeClass('is-hidden');
+        } else {
+            $wrapper.addClass('is-hidden');
+            $wrapper.find('input').val('');
+        }
+
+        updateGroupPricePreview($form);
+    }
+
+    $(document).on('change', '[data-group-promo-toggle]', function () {
+        togglePromoField($(this));
+    });
+
+    $(document).on('input change', '[data-group-price-input], [data-group-slot-input]', function () {
+        var $form = $(this).closest('form');
+        updateGroupPricePreview($form);
+    });
+
+    $(document).on('change', '#jp-group-instant', function () {
+        var $input = $(this);
+        var $caption = $input.closest('.juntaplay-toggle').find('.juntaplay-toggle__caption');
+
+        if ($caption.length) {
+            var activeLabel = ($caption.data('toggle-caption-active') || 'Ativado').toString();
+            var inactiveLabel = ($caption.data('toggle-caption-inactive') || 'Desativado').toString();
+            $caption.text($input.is(':checked') ? activeLabel : inactiveLabel);
+        }
+
+        updateGroupSharePreview($input.closest('form'));
+    });
+
+    $(document).on('input', '[data-group-member-input]', function () {
+        var $input = $(this);
+        $input.data('jpDirty', true);
+        $input.data('group-member-generated', 'no');
+        updateGroupPricePreview($input.closest('form'));
+    });
+
+    $(document).on('blur', '[data-group-member-input]', function () {
+        var $input = $(this);
+        var amount = parseMoneyInput($input.val());
+        if (amount > 0) {
+            $input.val(toLocaleDecimal(amount));
+        }
+    });
+
+    $(document).on('input change', '[data-group-share-watch]', function () {
+        var $form = $(this).closest('form');
+        updateGroupSharePreview($form);
+    });
+
+    $(document).on('click', '[data-group-share-copy]', function (event) {
+        event.preventDefault();
+
+        var $button = $(this);
+        var $share = $button.closest('[data-group-share]');
+        var $textarea = $share.find('[data-group-share-text]');
+
+        if (!$textarea.length) {
+            var $form = $button.closest('form');
+            if ($form.length) {
+                $textarea = $form.find('[data-group-share-text]');
+            }
+        }
+
+        if (!$textarea.length) {
+            return;
+        }
+
+        var text = ($textarea.val() || '').toString();
+        if (!text) {
+            return;
+        }
+
+        var defaultLabel = ($button.data('default-label') || $button.text() || '').toString();
+        var successLabel = ($button.data('success-label') || defaultLabel).toString();
+
+        var onSuccess = function () {
+            $button.text(successLabel).addClass('is-success');
+            setTimeout(function () {
+                $button.text(defaultLabel).removeClass('is-success');
+            }, 2000);
+        };
+
+        var onFailure = function () {
+            alert($button.data('error-label') || 'Não foi possível copiar agora. Copie manualmente.');
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(onSuccess).catch(onFailure);
+        } else {
+            var element = $textarea[0];
+            var shouldHide = element.hasAttribute('hidden');
+
+            try {
+                element.removeAttribute('hidden');
+                element.select();
+                var result = document.execCommand('copy');
+                if (result) {
+                    onSuccess();
+                } else {
+                    onFailure();
+                }
+            } catch (err) {
+                onFailure();
+            } finally {
+                if (shouldHide) {
+                    element.setAttribute('hidden', 'hidden');
+                }
+                if (window.getSelection) {
+                    try {
+                        window.getSelection().removeAllRanges();
+                    } catch (ignore) {
+                        /* noop */
+                    }
+                }
+            }
+        }
+    });
+
+    $(document).on('click', '[data-group-suggestion-apply]', function (event) {
+        event.preventDefault();
+
+        var $button = $(this);
+        var $card = $button.closest('[data-group-suggestion]');
+        var $form = $button.closest('.juntaplay-groups__create').find('form');
+
+        if (!$card.length || !$form.length) {
+            return;
+        }
+
+        var service = ($card.data('title') || '').toString();
+        var amount = parseFloat(($card.data('amount') || '').toString().replace(',', '.'));
+        var category = ($card.data('category') || '').toString();
+        var description = ($card.data('description') || '').toString();
+
+        if (service) {
+            $form.find('[name="jp_profile_group_service"]').val(service).trigger('input');
+        }
+
+        var $name = $form.find('[name="jp_profile_group_name"]');
+        if ($name.length && !$.trim(($name.val() || '').toString())) {
+            $name.val('Grupo ' + service).trigger('input');
+        }
+
+        if (description) {
+            var $description = $form.find('[name="jp_profile_group_description"]');
+            if ($description.length && !$.trim(($description.val() || '').toString())) {
+                $description.val(description).trigger('input');
+            }
+        }
+
+        if (Number.isFinite(amount) && amount > 0) {
+            $form.find('[name="jp_profile_group_price"]').val(toLocaleDecimal(amount)).trigger('input');
+        }
+
+        if (category) {
+            $form.find('[name="jp_profile_group_category"]').val(category).trigger('change');
+        }
+
+        var $promoToggle = $form.find('[data-group-promo-toggle]');
+        if ($promoToggle.length) {
+            $promoToggle.prop('checked', false);
+            togglePromoField($promoToggle);
+        }
+
+        var $promoValue = $form.find('[name="jp_profile_group_price_promo"]');
+        if ($promoValue.length) {
+            $promoValue.val('');
+        }
+
+        var $memberInput = $form.find('[name="jp_profile_group_member_price"]');
+        if ($memberInput.length) {
+            $memberInput.val('').data('group-member-generated', 'yes');
+        }
+
+        updateGroupPricePreview($form);
+        updateGroupSharePreview($form);
+    });
+
+    $(document.body).on('updated_wc_div updated_cart_totals wc_fragments_refreshed', function () {
+        $('.juntaplay-quota-selector').each(function () {
+            refreshSelected($(this));
+        });
+    });
+
+    $(function () {
+        $('[data-groups]').each(function () {
+            applyGroupFilters($(this));
+        });
+
+        $('[data-group-member-input]').each(function () {
+            var $input = $(this);
+            if ($input.data('group-member-generated') === 'yes') {
+                $input.removeData('jpDirty');
+            } else if ($input.val()) {
+                $input.data('jpDirty', true);
+            }
+            updateGroupPricePreview($input.closest('form'));
+        });
+
+        $('[data-group-promo-toggle]').each(function () {
+            var $toggle = $(this);
+            if ($toggle.is(':checked')) {
+                $toggle.closest('form').find('[data-group-promo-field]').removeClass('is-hidden');
+            }
+        });
+
+        $('[data-group-share]').each(function () {
+            var $form = $(this).closest('form');
+            updateGroupSharePreview($form);
+        });
+    });
+
+    function activateAuthView($auth, view) {
+        if (!view) {
+            return;
+        }
+
+        $auth.attr('data-active-view', view);
+
+        $auth.find('.juntaplay-auth__switch-btn').each(function () {
+            var $btn = $(this);
+            var isActive = $btn.data('target') === view;
+            $btn.toggleClass('is-active', isActive);
+            $btn.attr('aria-selected', isActive ? 'true' : 'false');
+        });
+
+        $auth.find('.juntaplay-auth__pane').each(function () {
+            var $pane = $(this);
+            var isActive = $pane.data('pane') === view;
+            $pane.toggleClass('is-active', isActive);
+            $pane.attr('aria-hidden', isActive ? 'false' : 'true');
+        });
+    }
+
+    $(document).on('click', '.juntaplay-auth__switch-btn', function (event) {
+        event.preventDefault();
+
+        var $btn = $(this);
+
+        if ($btn.is(':disabled')) {
+            return;
+        }
+
+        var target = $btn.data('target');
+        var $auth = $btn.closest('.juntaplay-auth');
+
+        activateAuthView($auth, target);
+    });
+
+    $(function () {
+        $('.juntaplay-auth').each(function () {
+            var $auth = $(this);
+            activateAuthView($auth, $auth.data('active-view'));
+        });
+    });
+
+    $(document).on('click', '.juntaplay-profile__edit', function (event) {
+        event.preventDefault();
+
+        var $btn = $(this);
+        var $row = $btn.closest('.juntaplay-profile__row');
+        var $profile = $btn.closest('.juntaplay-profile');
+        var isOpen = $row.hasClass('is-editing');
+
+        if (!isOpen) {
+            $profile.find('.juntaplay-profile__row').removeClass('is-editing');
+            $profile.find('.juntaplay-profile__form').attr('aria-hidden', 'true');
+            $profile.find('.juntaplay-profile__edit').attr('aria-expanded', 'false');
+        }
+
+        $row.toggleClass('is-editing', !isOpen);
+        $row.find('.juntaplay-profile__form').attr('aria-hidden', !isOpen ? 'false' : 'true');
+        $btn.attr('aria-expanded', !isOpen ? 'true' : 'false');
+
+        if (!isOpen) {
+            var $input = $row.find('.juntaplay-form__input').first();
+            if ($input.length) {
+                setTimeout(function () {
+                    $input.trigger('focus');
+                }, 20);
+            }
+        }
+    });
+
+    $(document).on('click', '.juntaplay-profile__cancel', function (event) {
+        event.preventDefault();
+
+        var $row = $(this).closest('.juntaplay-profile__row');
+        $row.removeClass('is-editing');
+        $row.find('.juntaplay-profile__form').attr('aria-hidden', 'true');
+        $row.find('.juntaplay-profile__edit').attr('aria-expanded', 'false');
+    });
+
+    function updateComplaintToggle($button, isOpen) {
+        var defaultLabel = $button.data('defaultLabel');
+        var openLabel = $button.data('openLabel');
+
+        if (!defaultLabel) {
+            defaultLabel = $button.text();
+            $button.data('defaultLabel', defaultLabel);
+        }
+
+        if (!openLabel) {
+            openLabel = defaultLabel;
+        }
+
+        if (isOpen) {
+            $button.addClass('is-active').text(openLabel);
+        } else {
+            $button.removeClass('is-active').text(defaultLabel);
+        }
+    }
+
+    $(document).on('click', '[data-group-complaint-toggle]', function (event) {
+        event.preventDefault();
+
+        var $button = $(this);
+        var target = $button.attr('data-target') || '';
+        var $form = target ? $('#' + target) : $button.closest('[data-group-complaint]').find('[data-group-complaint-form]');
+
+        if (!$form.length) {
+            return;
+        }
+
+        var willOpen = $form.hasClass('is-hidden');
+        $form.toggleClass('is-hidden', !willOpen).toggleClass('is-open', willOpen);
+        $button.attr('aria-expanded', willOpen ? 'true' : 'false');
+        updateComplaintToggle($button, willOpen);
+    });
+
+    $(document).on('click', '[data-group-complaint-close]', function (event) {
+        event.preventDefault();
+
+        var $form = $(this).closest('[data-group-complaint-form]');
+
+        if (!$form.length) {
+            return;
+        }
+
+        $form.removeClass('is-open').addClass('is-hidden');
+
+        var formId = $form.attr('id');
+        if (!formId) {
+            return;
+        }
+
+        var $toggle = $('[data-group-complaint-toggle][data-target="' + formId + '"]');
+        if ($toggle.length) {
+            $toggle.attr('aria-expanded', 'false');
+            updateComplaintToggle($toggle, false);
+        }
+    });
+
+    $(document).on('change', '[data-group-complaint-files]', function () {
+        var $input = $(this);
+        var files = this.files;
+        var $preview = $input.closest('[data-group-complaint]').find('[data-group-complaint-preview]');
+
+        if (!$preview.length) {
+            return;
+        }
+
+        $preview.empty();
+
+        if (!files || !files.length) {
+            return;
+        }
+
+        Array.prototype.forEach.call(files, function (file) {
+            var size = file.size || 0;
+            var label = file.name;
+
+            if (size > 0) {
+                label += ' (' + formatBytes(size) + ')';
+            }
+
+            $('<li />').text(label).appendTo($preview);
+        });
+    });
+
+    function formatBytes(bytes) {
+        if (!bytes || bytes <= 0) {
+            return '';
+        }
+
+        var units = ['B', 'KB', 'MB', 'GB'];
+        var index = 0;
+        var value = bytes;
+
+        while (value >= 1024 && index < units.length - 1) {
+            value /= 1024;
+            index += 1;
+        }
+
+        return value.toFixed(index === 0 ? 0 : 1) + ' ' + units[index];
+    }
+
+    function renderGroupCard(item, variant) {
+        var mode = (variant || 'spotlight').toString();
+        var classes = ['juntaplay-group-card'];
+        if (mode === 'spotlight') {
+            classes.push('juntaplay-group-card--spotlight');
+        }
+
+        var cover = item.coverUrl || coverPlaceholder || '';
+        var alt = escapeHtml(item.coverAlt || item.title || item.service || __('Capa do grupo', 'juntaplay'));
+        var category = item.categoryLabel ? '<span class="juntaplay-group-card__category">' + escapeHtml(item.categoryLabel) + '</span>' : '';
+        var instant = item.instantAccess ? '<span class="juntaplay-group-card__instant">' + __('Acesso imediato', 'juntaplay') + '</span>' : '';
+        var service = escapeHtml(item.service || '');
+        var title = escapeHtml(item.title || '');
+        var description = truncate(item.description || '', 140);
+        var price = escapeHtml(item.memberPriceLabel || item.priceLabel || __('Sob consulta', 'juntaplay'));
+        var available = parseInt(item.slotsAvailable || 0, 10) || 0;
+        var total = parseInt(item.slotsTotal || 0, 10) || 0;
+        var members = parseInt(item.membersCount || 0, 10) || 0;
+        var slotsLabel = '';
+
+        if (available > 0 || total > 0) {
+            slotsLabel = available + (total ? ' / ' + total : '') + ' ' + __('vagas', 'juntaplay');
+        }
+
+        var membersLabel = members ? members + ' ' + __('participantes', 'juntaplay') : '';
+        var link = item.permalink ? escapeHtml(item.permalink) : '#';
+
+        return '<article class="' + classes.join(' ') + '" data-group-card>'
+            + '<div class="juntaplay-group-card__frame">'
+            + '<img src="' + escapeHtml(cover) + '" alt="' + alt + '" loading="lazy" width="495" height="370" />'
+            + category
+            + instant
+            + '<div class="juntaplay-group-card__overlay">'
+            + (service ? '<span class="juntaplay-group-card__service">' + service + '</span>' : '')
+            + '<h3 class="juntaplay-group-card__title">' + (title || service) + '</h3>'
+            + (description ? '<p class="juntaplay-group-card__excerpt">' + escapeHtml(description) + '</p>' : '')
+            + '<div class="juntaplay-group-card__stats">'
+            + '<span class="juntaplay-group-card__price">' + price + '</span>'
+            + (slotsLabel ? '<span class="juntaplay-group-card__slots">' + escapeHtml(slotsLabel) + '</span>' : '')
+            + (membersLabel ? '<span class="juntaplay-group-card__members">' + escapeHtml(membersLabel) + '</span>' : '')
+            + '</div>'
+            + '<a class="juntaplay-button juntaplay-button--primary" href="' + link + '">' + __('Participar agora', 'juntaplay') + '</a>'
+            + '</div>'
+            + '</div>'
+            + '</article>';
+    }
+
+    function initGroupCoverPicker($wrapper) {
+        if (!$wrapper.length || typeof wp === 'undefined' || !wp.media || typeof wp.media !== 'function') {
+            return;
+        }
+
+        var frame;
+        var placeholder = ($wrapper.data('placeholder') || '').toString();
+        var $input = $wrapper.find('[data-group-cover-input]');
+        var $preview = $wrapper.find('[data-group-cover-preview]');
+        var $remove = $wrapper.find('[data-group-cover-remove]');
+
+        function setCover(id, url) {
+            var value = id ? id.toString() : '';
+            var source = url || placeholder || coverPlaceholder;
+
+            $input.val(value);
+
+            if ($preview.length) {
+                $preview.css('background-image', source ? 'url(' + source + ')' : 'none');
+                var $img = $preview.find('img');
+                if ($img.length) {
+                    $img.attr('src', source || coverPlaceholder || '');
+                }
+            }
+
+            if ($remove.length) {
+                $remove.prop('disabled', !value);
+            }
+        }
+
+        $wrapper.on('click', '[data-group-cover-select]', function (event) {
+            event.preventDefault();
+
+            if (frame) {
+                frame.open();
+                return;
+            }
+
+            frame = wp.media({
+                title: __('Escolher capa do grupo', 'juntaplay'),
+                button: { text: __('Usar esta imagem', 'juntaplay') },
+                multiple: false
+            });
+
+            frame.on('select', function () {
+                var attachment = frame.state().get('selection').first();
+                if (!attachment) {
+                    return;
+                }
+
+                attachment = attachment.toJSON();
+                setCover(attachment.id || '', attachment.url || placeholder || coverPlaceholder || '');
+            });
+
+            frame.open();
+        });
+
+        $wrapper.on('click', '[data-group-cover-remove]', function (event) {
+            event.preventDefault();
+            setCover('', '');
+        });
+    }
+
+    function initGroupsDirectory($root) {
+        if (!$root.length || typeof window.JuntaPlay === 'undefined') {
+            return;
+        }
+
+        var state = {
+            page: 1,
+            perPage: parseInt($root.data('perPage'), 10) || 9,
+            loading: false,
+            hasMore: true,
+            orderby: 'created',
+            order: 'desc',
+            category: '',
+            search: '',
+            instant: ''
+        };
+
+        var defaultSearch = $root.data('defaultSearch');
+        var defaultCategory = $root.data('defaultCategory');
+        var defaultOrderby = $root.data('defaultOrderby');
+        var defaultOrder = $root.data('defaultOrder');
+        var defaultInstant = $root.data('defaultInstant');
+
+        if (typeof defaultSearch === 'string' && defaultSearch.length) {
+            state.search = defaultSearch;
+        }
+
+        if (typeof defaultCategory === 'string' && defaultCategory.length) {
+            state.category = defaultCategory;
+        }
+
+        if (typeof defaultOrderby === 'string' && defaultOrderby.length) {
+            state.orderby = defaultOrderby;
+        }
+
+        if (typeof defaultOrder === 'string' && defaultOrder.length) {
+            state.order = defaultOrder;
+        }
+
+        if (typeof defaultInstant === 'string' && defaultInstant.length) {
+            state.instant = defaultInstant;
+        }
+
+        var $list = $root.find('[data-jp-groups-list]');
+        var $empty = $root.find('[data-jp-groups-empty]');
+        var $more = $root.find('[data-jp-groups-more]');
+        var $total = $root.find('[data-jp-groups-total]');
+        var $filters = $root.find('[data-jp-groups-filters]');
+
+        function setLoading(isLoading) {
+            state.loading = isLoading;
+            $root.toggleClass('is-loading', isLoading);
+
+            if ($more.length) {
+                if (isLoading) {
+                    $more.prop('disabled', true).text(__('Carregando...', 'juntaplay'));
+                } else {
+                    $more.prop('disabled', false).toggle(state.hasMore).text(state.hasMore ? __('Carregar mais grupos', 'juntaplay') : __('Todos os grupos carregados', 'juntaplay'));
+                }
+            }
+        }
+
+        function updateTotal(total) {
+            if (!$total.length) {
+                return;
+            }
+
+            total = parseInt(total, 10) || 0;
+            $total.text(total ? _n('%d grupo encontrado', '%d grupos encontrados', total, 'juntaplay').replace('%d', total) : __('Nenhum grupo encontrado', 'juntaplay'));
+        }
+
+        function render(items, reset) {
+            if (reset) {
+                $list.empty();
+            }
+
+            if (items && items.length) {
+                var html = items.map(function (item) {
+                    return renderGroupCard(item, 'spotlight');
+                }).join('');
+                $list.append(html);
+                $empty.attr('hidden', 'hidden');
+            } else if (reset) {
+                $empty.removeAttr('hidden');
+            }
+        }
+
+        function fetch(reset) {
+            if (state.loading) {
+                return;
+            }
+
+            setLoading(true);
+
+            if (reset) {
+                state.page = 1;
+                state.hasMore = true;
+            }
+
+            $.getJSON(window.JuntaPlay.ajax, {
+                action: 'juntaplay_groups_directory',
+                nonce: window.JuntaPlay.nonce,
+                page: state.page,
+                per_page: state.perPage,
+                search: state.search,
+                category: state.category,
+                orderby: state.orderby,
+                order: state.order,
+                instant_access: state.instant
+            }).done(function (response) {
+                if (!response || !response.success || !response.data) {
+                    return;
+                }
+
+                var data = response.data;
+                render(data.items || [], reset);
+                updateTotal(data.total || 0);
+                var currentPage = parseInt(data.page, 10) || 1;
+                var totalPages = parseInt(data.pages, 10) || 1;
+
+                state.page = currentPage + 1;
+                state.hasMore = currentPage < totalPages;
+
+                if ($more.length) {
+                    if (state.hasMore) {
+                        $more.removeAttr('hidden').prop('disabled', false).text(__('Carregar mais grupos', 'juntaplay'));
+                    } else {
+                        $more.attr('hidden', 'hidden').prop('disabled', true).text(__('Todos os grupos carregados', 'juntaplay'));
+                    }
+                }
+            }).fail(function () {
+                if (reset) {
+                    $list.empty();
+                    $empty.removeAttr('hidden').text(__('Não foi possível carregar os grupos agora.', 'juntaplay'));
+                    if ($more.length) {
+                        $more.attr('hidden', 'hidden').prop('disabled', true);
+                    }
+                }
+            }).always(function () {
+                setLoading(false);
+            });
+        }
+
+        if ($filters.length) {
+            if (state.search) {
+                $filters.find('input[name="search"]').val(state.search);
+            }
+
+            if (state.category) {
+                $filters.find('select[name="category"]').val(state.category);
+            }
+
+            if (state.instant === '1') {
+                $filters.find('input[name="instant"]').prop('checked', true);
+            }
+
+            if (state.orderby) {
+                var $sortSelect = $filters.find('select[name="orderby"]');
+                if ($sortSelect.length) {
+                    var $matchingOption = $sortSelect.find('option').filter(function () {
+                        var $option = $(this);
+                        var optionValue = ($option.val() || '').toString();
+                        var optionOrder = ($option.data('order') || '').toString();
+                        if (optionValue !== state.orderby) {
+                            return false;
+                        }
+
+                        if (!state.order) {
+                            return true;
+                        }
+
+                        return optionOrder === state.order;
+                    }).first();
+
+                    if ($matchingOption.length) {
+                        $sortSelect.val($matchingOption.val());
+                        $sortSelect.find('option').prop('selected', false);
+                        $matchingOption.prop('selected', true);
+                        state.order = ($matchingOption.data('order') || state.order || 'desc').toString();
+                    } else {
+                        $sortSelect.val(state.orderby);
+                        var $selectedOption = $sortSelect.find(':selected');
+                        if ($selectedOption.length) {
+                            state.order = ($selectedOption.data('order') || state.order || 'desc').toString();
+                        }
+                    }
+                }
+            }
+
+            $filters.on('submit', function (event) {
+                event.preventDefault();
+                state.search = $filters.find('input[name="search"]').val() || '';
+                fetch(true);
+            });
+
+            $filters.on('change', 'select[name="category"]', function () {
+                state.category = $(this).val() || '';
+                fetch(true);
+            });
+
+            $filters.on('change', 'select[name="orderby"]', function () {
+                var $selected = $(this).find(':selected');
+                state.orderby = $(this).val() || 'created';
+                state.order = ($selected.data('order') || 'desc').toString();
+                fetch(true);
+            });
+
+            $filters.on('change', 'input[name="instant"]', function () {
+                state.instant = $(this).is(':checked') ? '1' : '';
+                fetch(true);
+            });
+
+            $filters.on('click', '[data-jp-groups-clear]', function () {
+                $filters.find('input[name="search"]').val('');
+                $filters.find('select[name="category"]').prop('selectedIndex', 0);
+                var $sort = $filters.find('select[name="orderby"]');
+                $sort.prop('selectedIndex', 0);
+                state.orderby = $sort.val() || 'created';
+                state.order = ($sort.find(':selected').data('order') || 'desc').toString();
+                $filters.find('input[name="instant"]').prop('checked', false);
+                state.search = '';
+                state.category = '';
+                state.instant = '';
+                fetch(true);
+            });
+        }
+
+        if ($more.length) {
+            $more.on('click', function () {
+                if (!state.hasMore || state.loading) {
+                    return;
+                }
+
+                fetch(false);
+            });
+        }
+
+        fetch(true);
+    }
+
+    function initTwoFactor($root) {
+        if (!$root.length) {
+            return;
+        }
+
+        var remaining = parseInt($root.data('remaining'), 10) || 0;
+        var cooldown = parseInt($root.data('cooldown'), 10) || 45;
+        var $timer = $root.find('[data-jp-two-factor-timer]');
+        var $resendButton = $root.find('[data-jp-two-factor-resend-button]');
+        var $input = $root.find('[data-jp-two-factor-input]');
+
+        if ($input.length) {
+            setTimeout(function () {
+                $input.trigger('focus');
+            }, 150);
+        }
+
+        if ($timer.length && remaining > 0) {
+            var countdown = setInterval(function () {
+                remaining -= 1;
+
+                if (remaining <= 0) {
+                    clearInterval(countdown);
+                    $timer.attr('hidden', 'hidden');
+                    return;
+                }
+
+                var minutes = Math.floor(remaining / 60);
+                var seconds = remaining % 60;
+                var formatted = String(minutes).padStart(2, '0') + ':' + String(seconds).padStart(2, '0');
+                $timer.removeAttr('hidden').text(__('O código expira em %s.', 'juntaplay').replace('%s', formatted));
+            }, 1000);
+        }
+
+        if ($resendButton.length && cooldown > 0) {
+            var cooldownTimer;
+            $root.on('submit', '[data-jp-two-factor-resend]', function () {
+                if ($resendButton.prop('disabled')) {
+                    return;
+                }
+
+                $resendButton.prop('disabled', true).text(__('Enviando...', 'juntaplay'));
+
+                if (cooldownTimer) {
+                    clearInterval(cooldownTimer);
+                }
+
+                var remainingCooldown = cooldown;
+                cooldownTimer = setInterval(function () {
+                    remainingCooldown -= 1;
+
+                    if (remainingCooldown <= 0) {
+                        clearInterval(cooldownTimer);
+                        $resendButton.prop('disabled', false).text(__('Enviar novo código', 'juntaplay'));
+                    } else {
+                        $resendButton.text(__('Tente novamente em %s s', 'juntaplay').replace('%s', remainingCooldown));
+                    }
+                }, 1000);
+            });
+        }
+    }
+
+    $(function () {
+        $('.juntaplay-profile__row').each(function () {
+            var $row = $(this);
+            var isEditing = $row.hasClass('is-editing');
+            $row.find('.juntaplay-profile__form').attr('aria-hidden', isEditing ? 'false' : 'true');
+            $row.find('.juntaplay-profile__edit').attr('aria-expanded', isEditing ? 'true' : 'false');
+        });
+
+        $('[data-jp-wallet]').each(function () {
+            initWallet($(this));
+        });
+
+        initNotifications();
+    });
+
+    $(document).on('submit', '.juntaplay-form[data-confirm]', function (event) {
+        var $form = $(this);
+        var message = $form.data('confirm');
+
+        if (message && !window.confirm(message)) {
+            event.preventDefault();
+            return false;
+        }
+
+        return true;
+    });
+
+    function initWallet($root) {
+        if (!$root.length || typeof window.JuntaPlay === 'undefined') {
+            return;
+        }
+
+        var isLoading = false;
+        var $details = $root.find('[data-jp-credit-details]');
+        var $detailsBody = $details.find('[data-jp-credit-details-body]');
+        var $detailsTitle = $details.find('[data-jp-credit-details-title]');
+        var $loadMore = $root.find('[data-jp-credit-load-more]');
+        var $hint = $root.find('[data-jp-credit-countdown]');
+        var $depositPanel = $root.find('[data-jp-credit-deposit]');
+        var $depositForm = $depositPanel.find('[data-jp-credit-deposit-form]');
+        var $depositInput = $depositForm.find('[name="jp_profile_deposit_amount"]');
+        var $depositError = $depositForm.find('[data-jp-credit-deposit-error]');
+        var depositEnabled = parseInt($root.data('deposit-enabled'), 10) === 1;
+        var depositMin = parseFloat($root.data('deposit-min')) || 0;
+        var depositMax = parseFloat($root.data('deposit-max')) || 0;
+        var depositLoading = false;
+
+        function showNotice(type, message) {
+            var $notice = $('<div/>')
+                .addClass('juntaplay-wallet__alert juntaplay-wallet__alert--' + type)
+                .text(message || '');
+            $root.find('.juntaplay-wallet__withdraw .juntaplay-wallet__alert').remove();
+            $root.find('.juntaplay-wallet__withdraw').prepend($notice);
+        }
+
+        function renderTransaction(item) {
+            var id = item.id || 0;
+            var title = item.type_label || '';
+            var status = item.status_label || '';
+            var amount = item.amount_formatted || item.amount || '';
+            var time = item.time || '';
+            var reference = item.reference || '';
+
+            var meta = time;
+            if (reference) {
+                meta += ' · ' + reference;
+            }
+
+            return [
+                '<li class="juntaplay-wallet__item" data-transaction="' + id + '">',
+                '  <div class="juntaplay-wallet__item-main">',
+                '    <strong class="juntaplay-wallet__item-title">' + title + '</strong>',
+                '    <span class="juntaplay-wallet__item-meta">' + meta + '</span>',
+                '  </div>',
+                '  <div class="juntaplay-wallet__item-side">',
+                '    <span class="juntaplay-wallet__item-status">' + status + '</span>',
+                '    <span class="juntaplay-wallet__item-amount">' + amount + '</span>',
+                '  </div>',
+                '</li>'
+            ].join('');
+        }
+
+        function openDetails(data) {
+            if (!data || !$details.length) {
+                return;
+            }
+
+            var html = ['<dl>'];
+            html.push('<dt>' + (data.type_label || '') + '</dt>');
+            html.push('<dd>' + (data.amount_formatted || '') + '</dd>');
+
+            if (data.status_label) {
+                html.push('<dt>' + __('Status', 'juntaplay') + '</dt>');
+                html.push('<dd>' + data.status_label + '</dd>');
+            }
+
+            if (data.reference) {
+                html.push('<dt>' + __('Referência', 'juntaplay') + '</dt>');
+                html.push('<dd>' + data.reference + '</dd>');
+            }
+
+            if (data.time) {
+                html.push('<dt>' + __('Data', 'juntaplay') + '</dt>');
+                html.push('<dd>' + data.time + '</dd>');
+            }
+
+            if (data.balance_after) {
+                html.push('<dt>' + __('Saldo após', 'juntaplay') + '</dt>');
+                html.push('<dd>' + data.balance_after + '</dd>');
+            }
+
+            if (data.context) {
+                Object.keys(data.context).forEach(function (key) {
+                    if (!data.context[key]) {
+                        return;
+                    }
+                    html.push('<dt>' + key + '</dt>');
+                    html.push('<dd>' + data.context[key] + '</dd>');
+                });
+            }
+
+            html.push('</dl>');
+
+            $detailsTitle.text(data.type_label || __('Detalhes', 'juntaplay'));
+            $detailsBody.html(html.join(''));
+            $details.removeAttr('hidden');
+        }
+
+        function closeDetails() {
+            $details.attr('hidden', 'hidden');
+        }
+
+        function openDeposit() {
+            if (!$depositPanel.length) {
+                return;
+            }
+
+            $depositPanel.removeAttr('hidden').addClass('is-open');
+            if ($depositInput.length) {
+                $depositInput.trigger('focus');
+            }
+        }
+
+        function closeDeposit() {
+            if (!$depositPanel.length) {
+                return;
+            }
+
+            $depositPanel.attr('hidden', 'hidden').removeClass('is-open');
+            $depositError.attr('hidden', 'hidden').text('');
+            depositLoading = false;
+        }
+
+        function showDepositError(message) {
+            if (!$depositError.length) {
+                window.alert(message);
+                return;
+            }
+
+            $depositError.text(message || '').removeAttr('hidden');
+        }
+
+        $root.on('click', '[data-jp-credit-details-close]', function () {
+            closeDetails();
+        });
+
+        $root.on('click', '.juntaplay-wallet__item', function () {
+            if (isLoading) {
+                return;
+            }
+
+            var transactionId = $(this).data('transaction');
+            if (!transactionId) {
+                return;
+            }
+
+            isLoading = true;
+            $.getJSON(window.JuntaPlay.ajax, {
+                action: 'juntaplay_credit_transaction',
+                nonce: window.JuntaPlay.nonce,
+                id: transactionId
+            }).done(function (response) {
+                if (response && response.success && response.data && response.data.transaction) {
+                    openDetails(response.data.transaction);
+                }
+            }).fail(function () {
+                window.alert(__('Não foi possível carregar os detalhes agora.', 'juntaplay'));
+            }).always(function () {
+                isLoading = false;
+            });
+        });
+
+        $root.on('click', '[data-jp-credit-load-more]', function () {
+            if (isLoading) {
+                return;
+            }
+
+            var current = parseInt($root.attr('data-page'), 10) || 1;
+            var pages = parseInt($root.attr('data-pages'), 10) || 1;
+
+            if (current >= pages) {
+                return;
+            }
+
+            isLoading = true;
+            $.getJSON(window.JuntaPlay.ajax, {
+                action: 'juntaplay_credit_transactions',
+                nonce: window.JuntaPlay.nonce,
+                page: current + 1
+            }).done(function (response) {
+                if (!response || !response.success) {
+                    return;
+                }
+
+                if (response.data && response.data.items) {
+                    var items = response.data.items.map(renderTransaction).join('');
+                    $root.find('.juntaplay-wallet__list').append(items);
+                }
+
+                if (response.data && typeof response.data.page !== 'undefined') {
+                    $root.attr('data-page', response.data.page);
+                }
+
+                if (response.data && typeof response.data.pages !== 'undefined') {
+                    $root.attr('data-pages', response.data.pages);
+                    if (response.data.page >= response.data.pages) {
+                        $loadMore.remove();
+                    }
+                }
+
+                if (response.data && typeof response.data.total !== 'undefined') {
+                    $root.attr('data-total', response.data.total);
+                    $root.find('[data-jp-credit-total]').text(response.data.total + ' ' + (response.data.total === 1 ? __('movimento', 'juntaplay') : __('movimentos', 'juntaplay')));
+                }
+            }).always(function () {
+                isLoading = false;
+            });
+        });
+
+        $root.on('submit', '.juntaplay-wallet__form', function (event) {
+            var $form = $(this);
+
+            if (!window.JuntaPlay || !window.JuntaPlay.ajax) {
+                return true;
+            }
+
+            event.preventDefault();
+
+            if (isLoading) {
+                return false;
+            }
+
+            isLoading = true;
+
+            var payload = {
+                action: 'juntaplay_credit_withdraw',
+                nonce: window.JuntaPlay.nonce,
+                amount: $form.find('[name="jp_profile_withdraw_amount"]').val(),
+                method: $form.find('[name="jp_profile_withdraw_method"]').val(),
+                code: $form.find('[name="jp_profile_withdraw_code"]').val()
+            };
+
+            $.post(window.JuntaPlay.ajax, payload, null, 'json').done(function (response) {
+                if (!response) {
+                    return;
+                }
+
+                if (response.success) {
+                    showNotice('success', response.data && response.data.message ? response.data.message : __('Solicitação registrada com sucesso.', 'juntaplay'));
+                    window.setTimeout(function () {
+                        window.location.reload();
+                    }, 1500);
+                    return;
+                }
+
+                if (response.data && response.data.message) {
+                    showNotice('warning', response.data.message);
+                }
+            }).fail(function () {
+                showNotice('warning', __('Não foi possível registrar a solicitação agora.', 'juntaplay'));
+            }).always(function () {
+                isLoading = false;
+            });
+
+            return false;
+        });
+
+        $root.on('click', '[data-jp-credit-send-code]', function () {
+            if (isLoading) {
+                return;
+            }
+
+            isLoading = true;
+            var $button = $(this);
+            $button.prop('disabled', true);
+
+            $.post(window.JuntaPlay.ajax, {
+                action: 'juntaplay_credit_send_code',
+                nonce: window.JuntaPlay.nonce
+            }, null, 'json').done(function (response) {
+                if (response && response.success) {
+                    var data = response.data || {};
+                    if ($hint.length && data.message) {
+                        $hint.text(data.message);
+                    }
+                    if ($root.find('[data-jp-credit-destination]').length && data.destination) {
+                        $root.find('[data-jp-credit-destination]').text(data.destination);
+                    }
+                } else if (response && response.data && response.data.message) {
+                    window.alert(response.data.message);
+                }
+            }).fail(function () {
+                window.alert(__('Não foi possível enviar o código agora.', 'juntaplay'));
+            }).always(function () {
+                isLoading = false;
+                $button.prop('disabled', false);
+            });
+        });
+
+        $root.on('click', '[data-jp-credit-details]', function (event) {
+            if ($(event.target).is('[data-jp-credit-details]')) {
+                closeDetails();
+            }
+        });
+
+        $root.on('click', '[data-jp-credit-topup]', function (event) {
+            event.preventDefault();
+
+            if (!depositEnabled) {
+                window.alert(__('Recarga indisponível no momento.', 'juntaplay'));
+
+                return;
+            }
+
+            openDeposit();
+        });
+
+        $root.on('click', '[data-jp-credit-deposit-close]', function (event) {
+            event.preventDefault();
+            closeDeposit();
+        });
+
+        $root.on('click', '[data-jp-credit-suggestion]', function (event) {
+            event.preventDefault();
+            if (!$depositInput.length) {
+                return;
+            }
+
+            var value = parseFloat($(this).data('jp-credit-suggestion')) || 0;
+            if (value > 0) {
+                $depositInput.val(value.toFixed(2)).trigger('change');
+            }
+        });
+
+        $root.on('submit', '[data-jp-credit-deposit-form]', function (event) {
+            event.preventDefault();
+
+            if (!window.JuntaPlay || !window.JuntaPlay.ajax) {
+                return false;
+            }
+
+            if (depositLoading) {
+                return false;
+            }
+
+            var amount = 0;
+            if ($depositInput.length) {
+                amount = parseFloat(($depositInput.val() || '').toString().replace(',', '.')) || 0;
+            }
+
+            if (amount <= 0 || (depositMin > 0 && amount < depositMin)) {
+                showDepositError(__('Informe um valor de recarga acima do mínimo permitido.', 'juntaplay'));
+
+                return false;
+            }
+
+            if (depositMax > 0 && amount > depositMax) {
+                showDepositError(__('O valor informado excede o limite máximo permitido.', 'juntaplay'));
+
+                return false;
+            }
+
+            depositLoading = true;
+            $depositError.attr('hidden', 'hidden').text('');
+
+            var payload = {
+                action: 'juntaplay_credit_deposit',
+                nonce: window.JuntaPlay.nonce,
+                amount: amount
+            };
+
+            $.post(window.JuntaPlay.ajax, payload, null, 'json').done(function (response) {
+                if (!response) {
+                    return;
+                }
+
+                if (response.success && response.data && response.data.redirect) {
+                    window.location.href = response.data.redirect;
+                    return;
+                }
+
+                if (response.success) {
+                    window.location.reload();
+                    return;
+                }
+
+                if (response.data && response.data.message) {
+                    showDepositError(response.data.message);
+                } else {
+                    showDepositError(__('Não foi possível iniciar a recarga agora.', 'juntaplay'));
+                }
+            }).fail(function () {
+                showDepositError(__('Não foi possível iniciar a recarga agora.', 'juntaplay'));
+            }).always(function () {
+                depositLoading = false;
+            });
+
+            return false;
+        });
+    }
+
+    function initGroupRotator($root) {
+        if (!$root.length || typeof window.JuntaPlay === 'undefined') {
+            return;
+        }
+
+        var limit = parseInt($root.data('limit'), 10) || 12;
+        var autoplay = parseInt($root.data('autoplay'), 10) || 6500;
+        var defaultCategory = ($root.data('defaultCategory') || '').toString();
+
+        var state = {
+            category: defaultCategory,
+            loading: false,
+            items: []
+        };
+
+        var $viewport = $root.find('[data-rotator-viewport]');
+        var $track = $root.find('[data-rotator-track]');
+        var $filters = $root.find('[data-rotator-filter]');
+        var $prev = $root.find('[data-rotator-prev]');
+        var $next = $root.find('[data-rotator-next]');
+        var $empty = $root.find('[data-rotator-empty]');
+        var timer = null;
+
+        function setLoading(isLoading) {
+            state.loading = isLoading;
+            $root.toggleClass('is-loading', isLoading);
+        }
+
+        function render(items) {
+            $track.empty();
+
+            if (!items || !items.length) {
+                if ($empty.length) {
+                    $empty.removeAttr('hidden');
+                }
+                if ($prev.length) {
+                    $prev.prop('disabled', true).addClass('is-hidden');
+                }
+                if ($next.length) {
+                    $next.prop('disabled', true).addClass('is-hidden');
+                }
+                return;
+            }
+
+            var html = items.map(function (item) {
+                return renderGroupCard(item, 'spotlight');
+            }).join('');
+
+            $track.html(html);
+            if ($empty.length) {
+                $empty.attr('hidden', 'hidden');
+            }
+
+            if ($viewport.length && $viewport.get(0)) {
+                $viewport.get(0).scrollTo({ left: 0 });
+            }
+
+            var single = items.length <= 1;
+            if ($prev.length) {
+                $prev.toggleClass('is-hidden', single).prop('disabled', single);
+            }
+            if ($next.length) {
+                $next.toggleClass('is-hidden', single).prop('disabled', single);
+            }
+        }
+
+        function fetch() {
+            if (state.loading) {
+                return;
+            }
+
+            setLoading(true);
+
+            $.getJSON(window.JuntaPlay.ajax, {
+                action: 'juntaplay_groups_directory',
+                nonce: window.JuntaPlay.nonce,
+                page: 1,
+                per_page: limit,
+                orderby: 'updated',
+                order: 'desc',
+                category: state.category
+            }).done(function (response) {
+                if (!response || !response.success || !response.data) {
+                    render([]);
+                    return;
+                }
+
+                state.items = response.data.items || [];
+                render(state.items);
+            }).fail(function () {
+                render([]);
+            }).always(function () {
+                setLoading(false);
+            });
+        }
+
+        function scroll(direction) {
+            var viewport = $viewport.get(0);
+            if (!viewport) {
+                return;
+            }
+
+            var step = $track.find('.juntaplay-group-card').first().outerWidth(true) || $viewport.innerWidth();
+            var distance = direction === 'next' ? step : -step;
+
+            viewport.scrollBy({ left: distance, behavior: 'smooth' });
+        }
+
+        function restartTimer() {
+            if (!autoplay || autoplay < 0) {
+                return;
+            }
+
+            if (timer) {
+                clearInterval(timer);
+            }
+
+            timer = setInterval(function () {
+                if (!state.items.length) {
+                    return;
+                }
+
+                scroll('next');
+            }, autoplay);
+        }
+
+        if ($filters.length) {
+            $filters.on('click', '[data-rotator-filter]', function (event) {
+                event.preventDefault();
+
+                var $button = $(this);
+                var category = ($button.data('rotatorFilter') || '').toString();
+
+                if (category === state.category) {
+                    return;
+                }
+
+                state.category = category;
+                $button.addClass('is-active').attr('aria-selected', 'true');
+                $button.siblings('[data-rotator-filter]').removeClass('is-active').attr('aria-selected', 'false');
+                fetch();
+            });
+        }
+
+        if ($prev.length) {
+            $prev.on('click', function (event) {
+                event.preventDefault();
+                scroll('prev');
+                restartTimer();
+            });
+        }
+
+        if ($next.length) {
+            $next.on('click', function (event) {
+                event.preventDefault();
+                scroll('next');
+                restartTimer();
+            });
+        }
+
+        if ($viewport.length) {
+            $viewport.on('mouseenter', function () {
+                if (timer) {
+                    clearInterval(timer);
+                }
+            });
+
+            $viewport.on('mouseleave', function () {
+                restartTimer();
+            });
+        }
+
+        fetch();
+        restartTimer();
+    }
+
+    function initNotifications() {
+        if (typeof window.JuntaPlay === 'undefined') {
+            return;
+        }
+
+        var $bell = $('[data-jp-notifications]');
+        if (!$bell.length) {
+            return;
+        }
+
+        var $panel = $('[data-jp-notifications-panel]');
+        var $list = $panel.find('[data-jp-notifications-list]');
+        var isLoaded = false;
+        var isLoading = false;
+
+        function setState(open) {
+            $bell.attr('aria-expanded', open ? 'true' : 'false');
+            $panel.attr('aria-hidden', open ? 'false' : 'true');
+        }
+
+        function togglePanel(force) {
+            var open = typeof force === 'boolean' ? force : !$panel.hasClass('is-open');
+            if (open) {
+                $panel.addClass('is-open');
+                $bell.addClass('is-active');
+                setState(true);
+                if (!isLoaded) {
+                    fetchNotifications();
+                }
+            } else {
+                $panel.removeClass('is-open');
+                $bell.removeClass('is-active');
+                setState(false);
+            }
+        }
+
+        function fetchNotifications() {
+            if (isLoading) {
+                return;
+            }
+
+            isLoading = true;
+
+            if (!isLoaded) {
+                $list.html('<li class="juntaplay-notifications__empty">' + __('Carregando notificações...', 'juntaplay') + '</li>');
+            }
+
+            $.getJSON(window.JuntaPlay.ajax, {
+                action: 'juntaplay_notifications_feed',
+                nonce: window.JuntaPlay.nonce
+            }).done(function (response) {
+                if (!response || !response.success) {
+                    return;
+                }
+
+                isLoaded = true;
+
+                if (response.data && response.data.items) {
+                    if (!response.data.items.length) {
+                        $list.html('<li class="juntaplay-notifications__empty">' + __('Nenhuma notificação por enquanto.', 'juntaplay') + '</li>');
+                    } else {
+                        var html = response.data.items.map(function (item) {
+                            var title = item.title || '';
+                            var message = item.message || '';
+                            var time = item.time || '';
+                            var href = item.action_url || '';
+                            var content = '<span class="juntaplay-notifications__item-title">' + title + '</span>' +
+                                '<span class="juntaplay-notifications__item-message">' + message + '</span>' +
+                                '<span class="juntaplay-notifications__item-time">' + time + '</span>';
+
+                            if (href) {
+                                return '<li><a class="juntaplay-notifications__item" data-notification-id="' + item.id + '" href="' + href + '">' + content + '</a></li>';
+                            }
+
+                            return '<li><span class="juntaplay-notifications__item" data-notification-id="' + item.id + '">' + content + '</span></li>';
+                        }).join('');
+
+                        $list.html(html);
+                    }
+                }
+
+                if (response.data && typeof response.data.unread !== 'undefined') {
+                    var unread = parseInt(response.data.unread, 10) || 0;
+                    if (unread > 0) {
+                        $bell.attr('data-count', unread);
+                    } else {
+                        $bell.removeAttr('data-count');
+                    }
+                }
+            }).always(function () {
+                isLoading = false;
+            });
+        }
+
+        function markNotification(id) {
+            $.post(window.JuntaPlay.ajax, {
+                action: 'juntaplay_notifications_mark',
+                nonce: window.JuntaPlay.nonce,
+                ids: [id]
+            }, null, 'json').done(function (response) {
+                if (response && response.data && typeof response.data.unread !== 'undefined') {
+                    var unread = parseInt(response.data.unread, 10) || 0;
+                    if (unread > 0) {
+                        $bell.attr('data-count', unread);
+                    } else {
+                        $bell.removeAttr('data-count');
+                    }
+                }
+                isLoaded = false;
+            });
+        }
+
+        $bell.on('click', function (event) {
+            event.preventDefault();
+            togglePanel();
+        });
+
+        $(document).on('click', function (event) {
+            if (!$panel.hasClass('is-open')) {
+                return;
+            }
+
+            if ($(event.target).closest('[data-jp-notifications]').length || $(event.target).closest('[data-jp-notifications-panel]').length) {
+                return;
+            }
+
+            togglePanel(false);
+        });
+
+        $panel.on('click', '[data-notification-id]', function () {
+            var id = $(this).data('notification-id');
+            if (id) {
+                markNotification(id);
+                var $item = $(this).closest('li');
+                if ($item.length) {
+                    $item.remove();
+                    if (!$list.children().length) {
+                        $list.html('<li class="juntaplay-notifications__empty">' + __('Nenhuma notificação por enquanto.', 'juntaplay') + '</li>');
+                    }
+                }
+            }
+        });
+
+        $panel.on('click', '[data-jp-notifications-close]', function (event) {
+            event.preventDefault();
+            togglePanel(false);
+        });
+
+        setState(false);
+    }
+})(jQuery);

--- a/juntaplay/elementor/Widgets/WidgetPoolHero.php
+++ b/juntaplay/elementor/Widgets/WidgetPoolHero.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlayElementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+defined('ABSPATH') || exit;
+
+class WidgetPoolHero extends Widget_Base
+{
+    public function get_name(): string
+    {
+        return 'juntaplay_pool_hero';
+    }
+
+    public function get_title(): string
+    {
+        return __('JuntaPlay — Hero da Campanha', 'juntaplay');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-info-box';
+    }
+
+    public function get_categories(): array
+    {
+        return ['general'];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('content', [
+            'label' => __('Conteúdo', 'juntaplay'),
+        ]);
+
+        $this->add_control('pool_id', [
+            'label'       => __('ID da Campanha', 'juntaplay'),
+            'type'        => Controls_Manager::NUMBER,
+            'default'     => 0,
+            'description' => __('Informe o ID da campanha ou deixe 0 para detectar automaticamente em páginas de produto.', 'juntaplay'),
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $id       = isset($settings['pool_id']) ? (int) $settings['pool_id'] : 0;
+
+        echo do_shortcode('[juntaplay_pool id="' . $id . '"]');
+    }
+}

--- a/juntaplay/elementor/Widgets/WidgetPoolList.php
+++ b/juntaplay/elementor/Widgets/WidgetPoolList.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlayElementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+defined('ABSPATH') || exit;
+
+class WidgetPoolList extends Widget_Base
+{
+    public function get_name(): string
+    {
+        return 'juntaplay_pool_list';
+    }
+
+    public function get_title(): string
+    {
+        return __('JuntaPlay — Lista de Campanhas', 'juntaplay');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-post-list';
+    }
+
+    public function get_categories(): array
+    {
+        return ['general'];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('content', [
+            'label' => __('Conteúdo', 'juntaplay'),
+        ]);
+
+        $this->add_control('show_search', [
+            'label'        => __('Exibir busca', 'juntaplay'),
+            'type'         => Controls_Manager::SWITCHER,
+            'default'      => 'yes',
+            'return_value' => 'yes',
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        echo do_shortcode('[juntaplay_pools]');
+    }
+}

--- a/juntaplay/elementor/Widgets/WidgetQuotaGrid.php
+++ b/juntaplay/elementor/Widgets/WidgetQuotaGrid.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlayElementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+defined('ABSPATH') || exit;
+
+class WidgetQuotaGrid extends Widget_Base
+{
+    public function get_name(): string
+    {
+        return 'juntaplay_quota_grid';
+    }
+
+    public function get_title(): string
+    {
+        return __('JuntaPlay — Seletor de Cotas', 'juntaplay');
+    }
+
+    public function get_icon(): string
+    {
+        return 'eicon-number-field';
+    }
+
+    public function get_categories(): array
+    {
+        return ['general'];
+    }
+
+    protected function register_controls(): void
+    {
+        $this->start_controls_section('content', [
+            'label' => __('Conteúdo', 'juntaplay'),
+        ]);
+
+        $this->add_control('pool_id', [
+            'label'       => __('ID da Campanha', 'juntaplay'),
+            'type'        => Controls_Manager::NUMBER,
+            'default'     => 0,
+        ]);
+
+        $this->add_control('per_page', [
+            'label'   => __('Itens por página', 'juntaplay'),
+            'type'    => Controls_Manager::NUMBER,
+            'default' => 100,
+        ]);
+
+        $this->end_controls_section();
+    }
+
+    protected function render(): void
+    {
+        $settings = $this->get_settings_for_display();
+        $id       = isset($settings['pool_id']) ? (int) $settings['pool_id'] : 0;
+        $per_page = isset($settings['per_page']) ? (int) $settings['per_page'] : 100;
+
+        echo do_shortcode('[juntaplay_quota_selector id="' . $id . '" per_page="' . $per_page . '"]');
+    }
+}

--- a/juntaplay/includes/Admin/Groups.php
+++ b/juntaplay/includes/Admin/Groups.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JuntaPlay\Admin;
+
+use JuntaPlay\Data\Groups as GroupsData;
+
+use function absint;
+use function add_action;
+use function add_submenu_page;
+use function admin_url;
+use function current_user_can;
+use function esc_html;
+use function esc_html__;
+use function get_transient;
+use function sanitize_key;
+use function sanitize_text_field;
+use function sanitize_textarea_field;
+use function set_transient;
+use function wp_safe_redirect;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function wp_die;
+use function delete_transient;
+use function esc_url_raw;
+use function get_current_user_id;
+
+use const HOUR_IN_SECONDS;
+
+defined('ABSPATH') || exit;
+
+class Groups
+{
+    private const NOTICE_KEY = 'juntaplay_groups_notice';
+
+    public function init(): void
+    {
+        add_action('admin_menu', [$this, 'register_menu']);
+        add_action('admin_post_juntaplay_group_action', [$this, 'handle_action']);
+    }
+
+    public function register_menu(): void
+    {
+        add_submenu_page(
+            'juntaplay',
+            esc_html__('Grupos do JuntaPlay', 'juntaplay'),
+            esc_html__('Grupos', 'juntaplay'),
+            'manage_options',
+            'juntaplay-groups',
+            [$this, 'render_page']
+        );
+    }
+
+    public function render_page(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Você não tem permissão suficiente para acessar esta página.', 'juntaplay'));
+        }
+
+        $status = isset($_GET['status']) ? sanitize_key((string) wp_unslash($_GET['status'])) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $search = isset($_GET['s']) ? sanitize_text_field((string) wp_unslash($_GET['s'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        $status_counts = GroupsData::counts_by_status();
+        $groups        = GroupsData::all([
+            'status' => $status,
+            'search' => $search,
+            'limit'  => 200,
+        ]);
+
+        $notice = get_transient(self::NOTICE_KEY);
+        if ($notice) {
+            delete_transient(self::NOTICE_KEY);
+        }
+
+        $template = JP_DIR . 'templates/admin-groups.php';
+        if (!file_exists($template)) {
+            wp_die(esc_html__('Template de administração de grupos não encontrado.', 'juntaplay'));
+        }
+
+        $groups_page_context = [
+            'groups'        => $groups,
+            'status'        => $status,
+            'search'        => $search,
+            'status_counts' => $status_counts,
+            'notice'        => is_array($notice) ? $notice : null,
+        ];
+
+        include $template;
+    }
+
+    public function handle_action(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(esc_html__('Você não tem permissão suficiente para executar esta ação.', 'juntaplay'));
+        }
+
+        $referer = isset($_POST['_wpnonce']) ? sanitize_text_field((string) wp_unslash($_POST['_wpnonce'])) : '';
+
+        if ($referer === '' || !wp_verify_nonce($referer, 'juntaplay_group_action')) {
+            $this->store_notice('error', esc_html__('Sua sessão expirou. Atualize a página e tente novamente.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        $group_id = isset($_POST['group_id']) ? absint(wp_unslash($_POST['group_id'])) : 0;
+        $action   = isset($_POST['group_action']) ? sanitize_key((string) wp_unslash($_POST['group_action'])) : '';
+        $note     = isset($_POST['group_note']) ? sanitize_textarea_field((string) wp_unslash($_POST['group_note'])) : '';
+
+        if ($group_id <= 0 || $action === '') {
+            $this->store_notice('error', esc_html__('Selecione um grupo e uma ação válida.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        $group = GroupsData::get($group_id);
+        if (!$group) {
+            $this->store_notice('error', esc_html__('Grupo não encontrado.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        $current_status = isset($group->status) ? (string) $group->status : GroupsData::STATUS_PENDING;
+        $new_status     = $this->map_action_to_status($action, $current_status);
+
+        if (!$new_status) {
+            $this->store_notice('error', esc_html__('Ação não suportada para o status atual.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        if ($new_status === $current_status) {
+            $this->store_notice('success', esc_html__('O status do grupo já está atualizado.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        $updated = GroupsData::update_status($group_id, $new_status, [
+            'review_note'  => $note,
+            'reviewed_by'  => get_current_user_id(),
+            'reviewed_at'  => '',
+        ]);
+
+        if (!$updated) {
+            $this->store_notice('error', esc_html__('Não foi possível atualizar o status do grupo.', 'juntaplay'));
+            $this->redirect_back();
+        }
+
+        do_action('juntaplay/groups/status_changed', $group_id, $current_status, $new_status, [
+            'note'     => $note,
+            'admin_id' => get_current_user_id(),
+        ]);
+
+        $this->store_notice('success', esc_html__('Status do grupo atualizado com sucesso.', 'juntaplay'));
+        $this->redirect_back();
+    }
+
+    private function map_action_to_status(string $action, string $current_status): ?string
+    {
+        return match ($action) {
+            'approve' => GroupsData::STATUS_APPROVED,
+            'reject'  => GroupsData::STATUS_REJECTED,
+            'archive' => GroupsData::STATUS_ARCHIVED,
+            'reset'   => GroupsData::STATUS_PENDING,
+            default   => null,
+        };
+    }
+
+    private function store_notice(string $type, string $message): void
+    {
+        set_transient(
+            self::NOTICE_KEY,
+            [
+                'type'    => $type,
+                'message' => $message,
+            ],
+            HOUR_IN_SECONDS
+        );
+    }
+
+    private function redirect_back(): void
+    {
+        $redirect = isset($_POST['redirect_to']) ? esc_url_raw((string) wp_unslash($_POST['redirect_to'])) : '';
+
+        if ($redirect === '') {
+            $redirect = admin_url('admin.php?page=juntaplay-groups');
+        }
+
+        wp_safe_redirect($redirect);
+        exit;
+    }
+}

--- a/juntaplay/includes/Admin/Importer.php
+++ b/juntaplay/includes/Admin/Importer.php
@@ -1,0 +1,241 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Admin;
+
+use JuntaPlay\Data\Pools;
+use JuntaPlay\Data\Quotas;
+use JuntaPlay\Setup\DemoSeeder;
+use WC_Product_Simple;
+
+use function absint;
+use function add_query_arg;
+use function check_admin_referer;
+use function current_user_can;
+use function delete_transient;
+use function esc_html;
+use function esc_html_e;
+use function esc_url;
+use function get_transient;
+use function is_wp_error;
+use function sanitize_key;
+use function sanitize_text_field;
+use function sanitize_title;
+use function set_transient;
+use function submit_button;
+use function wp_die;
+use function wp_get_referer;
+use function wp_safe_redirect;
+use function wp_unslash;
+
+use const MINUTE_IN_SECONDS;
+
+defined('ABSPATH') || exit;
+
+class Importer
+{
+    public function init(): void
+    {
+        add_action('admin_post_juntaplay_import_csv', [$this, 'handle_import']);
+        add_action('admin_post_juntaplay_generate_pages', [$this, 'handle_generate_pages']);
+        add_action('admin_post_juntaplay_seed_demo', [$this, 'handle_seed_demo']);
+        add_action('juntaplay/admin/import_page', [$this, 'render']);
+    }
+
+    public function render(): void
+    {
+        $success = isset($_GET['jp_success']) ? sanitize_key(wp_unslash((string) $_GET['jp_success'])) : '';
+        $error   = isset($_GET['jp_error']) ? sanitize_key(wp_unslash((string) $_GET['jp_error'])) : '';
+
+        $demo_result = null;
+        if ($success === 'demo') {
+            $demo_result = get_transient('juntaplay_demo_seed_result');
+            if ($demo_result !== false) {
+                delete_transient('juntaplay_demo_seed_result');
+            }
+        }
+
+        $demo_error = '';
+        if ($error === 'demo') {
+            $stored_error = get_transient('juntaplay_demo_seed_error');
+            if ($stored_error !== false) {
+                $demo_error = (string) $stored_error;
+                delete_transient('juntaplay_demo_seed_error');
+            }
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Importação e Páginas Automáticas', 'juntaplay'); ?></h1>
+
+            <?php if ($demo_result && is_array($demo_result)) :
+                $created_users = array_filter($demo_result['users'], static fn ($u) => isset($u['status']) && $u['status'] === 'created');
+                $skipped_users = array_filter($demo_result['users'], static fn ($u) => isset($u['status']) && $u['status'] === 'existing');
+                $created_groups = array_filter($demo_result['groups'], static fn ($g) => isset($g['status']) && $g['status'] === 'created');
+                $skipped_groups = array_filter($demo_result['groups'], static fn ($g) => isset($g['status']) && $g['status'] !== 'created');
+            ?>
+                <div class="notice notice-success is-dismissible">
+                    <p><strong><?php esc_html_e('Dados de demonstração criados com sucesso.', 'juntaplay'); ?></strong></p>
+                    <p><?php echo esc_html(sprintf(
+                        /* translators: 1: count of users created, 2: count of groups created */
+                        __('Usuários criados: %1$d · Grupos criados: %2$d.', 'juntaplay'),
+                        count($created_users),
+                        count($created_groups)
+                    )); ?></p>
+                    <p><?php echo esc_html(sprintf(
+                        /* translators: %s: demo password */
+                        __('Senha de demonstração para todos os perfis: %s', 'juntaplay'),
+                        $demo_result['demo_password']
+                    )); ?></p>
+                    <?php if ($skipped_users) : ?>
+                        <p><?php echo esc_html(sprintf(
+                            /* translators: %d: count of existing users */
+                            __('Usuários já existentes preservados: %d.', 'juntaplay'),
+                            count($skipped_users)
+                        )); ?></p>
+                    <?php endif; ?>
+                    <?php if ($skipped_groups) : ?>
+                        <p><?php esc_html_e('Alguns grupos foram ignorados por já existirem ou por falta do responsável.', 'juntaplay'); ?></p>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if ($demo_error !== '') : ?>
+                <div class="notice notice-error">
+                    <p><strong><?php esc_html_e('Não foi possível gerar os dados de demonstração.', 'juntaplay'); ?></strong></p>
+                    <p><?php echo esc_html($demo_error); ?></p>
+                </div>
+            <?php endif; ?>
+
+            <h2><?php esc_html_e('Importar Campanhas via CSV', 'juntaplay'); ?></h2>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" enctype="multipart/form-data">
+                <?php wp_nonce_field('juntaplay_import_csv'); ?>
+                <input type="hidden" name="action" value="juntaplay_import_csv" />
+                <p>
+                    <input type="file" name="juntaplay_csv" accept="text/csv" required />
+                </p>
+                <p class="description"><?php esc_html_e('Colunas esperadas: title, slug, price, quota_start, quota_end, category (opcional), excerpt, thumbnail_id, is_featured.', 'juntaplay'); ?></p>
+                <?php submit_button(__('Importar CSV', 'juntaplay')); ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e('Gerar/Recriar Páginas com Shortcodes', 'juntaplay'); ?></h2>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <?php wp_nonce_field('juntaplay_generate_pages'); ?>
+                <input type="hidden" name="action" value="juntaplay_generate_pages" />
+                <?php submit_button(__('Gerar Páginas Padrão', 'juntaplay'), 'secondary'); ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e('Popular dados de demonstração', 'juntaplay'); ?></h2>
+            <p class="description">
+                <?php esc_html_e('Cria usuários fictícios, grupos populares (YouTube Premium, Spotify, Canva, ExpressVPN e outros) e relacionamentos para testar buscas e aprovações.', 'juntaplay'); ?>
+            </p>
+            <p class="description">
+                <?php esc_html_e('A senha padrão utilizada para todos os perfis de exemplo é JuntaPlay#2024. Execute apenas em ambientes de testes.', 'juntaplay'); ?>
+            </p>
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <?php wp_nonce_field('juntaplay_seed_demo'); ?>
+                <input type="hidden" name="action" value="juntaplay_seed_demo" />
+                <?php submit_button(__('Criar dados de demonstração', 'juntaplay'), 'secondary'); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function handle_import(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão para executar esta ação.', 'juntaplay'));
+        }
+
+        check_admin_referer('juntaplay_import_csv');
+
+        if (empty($_FILES['juntaplay_csv']['tmp_name'])) {
+            wp_safe_redirect(add_query_arg('jp_error', 'no_file', wp_get_referer()));
+            exit;
+        }
+
+        $file = fopen($_FILES['juntaplay_csv']['tmp_name'], 'r');
+
+        if (!$file) {
+            wp_safe_redirect(add_query_arg('jp_error', 'invalid_file', wp_get_referer()));
+            exit;
+        }
+
+        $header = fgetcsv($file, 0, ',');
+        $rows   = [];
+
+        while (($data = fgetcsv($file, 0, ',')) !== false) {
+            $row = array_combine($header, $data);
+            if (!$row) {
+                continue;
+            }
+
+            $rows[] = $row;
+        }
+
+        fclose($file);
+
+        foreach ($rows as $row) {
+            $pool_id = Pools::create_or_update([
+                'title'        => sanitize_text_field($row['title'] ?? ''),
+                'slug'         => sanitize_title($row['slug'] ?? ''),
+                'price'        => (float) ($row['price'] ?? 0),
+                'quota_start'  => (int) ($row['quota_start'] ?? 1),
+                'quota_end'    => (int) ($row['quota_end'] ?? 1),
+                'category'     => sanitize_key($row['category'] ?? ''),
+                'excerpt'      => sanitize_text_field($row['excerpt'] ?? ''),
+                'thumbnail_id' => isset($row['thumbnail_id']) ? absint($row['thumbnail_id']) : null,
+                'is_featured'  => !empty($row['is_featured']) && in_array(strtolower((string) $row['is_featured']), ['1', 'yes', 'true'], true),
+            ]);
+
+            if ($pool_id) {
+                Pools::ensure_product((int) $pool_id);
+                Quotas::seed((int) $pool_id);
+            }
+        }
+
+        wp_safe_redirect(add_query_arg('jp_success', 'import', admin_url('admin.php?page=juntaplay-import')));
+        exit;
+    }
+
+    public function handle_generate_pages(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão para executar esta ação.', 'juntaplay'));
+        }
+
+        check_admin_referer('juntaplay_generate_pages');
+
+        (new \JuntaPlay\Installer())->activate();
+
+        wp_safe_redirect(add_query_arg('jp_success', 'pages', admin_url('admin.php?page=juntaplay-import')));
+        exit;
+    }
+
+    public function handle_seed_demo(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão para executar esta ação.', 'juntaplay'));
+        }
+
+        check_admin_referer('juntaplay_seed_demo');
+
+        $seeder = new DemoSeeder();
+        $result = $seeder->seed();
+
+        if (is_wp_error($result)) {
+            set_transient('juntaplay_demo_seed_error', $result->get_error_message(), 5 * MINUTE_IN_SECONDS);
+            wp_safe_redirect(add_query_arg('jp_error', 'demo', admin_url('admin.php?page=juntaplay-import')));
+            exit;
+        }
+
+        set_transient('juntaplay_demo_seed_result', $result, 5 * MINUTE_IN_SECONDS);
+
+        wp_safe_redirect(add_query_arg('jp_success', 'demo', admin_url('admin.php?page=juntaplay-import')));
+        exit;
+    }
+}

--- a/juntaplay/includes/Admin/Menu.php
+++ b/juntaplay/includes/Admin/Menu.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Admin;
+
+defined('ABSPATH') || exit;
+
+class Menu
+{
+    public function init(): void
+    {
+        add_action('admin_menu', [$this, 'register_menu']);
+    }
+
+    public function register_menu(): void
+    {
+        $capability = 'manage_options';
+
+        add_menu_page(
+            __('JuntaPlay', 'juntaplay'),
+            __('JuntaPlay', 'juntaplay'),
+            $capability,
+            'juntaplay',
+            [$this, 'render_dashboard'],
+            'dashicons-grid-view',
+            56
+        );
+
+        add_submenu_page(
+            'juntaplay',
+            __('Importar & Gerar Páginas', 'juntaplay'),
+            __('Importar', 'juntaplay'),
+            $capability,
+            'juntaplay-import',
+            [$this, 'render_import']
+        );
+
+        add_submenu_page(
+            'juntaplay',
+            __('Configurações', 'juntaplay'),
+            __('Configurações', 'juntaplay'),
+            $capability,
+            'juntaplay-settings',
+            [$this, 'render_settings']
+        );
+    }
+
+    public function render_dashboard(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão suficiente para acessar esta página.', 'juntaplay'));
+        }
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('JuntaPlay — Dashboard', 'juntaplay') . '</h1>';
+        echo '<p>' . esc_html__('Use os menus ao lado para gerenciar campanhas, importar cotas e ajustar configurações.', 'juntaplay') . '</p>';
+        echo '</div>';
+    }
+
+    public function render_import(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão suficiente para acessar esta página.', 'juntaplay'));
+        }
+
+        do_action('juntaplay/admin/import_page');
+    }
+
+    public function render_settings(): void
+    {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Você não tem permissão suficiente para acessar esta página.', 'juntaplay'));
+        }
+
+        do_action('juntaplay/admin/settings_page');
+    }
+}

--- a/juntaplay/includes/Admin/Settings.php
+++ b/juntaplay/includes/Admin/Settings.php
@@ -1,0 +1,281 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Admin;
+
+defined('ABSPATH') || exit;
+
+class Settings
+{
+    public const OPTION_GENERAL = 'juntaplay_general';
+    public const OPTION_SMTP    = 'juntaplay_smtp';
+    public const OPTION_RESERVE = 'juntaplay_reservations';
+    public const OPTION_CSS     = 'juntaplay_custom_css';
+    public const OPTION_SOCIAL  = 'juntaplay_social';
+
+    public function init(): void
+    {
+        add_action('admin_init', [$this, 'register_settings']);
+        add_action('juntaplay/admin/settings_page', [$this, 'render']);
+        add_action('admin_enqueue_scripts', [$this, 'enqueue_assets']);
+
+        add_action('phpmailer_init', [$this, 'configure_phpmailer']);
+        add_action('wp_head', [$this, 'output_custom_css']);
+    }
+
+    public function register_settings(): void
+    {
+        register_setting('juntaplay_settings', self::OPTION_GENERAL, ['sanitize_callback' => [$this, 'sanitize_general']]);
+        register_setting('juntaplay_settings', self::OPTION_SMTP, ['sanitize_callback' => [$this, 'sanitize_smtp']]);
+        register_setting('juntaplay_settings', self::OPTION_RESERVE, ['sanitize_callback' => [$this, 'sanitize_reservations']]);
+        register_setting('juntaplay_settings', self::OPTION_CSS, ['sanitize_callback' => 'wp_kses_post']);
+        register_setting('juntaplay_settings', self::OPTION_SOCIAL, ['sanitize_callback' => [$this, 'sanitize_social']]);
+    }
+
+    public function enqueue_assets(string $hook): void
+    {
+        if ($hook !== 'juntaplay_page_juntaplay-settings') {
+            return;
+        }
+
+        wp_enqueue_style('wp-color-picker');
+        wp_enqueue_script('wp-color-picker');
+    }
+
+    public function render(): void
+    {
+        $general = get_option(self::OPTION_GENERAL, []);
+        $smtp    = get_option(self::OPTION_SMTP, []);
+        $reserve = get_option(self::OPTION_RESERVE, ['minutes' => 15]);
+        $css     = get_option(self::OPTION_CSS, '');
+        $social  = get_option(self::OPTION_SOCIAL, []);
+        $google  = isset($social['google']) && is_array($social['google']) ? $social['google'] : [];
+        $facebook = isset($social['facebook']) && is_array($social['facebook']) ? $social['facebook'] : [];
+        $google_callback   = add_query_arg(['juntaplay_social' => 'google', 'callback' => '1'], home_url('/'));
+        $facebook_callback = add_query_arg(['juntaplay_social' => 'facebook', 'callback' => '1'], home_url('/'));
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Configurações do JuntaPlay', 'juntaplay'); ?></h1>
+            <form method="post" action="options.php">
+                <?php settings_fields('juntaplay_settings'); ?>
+                <h2 class="title"><?php esc_html_e('Gerais', 'juntaplay'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Cor principal (hex)', 'juntaplay'); ?></th>
+                            <td>
+                                <input type="text" name="<?php echo esc_attr(self::OPTION_GENERAL); ?>[primary_color]" value="<?php echo esc_attr($general['primary_color'] ?? '#ff5a5f'); ?>" class="regular-text" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Cards na vitrine de grupos', 'juntaplay'); ?></th>
+                            <td>
+                                <?php $rotator_limit = isset($general['group_rotator_limit']) ? (int) $general['group_rotator_limit'] : 12; ?>
+                                <input type="number" min="4" max="40" step="1" name="<?php echo esc_attr(self::OPTION_GENERAL); ?>[group_rotator_limit]" value="<?php echo esc_attr((string) $rotator_limit); ?>" />
+                                <p class="description"><?php esc_html_e('Quantidade padrão de grupos exibidos no carrossel rotativo (entre 4 e 40).', 'juntaplay'); ?></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2 class="title"><?php esc_html_e('Reservas', 'juntaplay'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Tempo de bloqueio (minutos)', 'juntaplay'); ?></th>
+                            <td>
+                                <input type="number" min="1" step="1" name="<?php echo esc_attr(self::OPTION_RESERVE); ?>[minutes]" value="<?php echo esc_attr((string) ($reserve['minutes'] ?? 15)); ?>" />
+                                <p class="description"><?php esc_html_e('Após esse tempo, cotas reservadas e não pagas serão liberadas automaticamente.', 'juntaplay'); ?></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2 class="title"><?php esc_html_e('SMTP', 'juntaplay'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Ativar SMTP', 'juntaplay'); ?></th>
+                            <td>
+                                <label>
+                                    <input type="checkbox" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[enabled]" value="1" <?php checked(!empty($smtp['enabled'])); ?> />
+                                    <?php esc_html_e('Forçar envio via SMTP configurado abaixo.', 'juntaplay'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Host', 'juntaplay'); ?></th>
+                            <td><input type="text" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[host]" value="<?php echo esc_attr($smtp['host'] ?? ''); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Porta', 'juntaplay'); ?></th>
+                            <td><input type="number" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[port]" value="<?php echo esc_attr($smtp['port'] ?? 587); ?>" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Criptografia', 'juntaplay'); ?></th>
+                            <td>
+                                <select name="<?php echo esc_attr(self::OPTION_SMTP); ?>[secure]">
+                                    <option value="tls" <?php selected(($smtp['secure'] ?? 'tls'), 'tls'); ?>>TLS</option>
+                                    <option value="ssl" <?php selected(($smtp['secure'] ?? '') === 'ssl'); ?>>SSL</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Usuário', 'juntaplay'); ?></th>
+                            <td><input type="text" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[user]" value="<?php echo esc_attr($smtp['user'] ?? ''); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Senha', 'juntaplay'); ?></th>
+                            <td><input type="password" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[pass]" value="<?php echo esc_attr($smtp['pass'] ?? ''); ?>" class="regular-text" autocomplete="new-password" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Remetente (nome)', 'juntaplay'); ?></th>
+                            <td><input type="text" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[from_name]" value="<?php echo esc_attr($smtp['from_name'] ?? get_bloginfo('name')); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Remetente (e-mail)', 'juntaplay'); ?></th>
+                            <td><input type="email" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[from_email]" value="<?php echo esc_attr($smtp['from_email'] ?? get_option('admin_email')); ?>" class="regular-text" /></td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Exigir autenticação', 'juntaplay'); ?></th>
+                            <td>
+                                <label>
+                                    <input type="checkbox" name="<?php echo esc_attr(self::OPTION_SMTP); ?>[auth]" value="1" <?php checked(!empty($smtp['auth'])); ?> />
+                                    <?php esc_html_e('Habilitar autenticação SMTP (recomendado)', 'juntaplay'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2 class="title"><?php esc_html_e('Login social', 'juntaplay'); ?></h2>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Google', 'juntaplay'); ?></th>
+                            <td>
+                                <label>
+                                    <input type="checkbox" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[google][enabled]" value="1" <?php checked(!empty($google['enabled'])); ?> />
+                                    <?php esc_html_e('Permitir login com Google', 'juntaplay'); ?>
+                                </label>
+                                <p><label for="jp-google-client" class="screen-reader-text"><?php esc_html_e('Client ID do Google', 'juntaplay'); ?></label>
+                                    <input id="jp-google-client" type="text" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[google][client_id]" value="<?php echo esc_attr((string) ($google['client_id'] ?? '')); ?>" class="regular-text" placeholder="client-id.apps.googleusercontent.com" /></p>
+                                <p><label for="jp-google-secret" class="screen-reader-text"><?php esc_html_e('Client secret do Google', 'juntaplay'); ?></label>
+                                    <input id="jp-google-secret" type="text" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[google][client_secret]" value="<?php echo esc_attr((string) ($google['client_secret'] ?? '')); ?>" class="regular-text" placeholder="••••••" /></p>
+                                <p class="description"><?php printf(esc_html__('URL de retorno: %s', 'juntaplay'), '<code>' . esc_html($google_callback) . '</code>'); ?></p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Facebook', 'juntaplay'); ?></th>
+                            <td>
+                                <label>
+                                    <input type="checkbox" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[facebook][enabled]" value="1" <?php checked(!empty($facebook['enabled'])); ?> />
+                                    <?php esc_html_e('Permitir login com Facebook', 'juntaplay'); ?>
+                                </label>
+                                <p><label for="jp-facebook-client" class="screen-reader-text"><?php esc_html_e('App ID do Facebook', 'juntaplay'); ?></label>
+                                    <input id="jp-facebook-client" type="text" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[facebook][client_id]" value="<?php echo esc_attr((string) ($facebook['client_id'] ?? '')); ?>" class="regular-text" placeholder="1234567890" /></p>
+                                <p><label for="jp-facebook-secret" class="screen-reader-text"><?php esc_html_e('App secret do Facebook', 'juntaplay'); ?></label>
+                                    <input id="jp-facebook-secret" type="text" name="<?php echo esc_attr(self::OPTION_SOCIAL); ?>[facebook][client_secret]" value="<?php echo esc_attr((string) ($facebook['client_secret'] ?? '')); ?>" class="regular-text" placeholder="••••••" /></p>
+                                <p class="description"><?php printf(esc_html__('URL de retorno: %s', 'juntaplay'), '<code>' . esc_html($facebook_callback) . '</code>'); ?></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2 class="title"><?php esc_html_e('CSS Personalizado', 'juntaplay'); ?></h2>
+                <p><?php esc_html_e('Cole abaixo trechos adicionais de CSS que serão carregados após o tema.', 'juntaplay'); ?></p>
+                <textarea name="<?php echo esc_attr(self::OPTION_CSS); ?>" rows="10" cols="120" class="large-text code"><?php echo esc_textarea($css); ?></textarea>
+
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function sanitize_general(array $input): array
+    {
+        $color = sanitize_hex_color($input['primary_color'] ?? '#ff5a5f') ?: '#ff5a5f';
+        $limit = isset($input['group_rotator_limit']) ? absint($input['group_rotator_limit']) : 12;
+
+        if ($limit < 4) {
+            $limit = 4;
+        } elseif ($limit > 40) {
+            $limit = 40;
+        }
+
+        return [
+            'primary_color'        => $color,
+            'group_rotator_limit'  => $limit,
+        ];
+    }
+
+    public function sanitize_smtp(array $input): array
+    {
+        return [
+            'enabled'    => !empty($input['enabled']) ? 1 : 0,
+            'host'       => sanitize_text_field($input['host'] ?? ''),
+            'port'       => absint($input['port'] ?? 587),
+            'secure'     => in_array($input['secure'] ?? 'tls', ['tls', 'ssl'], true) ? $input['secure'] : 'tls',
+            'user'       => sanitize_text_field($input['user'] ?? ''),
+            'pass'       => sanitize_text_field($input['pass'] ?? ''),
+            'from_name'  => sanitize_text_field($input['from_name'] ?? ''),
+            'from_email' => sanitize_email($input['from_email'] ?? ''),
+            'auth'       => !empty($input['auth']) ? 1 : 0,
+        ];
+    }
+
+    public function sanitize_reservations(array $input): array
+    {
+        $minutes = max(1, (int) ($input['minutes'] ?? 15));
+
+        return [
+            'minutes' => $minutes,
+        ];
+    }
+
+    public function sanitize_social(array $input): array
+    {
+        $providers = ['google', 'facebook'];
+        $output    = [];
+
+        foreach ($providers as $provider) {
+            $raw = isset($input[$provider]) && is_array($input[$provider]) ? $input[$provider] : [];
+            $output[$provider] = [
+                'enabled'       => !empty($raw['enabled']) ? 1 : 0,
+                'client_id'     => sanitize_text_field($raw['client_id'] ?? ''),
+                'client_secret' => sanitize_text_field($raw['client_secret'] ?? ''),
+            ];
+        }
+
+        return $output;
+    }
+
+    public function configure_phpmailer(\PHPMailer\PHPMailer\PHPMailer $phpmailer): void
+    {
+        $smtp = get_option(self::OPTION_SMTP, []);
+
+        if (empty($smtp['enabled'])) {
+            return;
+        }
+
+        $phpmailer->isSMTP();
+        $phpmailer->Host       = $smtp['host'] ?? '';
+        $phpmailer->Port       = (int) ($smtp['port'] ?? 587);
+        $phpmailer->SMTPAuth   = !empty($smtp['auth']);
+        $phpmailer->SMTPSecure = $smtp['secure'] ?? 'tls';
+        $phpmailer->Username   = $smtp['user'] ?? '';
+        $phpmailer->Password   = $smtp['pass'] ?? '';
+        $phpmailer->setFrom($smtp['from_email'] ?? get_option('admin_email'), $smtp['from_name'] ?? get_bloginfo('name'));
+    }
+
+    public function output_custom_css(): void
+    {
+        $css = get_option(self::OPTION_CSS, '');
+
+        if (empty($css)) {
+            return;
+        }
+
+        echo '<style id="juntaplay-custom-css">' . wp_strip_all_tags($css) . '</style>';
+    }
+}

--- a/juntaplay/includes/Data/CreditTransactions.php
+++ b/juntaplay/includes/Data/CreditTransactions.php
@@ -1,0 +1,216 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function absint;
+use function current_time;
+use function is_array;
+use function wp_json_encode;
+
+defined('ABSPATH') || exit;
+
+class CreditTransactions
+{
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_PENDING   = 'pending';
+    public const STATUS_FAILED    = 'failed';
+
+    public const TYPE_DEPOSIT     = 'deposit';
+    public const TYPE_WITHDRAWAL  = 'withdrawal';
+    public const TYPE_ADJUSTMENT  = 'adjustment';
+    public const TYPE_PURCHASE    = 'purchase';
+    public const TYPE_REFUND      = 'refund';
+    public const TYPE_BONUS       = 'bonus';
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create(array $data): int
+    {
+        global $wpdb;
+
+        $user_id = isset($data['user_id']) ? absint($data['user_id']) : 0;
+
+        if ($user_id <= 0) {
+            return 0;
+        }
+
+        $table    = "{$wpdb->prefix}jp_credit_transactions";
+        $type     = isset($data['type']) ? (string) $data['type'] : self::TYPE_ADJUSTMENT;
+        $status   = isset($data['status']) ? (string) $data['status'] : self::STATUS_COMPLETED;
+        $amount   = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $balance  = isset($data['balance_after']) ? (float) $data['balance_after'] : null;
+        $reference = isset($data['reference']) ? (string) $data['reference'] : '';
+        $context  = isset($data['context']) && is_array($data['context']) ? $data['context'] : [];
+
+        $payload = [
+            'user_id'       => $user_id,
+            'type'          => $type,
+            'status'        => $status,
+            'amount'        => $amount,
+            'balance_after' => $balance,
+            'reference'     => $reference !== '' ? $reference : null,
+            'context'       => $context ? wp_json_encode($context) : null,
+            'created_at'    => current_time('mysql'),
+        ];
+
+        $formats = ['%d', '%s', '%s', '%f', '%f', '%s', '%s', '%s'];
+
+        $inserted = $wpdb->insert($table, $payload, $formats);
+
+        return $inserted ? (int) $wpdb->insert_id : 0;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function get_for_user(int $user_id, int $page = 1, int $per_page = 10, array $filters = []): array
+    {
+        global $wpdb;
+
+        $user_id = absint($user_id);
+        if ($user_id <= 0) {
+            return ['items' => [], 'total' => 0, 'pages' => 0];
+        }
+
+        $page     = max(1, $page);
+        $per_page = max(1, min(100, $per_page));
+        $offset   = ($page - 1) * $per_page;
+
+        $table = "{$wpdb->prefix}jp_credit_transactions";
+
+        $where  = ['user_id = %d'];
+        $params = [$user_id];
+
+        if (!empty($filters['type'])) {
+            $where[]  = 'type = %s';
+            $params[] = (string) $filters['type'];
+        }
+
+        if (!empty($filters['status'])) {
+            $where[]  = 'status = %s';
+            $params[] = (string) $filters['status'];
+        }
+
+        $where_sql = implode(' AND ', $where);
+
+        $query = $wpdb->prepare(
+            "SELECT SQL_CALC_FOUND_ROWS *
+             FROM $table
+             WHERE $where_sql
+             ORDER BY created_at DESC
+             LIMIT %d OFFSET %d",
+            array_merge($params, [$per_page, $offset])
+        );
+
+        $rows = $wpdb->get_results($query, ARRAY_A) ?: [];
+        $total = (int) $wpdb->get_var('SELECT FOUND_ROWS()');
+        $pages = (int) ceil($total / $per_page);
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = self::format_row($row);
+        }
+
+        return [
+            'items' => $items,
+            'total' => $total,
+            'pages' => $pages,
+            'page'  => $page,
+            'per_page' => $per_page,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function get(int $transaction_id, int $user_id): ?array
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_credit_transactions";
+
+        $query = $wpdb->prepare(
+            "SELECT * FROM $table WHERE id = %d AND user_id = %d",
+            $transaction_id,
+            $user_id
+        );
+
+        $row = $wpdb->get_row($query, ARRAY_A);
+
+        if (!$row) {
+            return null;
+        }
+
+        return self::format_row($row);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_recent(int $user_id, int $limit = 5): array
+    {
+        global $wpdb;
+
+        $limit   = max(1, min(50, $limit));
+        $table   = "{$wpdb->prefix}jp_credit_transactions";
+        $query   = $wpdb->prepare(
+            "SELECT * FROM $table WHERE user_id = %d ORDER BY created_at DESC LIMIT %d",
+            $user_id,
+            $limit
+        );
+        $results = $wpdb->get_results($query, ARRAY_A) ?: [];
+
+        $items = [];
+        foreach ($results as $row) {
+            $items[] = self::format_row($row);
+        }
+
+        return $items;
+    }
+
+    public static function sum_by_status(int $user_id, string $status): float
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_credit_transactions";
+
+        $query = $wpdb->prepare(
+            "SELECT COALESCE(SUM(amount), 0) FROM $table WHERE user_id = %d AND status = %s",
+            $user_id,
+            $status
+        );
+
+        return (float) $wpdb->get_var($query);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private static function format_row(array $row): array
+    {
+        $context = [];
+        if (!empty($row['context'])) {
+            $decoded = json_decode((string) $row['context'], true);
+            if (is_array($decoded)) {
+                $context = $decoded;
+            }
+        }
+
+        return [
+            'id'            => isset($row['id']) ? (int) $row['id'] : 0,
+            'user_id'       => isset($row['user_id']) ? (int) $row['user_id'] : 0,
+            'type'          => (string) ($row['type'] ?? self::TYPE_ADJUSTMENT),
+            'status'        => (string) ($row['status'] ?? self::STATUS_COMPLETED),
+            'amount'        => isset($row['amount']) ? (float) $row['amount'] : 0.0,
+            'balance_after' => isset($row['balance_after']) ? (float) $row['balance_after'] : null,
+            'reference'     => (string) ($row['reference'] ?? ''),
+            'context'       => $context,
+            'created_at'    => (string) ($row['created_at'] ?? ''),
+        ];
+    }
+}

--- a/juntaplay/includes/Data/CreditWithdrawals.php
+++ b/juntaplay/includes/Data/CreditWithdrawals.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function absint;
+use function current_time;
+use function is_array;
+use function wp_json_encode;
+
+defined('ABSPATH') || exit;
+
+class CreditWithdrawals
+{
+    public const STATUS_PENDING    = 'pending';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_APPROVED   = 'approved';
+    public const STATUS_REJECTED   = 'rejected';
+    public const STATUS_CANCELED   = 'canceled';
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create(array $data): int
+    {
+        global $wpdb;
+
+        $user_id = isset($data['user_id']) ? absint($data['user_id']) : 0;
+
+        if ($user_id <= 0) {
+            return 0;
+        }
+
+        $table       = "{$wpdb->prefix}jp_credit_withdrawals";
+        $amount      = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $method      = isset($data['method']) ? (string) $data['method'] : 'pix';
+        $status      = isset($data['status']) ? (string) $data['status'] : self::STATUS_PENDING;
+        $destination = isset($data['destination']) && is_array($data['destination']) ? $data['destination'] : [];
+        $reference   = isset($data['reference']) ? (string) $data['reference'] : '';
+
+        $payload = [
+            'user_id'    => $user_id,
+            'amount'     => $amount,
+            'method'     => $method,
+            'status'     => $status,
+            'destination'=> $destination ? wp_json_encode($destination) : null,
+            'reference'  => $reference !== '' ? $reference : null,
+            'requested_at' => current_time('mysql'),
+            'updated_at'   => current_time('mysql'),
+        ];
+
+        $formats = ['%d', '%f', '%s', '%s', '%s', '%s', '%s'];
+
+        $inserted = $wpdb->insert($table, $payload, $formats);
+
+        return $inserted ? (int) $wpdb->insert_id : 0;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_for_user(int $user_id, int $limit = 10): array
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_credit_withdrawals";
+        $limit = max(1, min(50, $limit));
+
+        $query = $wpdb->prepare(
+            "SELECT * FROM $table WHERE user_id = %d ORDER BY requested_at DESC LIMIT %d",
+            $user_id,
+            $limit
+        );
+
+        $rows = $wpdb->get_results($query, ARRAY_A) ?: [];
+        $items = [];
+
+        foreach ($rows as $row) {
+            $items[] = self::format_row($row);
+        }
+
+        return $items;
+    }
+
+    public static function get_pending_total(int $user_id): float
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_credit_withdrawals";
+
+        $query = $wpdb->prepare(
+            "SELECT COALESCE(SUM(amount), 0)
+             FROM $table
+             WHERE user_id = %d AND status IN ('pending','processing')",
+            $user_id
+        );
+
+        return (float) $wpdb->get_var($query);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function get(int $withdrawal_id, int $user_id): ?array
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_credit_withdrawals";
+
+        $query = $wpdb->prepare(
+            "SELECT * FROM $table WHERE id = %d AND user_id = %d",
+            $withdrawal_id,
+            $user_id
+        );
+
+        $row = $wpdb->get_row($query, ARRAY_A);
+
+        if (!$row) {
+            return null;
+        }
+
+        return self::format_row($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private static function format_row(array $row): array
+    {
+        $destination = [];
+        if (!empty($row['destination'])) {
+            $decoded = json_decode((string) $row['destination'], true);
+            if (is_array($decoded)) {
+                $destination = $decoded;
+            }
+        }
+
+        return [
+            'id'          => isset($row['id']) ? (int) $row['id'] : 0,
+            'user_id'     => isset($row['user_id']) ? (int) $row['user_id'] : 0,
+            'amount'      => isset($row['amount']) ? (float) $row['amount'] : 0.0,
+            'method'      => (string) ($row['method'] ?? 'pix'),
+            'status'      => (string) ($row['status'] ?? self::STATUS_PENDING),
+            'destination' => $destination,
+            'reference'   => (string) ($row['reference'] ?? ''),
+            'requested_at'=> (string) ($row['requested_at'] ?? ''),
+            'processed_at'=> (string) ($row['processed_at'] ?? ''),
+            'updated_at'  => (string) ($row['updated_at'] ?? ''),
+            'admin_note'  => (string) ($row['admin_note'] ?? ''),
+        ];
+    }
+}

--- a/juntaplay/includes/Data/GroupComplaints.php
+++ b/juntaplay/includes/Data/GroupComplaints.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function __;
+use function absint;
+use function array_filter;
+use function array_map;
+use function count;
+use function current_time;
+use function implode;
+use function in_array;
+use function is_array;
+use function sanitize_key;
+use function sanitize_textarea_field;
+use function wp_json_encode;
+
+defined('ABSPATH') || exit;
+
+class GroupComplaints
+{
+    public const STATUS_OPEN         = 'open';
+    public const STATUS_UNDER_REVIEW = 'under_review';
+    public const STATUS_RESOLVED     = 'resolved';
+    public const STATUS_REJECTED     = 'rejected';
+
+    /**
+     * @return array<string, string>
+     */
+    public static function get_reasons(): array
+    {
+        return [
+            'access'  => __('Não recebi o acesso prometido', 'juntaplay'),
+            'quality' => __('O conteúdo entregue está diferente do combinado', 'juntaplay'),
+            'payment' => __('Cobrança incorreta ou duplicada', 'juntaplay'),
+            'support' => __('Administrador não responde ou sumiu', 'juntaplay'),
+            'other'   => __('Outro motivo', 'juntaplay'),
+        ];
+    }
+
+    public static function get_reason_label(string $reason): string
+    {
+        $reasons = self::get_reasons();
+        $reason  = sanitize_key($reason);
+
+        return $reasons[$reason] ?? $reasons['other'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function describe_status(string $status): array
+    {
+        $status = sanitize_key($status);
+
+        switch ($status) {
+            case self::STATUS_RESOLVED:
+                return [
+                    'label'   => __('Resolvida', 'juntaplay'),
+                    'tone'    => 'positive',
+                    'message' => __('A reclamação foi resolvida e os créditos envolvidos foram liberados.', 'juntaplay'),
+                ];
+            case self::STATUS_REJECTED:
+                return [
+                    'label'   => __('Encerrada', 'juntaplay'),
+                    'tone'    => 'info',
+                    'message' => __('A reclamação foi encerrada após análise da equipe JuntaPlay.', 'juntaplay'),
+                ];
+            case self::STATUS_UNDER_REVIEW:
+                return [
+                    'label'   => __('Em análise', 'juntaplay'),
+                    'tone'    => 'warning',
+                    'message' => __('Nossa equipe está verificando as evidências enviadas. Você receberá atualizações por e-mail.', 'juntaplay'),
+                ];
+            case self::STATUS_OPEN:
+            default:
+                return [
+                    'label'   => __('Aberta', 'juntaplay'),
+                    'tone'    => 'warning',
+                    'message' => __('Recebemos sua reclamação e o administrador do grupo já foi notificado.', 'juntaplay'),
+                ];
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create(array $data): int
+    {
+        global $wpdb;
+
+        $group_id = isset($data['group_id']) ? absint($data['group_id']) : 0;
+        $user_id  = isset($data['user_id']) ? absint($data['user_id']) : 0;
+
+        if ($group_id <= 0 || $user_id <= 0) {
+            return 0;
+        }
+
+        $table = "{$wpdb->prefix}jp_group_complaints";
+
+        $reason  = isset($data['reason']) ? sanitize_key((string) $data['reason']) : 'other';
+        $message = isset($data['message']) ? sanitize_textarea_field((string) $data['message']) : '';
+        $order_id = isset($data['order_id']) ? absint($data['order_id']) : 0;
+        $status   = isset($data['status']) ? sanitize_key((string) $data['status']) : self::STATUS_OPEN;
+
+        if ($message === '') {
+            return 0;
+        }
+
+        $attachments = [];
+        if (!empty($data['attachments']) && is_array($data['attachments'])) {
+            $attachments = array_filter(array_map('absint', $data['attachments']));
+        }
+
+        $payload = [
+            'group_id'    => $group_id,
+            'user_id'     => $user_id,
+            'order_id'    => $order_id > 0 ? $order_id : null,
+            'reason'      => $reason !== '' ? $reason : 'other',
+            'message'     => $message,
+            'attachments' => $attachments ? wp_json_encode($attachments) : null,
+            'status'      => $status !== '' ? $status : self::STATUS_OPEN,
+            'created_at'  => current_time('mysql'),
+            'updated_at'  => current_time('mysql'),
+        ];
+
+        $formats = ['%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s'];
+
+        $inserted = $wpdb->insert($table, $payload, $formats);
+
+        return $inserted ? (int) $wpdb->insert_id : 0;
+    }
+
+    /**
+     * @param int   $user_id
+     * @param int[] $group_ids
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_summary_for_user(int $user_id, array $group_ids): array
+    {
+        global $wpdb;
+
+        $user_id = absint($user_id);
+        $group_ids = array_values(array_filter(array_map('absint', $group_ids)));
+
+        if ($user_id <= 0 || !$group_ids) {
+            return [];
+        }
+
+        $table = "{$wpdb->prefix}jp_group_complaints";
+
+        $placeholders = implode(', ', array_fill(0, count($group_ids), '%d'));
+        $sql = $wpdb->prepare(
+            "SELECT id, group_id, reason, status, order_id, created_at, updated_at
+             FROM $table
+             WHERE user_id = %d AND group_id IN ($placeholders)
+             ORDER BY created_at DESC",
+            ...array_merge([$user_id], $group_ids)
+        );
+
+        $rows = $wpdb->get_results($sql, ARRAY_A) ?: [];
+
+        $summary = [];
+
+        foreach ($rows as $row) {
+            $group_id = isset($row['group_id']) ? (int) $row['group_id'] : 0;
+            if ($group_id <= 0) {
+                continue;
+            }
+
+            if (!isset($summary[$group_id])) {
+                $summary[$group_id] = [
+                    'open'   => 0,
+                    'total'  => 0,
+                    'latest' => null,
+                ];
+            }
+
+            $status = isset($row['status']) ? sanitize_key((string) $row['status']) : self::STATUS_OPEN;
+
+            $summary[$group_id]['total']++;
+
+            if (in_array($status, [self::STATUS_OPEN, self::STATUS_UNDER_REVIEW], true)) {
+                $summary[$group_id]['open']++;
+            }
+
+            if ($summary[$group_id]['latest'] === null) {
+                $summary[$group_id]['latest'] = [
+                    'id'         => isset($row['id']) ? (int) $row['id'] : 0,
+                    'status'     => $status,
+                    'reason'     => isset($row['reason']) ? sanitize_key((string) $row['reason']) : 'other',
+                    'order_id'   => isset($row['order_id']) ? absint($row['order_id']) : 0,
+                    'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : '',
+                    'updated_at' => isset($row['updated_at']) ? (string) $row['updated_at'] : '',
+                ];
+            }
+        }
+
+        return $summary;
+    }
+}

--- a/juntaplay/includes/Data/GroupMembers.php
+++ b/juntaplay/includes/Data/GroupMembers.php
@@ -1,0 +1,172 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function absint;
+use function current_time;
+use function sanitize_key;
+use function sprintf;
+use function wp_cache_get;
+use function wp_cache_set;
+
+defined('ABSPATH') || exit;
+
+class GroupMembers
+{
+    public static function add(int $group_id, int $user_id, string $role = 'member', string $status = 'active'): void
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+        $user_id  = absint($user_id);
+
+        if ($group_id <= 0 || $user_id <= 0) {
+            return;
+        }
+
+        $table = "{$wpdb->prefix}jp_group_members";
+
+        $wpdb->replace(
+            $table,
+            [
+                'group_id'  => $group_id,
+                'user_id'   => $user_id,
+                'role'      => $role,
+                'status'    => $status,
+                'joined_at' => current_time('mysql'),
+            ],
+            ['%d', '%d', '%s', '%s', '%s']
+        );
+    }
+
+    public static function count_active(int $group_id): int
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_group_members";
+
+        return (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table WHERE group_id = %d AND status = 'active'",
+                $group_id
+            )
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    public static function get_user_ids(int $group_id, string $status = 'active'): array
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+
+        if ($group_id <= 0) {
+            return [];
+        }
+
+        $table  = "{$wpdb->prefix}jp_group_members";
+        $status = sanitize_key($status);
+
+        if ($status === 'all' || $status === '') {
+            $query = $wpdb->prepare("SELECT user_id FROM $table WHERE group_id = %d", $group_id);
+        } else {
+            $query = $wpdb->prepare(
+                "SELECT user_id FROM $table WHERE group_id = %d AND status = %s",
+                $group_id,
+                $status
+            );
+        }
+
+        $results = $wpdb->get_col($query) ?: [];
+
+        return array_map('intval', $results);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_details(int $group_id, int $limit = 5, string $status = 'active'): array
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+        $limit    = absint($limit);
+
+        if ($group_id <= 0 || $limit <= 0) {
+            return [];
+        }
+
+        $members_table = "{$wpdb->prefix}jp_group_members";
+        $users_table   = $wpdb->users;
+        $status        = sanitize_key($status);
+
+        $where  = $status !== '' && $status !== 'all'
+            ? $wpdb->prepare('AND gm.status = %s', $status)
+            : '';
+
+        $sql = $wpdb->prepare(
+            "SELECT gm.user_id, gm.role, gm.status, gm.joined_at, u.display_name
+             FROM $members_table gm
+             LEFT JOIN $users_table u ON u.ID = gm.user_id
+             WHERE gm.group_id = %d $where
+             ORDER BY (gm.role = 'owner') DESC, gm.joined_at ASC
+             LIMIT %d",
+            $group_id,
+            $limit
+        );
+
+        $rows = $wpdb->get_results($sql, ARRAY_A) ?: [];
+
+        $members = [];
+        foreach ($rows as $row) {
+            $members[] = [
+                'user_id' => isset($row['user_id']) ? (int) $row['user_id'] : 0,
+                'role'    => isset($row['role']) ? (string) $row['role'] : 'member',
+                'status'  => isset($row['status']) ? (string) $row['status'] : 'active',
+                'name'    => (string) ($row['display_name'] ?? ''),
+            ];
+        }
+
+        return $members;
+    }
+
+    public static function user_has_membership(int $group_id, int $user_id): bool
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+        $user_id  = absint($user_id);
+
+        if ($group_id <= 0 || $user_id <= 0) {
+            return false;
+        }
+
+        $cache_key = sprintf('jp_group_membership_%d_%d', $group_id, $user_id);
+        $cached    = wp_cache_get($cache_key, 'juntaplay');
+
+        if ($cached !== false) {
+            return (bool) $cached;
+        }
+
+        $table = "{$wpdb->prefix}jp_group_members";
+
+        $count = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table WHERE group_id = %d AND user_id = %d",
+                $group_id,
+                $user_id
+            )
+        );
+
+        $has_membership = $count > 0;
+
+        wp_cache_set($cache_key, $has_membership ? 1 : 0, 'juntaplay', 10 * MINUTE_IN_SECONDS);
+
+        return $has_membership;
+    }
+}

--- a/juntaplay/includes/Data/Groups.php
+++ b/juntaplay/includes/Data/Groups.php
@@ -1,0 +1,761 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function absint;
+use function array_merge;
+use function apply_filters;
+use function current_time;
+use function esc_url_raw;
+use function get_post_meta;
+use function is_array;
+use function max;
+use function min;
+use function sanitize_key;
+use function sanitize_textarea_field;
+use function sanitize_text_field;
+use function sanitize_title;
+use function trailingslashit;
+use function wp_generate_uuid4;
+use function wp_get_attachment_image_url;
+use function wp_hash_password;
+use function wp_prepare_attachment_for_js;
+use function wp_rand;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Groups
+{
+    public const STATUS_PENDING  = 'pending';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+    public const STATUS_ARCHIVED = 'archived';
+
+    /**
+     * @return array<string, string>
+     */
+    public static function get_category_labels(): array
+    {
+        $categories = [
+            'boloes'      => __('Bolões e rifas', 'juntaplay'),
+            'video'       => __('Vídeo e streaming', 'juntaplay'),
+            'music'       => __('Música e áudio', 'juntaplay'),
+            'education'   => __('Cursos e educação', 'juntaplay'),
+            'reading'     => __('Leitura e revistas', 'juntaplay'),
+            'office'      => __('Escritório e produtividade', 'juntaplay'),
+            'software'    => __('Software e ferramentas', 'juntaplay'),
+            'games'       => __('Jogos e esportes', 'juntaplay'),
+            'ai'          => __('Ferramentas de IA', 'juntaplay'),
+            'security'    => __('Segurança e VPN', 'juntaplay'),
+            'marketplace' => __('Mercado e delivery', 'juntaplay'),
+            'lifestyle'   => __('Lifestyle e clubes', 'juntaplay'),
+            'other'       => __('Outros serviços', 'juntaplay'),
+        ];
+
+        return apply_filters('juntaplay/groups/categories', $categories);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create(array $data): int
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_groups";
+
+        $title = isset($data['title']) ? sanitize_text_field((string) $data['title']) : '';
+        if ($title === '') {
+            return 0;
+        }
+
+        $owner_id    = isset($data['owner_id']) ? absint($data['owner_id']) : 0;
+        $pool_id     = isset($data['pool_id']) ? absint($data['pool_id']) : 0;
+        $description = isset($data['description']) ? sanitize_textarea_field((string) $data['description']) : '';
+        $service     = isset($data['service_name']) ? sanitize_text_field((string) $data['service_name']) : '';
+        $service_url = isset($data['service_url']) ? esc_url_raw((string) $data['service_url']) : '';
+        $rules       = isset($data['rules']) ? sanitize_textarea_field((string) $data['rules']) : '';
+        $price       = isset($data['price_regular']) ? (float) $data['price_regular'] : 0.0;
+        $promo       = isset($data['price_promotional']) && $data['price_promotional'] !== ''
+            ? (float) $data['price_promotional']
+            : null;
+        $member_price = isset($data['member_price']) && $data['member_price'] !== ''
+            ? (float) $data['member_price']
+            : null;
+        $slots_total    = isset($data['slots_total']) ? absint($data['slots_total']) : 0;
+        $slots_reserved = isset($data['slots_reserved']) ? absint($data['slots_reserved']) : 0;
+        $support        = isset($data['support_channel']) ? sanitize_text_field((string) $data['support_channel']) : '';
+        $delivery       = isset($data['delivery_time']) ? sanitize_text_field((string) $data['delivery_time']) : '';
+        $access         = isset($data['access_method']) ? sanitize_text_field((string) $data['access_method']) : '';
+        $category       = isset($data['category']) ? sanitize_text_field((string) $data['category']) : '';
+        $instant_access = !empty($data['instant_access']);
+        $cover_id       = isset($data['cover_id']) ? absint($data['cover_id']) : 0;
+        $visibility     = 'public';
+        $slug_input = isset($data['slug']) ? sanitize_title((string) $data['slug']) : '';
+        $slug       = $slug_input !== ''
+            ? self::ensure_unique_slug($slug_input)
+            : self::generate_unique_slug($title);
+
+        $payload = [
+            'owner_id'          => $owner_id,
+            'pool_id'           => $pool_id > 0 ? $pool_id : null,
+            'title'             => $title,
+            'service_name'      => $service,
+            'service_url'       => $service_url !== '' ? $service_url : null,
+            'rules'             => $rules !== '' ? $rules : null,
+            'description'       => $description,
+            'price_regular'     => $price,
+            'price_promotional' => $promo,
+            'member_price'      => $member_price,
+            'slots_total'       => $slots_total,
+            'slots_reserved'    => $slots_reserved,
+            'support_channel'   => $support,
+            'delivery_time'     => $delivery,
+            'access_method'     => $access,
+            'category'          => $category,
+            'instant_access'    => $instant_access ? 1 : 0,
+            'cover_id'          => $cover_id > 0 ? $cover_id : null,
+            'email_validation_hash'    => null,
+            'email_validation_sent_at' => null,
+            'email_validated_at'       => null,
+            'status'            => self::STATUS_PENDING,
+            'visibility'        => $visibility,
+            'slug'              => $slug,
+            'created_at'        => current_time('mysql'),
+            'updated_at'        => current_time('mysql'),
+        ];
+
+        $formats = ['%d', '%d', '%s', '%s', '%s', '%s', '%s', '%f', '%f', '%f', '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s'];
+
+        $inserted = $wpdb->insert($table, $payload, $formats);
+
+        return $inserted ? (int) $wpdb->insert_id : 0;
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public static function get_groups_for_user(int $user_id): array
+    {
+        global $wpdb;
+
+        $groups_table  = "{$wpdb->prefix}jp_groups";
+        $members_table = "{$wpdb->prefix}jp_group_members";
+        $pools_table   = "{$wpdb->prefix}jp_pools";
+
+        $query = $wpdb->prepare(
+            "SELECT g.*, gm.role AS membership_role, gm.status AS membership_status,
+                    IFNULL(p.title, '') AS pool_title, IFNULL(p.slug, '') AS pool_slug,
+                    (SELECT COUNT(*) FROM $members_table m WHERE m.group_id = g.id AND m.status = 'active') AS members_count
+             FROM $groups_table g
+             INNER JOIN $members_table gm ON gm.group_id = g.id
+             LEFT JOIN $pools_table p ON p.id = g.pool_id
+             WHERE gm.user_id = %d
+             ORDER BY g.created_at DESC",
+            $user_id
+        );
+
+        $results = $wpdb->get_results($query, ARRAY_A) ?: [];
+
+        $owned  = [];
+        $joined = [];
+
+        foreach ($results as $row) {
+            $group = [
+                'id'                 => isset($row['id']) ? (int) $row['id'] : 0,
+                'title'              => (string) ($row['title'] ?? ''),
+                'service_name'       => (string) ($row['service_name'] ?? ''),
+                'service_url'        => (string) ($row['service_url'] ?? ''),
+                'slug'               => (string) ($row['slug'] ?? ''),
+                'status'             => (string) ($row['status'] ?? self::STATUS_PENDING),
+                'visibility'         => (string) ($row['visibility'] ?? 'public'),
+                'pool_id'            => isset($row['pool_id']) ? (int) $row['pool_id'] : 0,
+                'pool_title'         => (string) ($row['pool_title'] ?? ''),
+                'pool_slug'          => (string) ($row['pool_slug'] ?? ''),
+                'price_regular'      => isset($row['price_regular']) ? (float) $row['price_regular'] : 0.0,
+                'price_promotional'  => isset($row['price_promotional']) ? (float) $row['price_promotional'] : null,
+                'member_price'       => isset($row['member_price']) ? (float) $row['member_price'] : null,
+                'slots_total'        => isset($row['slots_total']) ? (int) $row['slots_total'] : 0,
+                'slots_reserved'     => isset($row['slots_reserved']) ? (int) $row['slots_reserved'] : 0,
+                'support_channel'    => (string) ($row['support_channel'] ?? ''),
+                'delivery_time'      => (string) ($row['delivery_time'] ?? ''),
+                'access_method'      => (string) ($row['access_method'] ?? ''),
+                'category'           => (string) ($row['category'] ?? ''),
+                'instant_access'     => isset($row['instant_access']) ? (bool) $row['instant_access'] : false,
+                'description'        => (string) ($row['description'] ?? ''),
+                'rules'              => (string) ($row['rules'] ?? ''),
+                'review_note'        => (string) ($row['review_note'] ?? ''),
+                'reviewed_at'        => (string) ($row['reviewed_at'] ?? ''),
+                'reviewed_by'        => isset($row['reviewed_by']) ? (int) $row['reviewed_by'] : 0,
+                'email_validation_sent_at' => (string) ($row['email_validation_sent_at'] ?? ''),
+                'email_validated_at'      => (string) ($row['email_validated_at'] ?? ''),
+                'created_at'         => (string) ($row['created_at'] ?? ''),
+                'updated_at'         => (string) ($row['updated_at'] ?? ''),
+                'members_count'      => isset($row['members_count']) ? (int) $row['members_count'] : 0,
+                'membership_role'    => (string) ($row['membership_role'] ?? 'member'),
+                'membership_status'  => (string) ($row['membership_status'] ?? 'active'),
+            ];
+
+            $cover = self::resolve_cover(isset($row['cover_id']) ? (int) $row['cover_id'] : 0);
+            $group['cover_id']           = $cover['id'];
+            $group['cover_url']          = $cover['url'];
+            $group['cover_alt']          = $cover['alt'];
+            $group['cover_placeholder']  = $cover['placeholder'];
+
+            if ($group['membership_role'] === 'owner' || $group['membership_role'] === 'manager') {
+                $owned[] = $group;
+            } else {
+                $joined[] = $group;
+            }
+        }
+
+        return [
+            'owned'  => $owned,
+            'member' => $joined,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<string, mixed>
+     */
+    public static function query_public(array $args = []): array
+    {
+        global $wpdb;
+
+        $defaults = [
+            'page'           => 1,
+            'per_page'       => 12,
+            'search'         => '',
+            'category'       => '',
+            'orderby'        => 'created',
+            'order'          => 'desc',
+            'instant_access' => null,
+            'price_min'      => null,
+            'price_max'      => null,
+        ];
+
+        $args = array_merge($defaults, $args);
+
+        $page     = max(1, (int) ($args['page'] ?? 1));
+        $per_page = max(1, min(60, (int) ($args['per_page'] ?? 12)));
+        $offset   = ($page - 1) * $per_page;
+
+        $search   = sanitize_text_field((string) ($args['search'] ?? ''));
+        $category = sanitize_key((string) ($args['category'] ?? ''));
+        $orderby  = sanitize_key((string) ($args['orderby'] ?? 'created'));
+        $order    = strtolower((string) ($args['order'] ?? 'desc')) === 'asc' ? 'ASC' : 'DESC';
+        $instant  = $args['instant_access'];
+        $price_min = $args['price_min'];
+        $price_max = $args['price_max'];
+
+        $groups_table  = "{$wpdb->prefix}jp_groups";
+        $members_table = "{$wpdb->prefix}jp_group_members";
+        $users_table   = $wpdb->users;
+
+        $where   = [
+            "g.status = 'approved'",
+            "g.visibility = 'public'",
+        ];
+        $prepare = [];
+
+        if ($search !== '') {
+            $like      = '%' . $wpdb->esc_like($search) . '%';
+            $where[]   = '(g.title LIKE %s OR g.service_name LIKE %s OR g.description LIKE %s)';
+            $prepare[] = $like;
+            $prepare[] = $like;
+            $prepare[] = $like;
+        }
+
+        $categories = self::get_category_labels();
+        if ($category !== '' && isset($categories[$category])) {
+            $where[]   = 'g.category = %s';
+            $prepare[] = $category;
+        }
+
+        if ($instant !== null) {
+            $where[]   = 'g.instant_access = %d';
+            $prepare[] = !empty($instant) ? 1 : 0;
+        }
+
+        $price_field = 'COALESCE(NULLIF(g.member_price, 0), NULLIF(g.price_promotional, 0), g.price_regular)';
+
+        if ($price_min !== null && is_numeric($price_min)) {
+            $where[]   = $price_field . ' >= %f';
+            $prepare[] = (float) $price_min;
+        }
+
+        if ($price_max !== null && is_numeric($price_max)) {
+            $where[]   = $price_field . ' <= %f';
+            $prepare[] = (float) $price_max;
+        }
+
+        $order_map = [
+            'created' => 'g.created_at',
+            'updated' => 'g.updated_at',
+            'name'    => 'g.title',
+            'price'   => $price_field,
+            'members' => 'members_count',
+        ];
+
+        $order_by = $order_map[$orderby] ?? $order_map['created'];
+
+        $sql = "SELECT SQL_CALC_FOUND_ROWS g.*, u.display_name AS owner_name, u.user_email AS owner_email,
+                       $price_field AS effective_price,
+                       (SELECT COUNT(*) FROM $members_table m WHERE m.group_id = g.id AND m.status = 'active') AS members_count
+                FROM $groups_table g
+                LEFT JOIN $users_table u ON u.ID = g.owner_id
+                WHERE " . implode(' AND ', $where) . '
+                ORDER BY ' . $order_by . ' ' . $order . '
+                LIMIT %d OFFSET %d';
+
+        $query = $wpdb->prepare($sql, array_merge($prepare, [$per_page, $offset]));
+
+        $rows  = $wpdb->get_results($query, ARRAY_A) ?: [];
+        $total = (int) $wpdb->get_var('SELECT FOUND_ROWS()');
+        $pages = $per_page > 0 ? (int) ceil($total / $per_page) : 0;
+
+        $items = [];
+
+        foreach ($rows as $row) {
+            $slots_total    = isset($row['slots_total']) ? (int) $row['slots_total'] : 0;
+            $slots_reserved = isset($row['slots_reserved']) ? (int) $row['slots_reserved'] : 0;
+            $available      = max(0, $slots_total - $slots_reserved);
+            $cover          = self::resolve_cover(isset($row['cover_id']) ? (int) $row['cover_id'] : 0);
+
+            $items[] = [
+                'id'                 => isset($row['id']) ? (int) $row['id'] : 0,
+                'slug'               => (string) ($row['slug'] ?? ''),
+                'title'              => (string) ($row['title'] ?? ''),
+                'service_name'       => (string) ($row['service_name'] ?? ''),
+                'service_url'        => (string) ($row['service_url'] ?? ''),
+                'description'        => (string) ($row['description'] ?? ''),
+                'rules'              => (string) ($row['rules'] ?? ''),
+                'category'           => (string) ($row['category'] ?? ''),
+                'instant_access'     => !empty($row['instant_access']),
+                'price_regular'      => isset($row['price_regular']) ? (float) $row['price_regular'] : 0.0,
+                'price_promotional'  => isset($row['price_promotional']) ? (float) $row['price_promotional'] : null,
+                'member_price'       => isset($row['member_price']) ? (float) $row['member_price'] : null,
+                'effective_price'    => isset($row['effective_price']) ? (float) $row['effective_price'] : 0.0,
+                'slots_total'        => $slots_total,
+                'slots_reserved'     => $slots_reserved,
+                'slots_available'    => $available,
+                'members_count'      => isset($row['members_count']) ? (int) $row['members_count'] : 0,
+                'owner_id'           => isset($row['owner_id']) ? (int) $row['owner_id'] : 0,
+                'owner_name'         => (string) ($row['owner_name'] ?? ''),
+                'owner_email'        => (string) ($row['owner_email'] ?? ''),
+                'support_channel'    => (string) ($row['support_channel'] ?? ''),
+                'delivery_time'      => (string) ($row['delivery_time'] ?? ''),
+                'access_method'      => (string) ($row['access_method'] ?? ''),
+                'created_at'         => (string) ($row['created_at'] ?? ''),
+                'updated_at'         => (string) ($row['updated_at'] ?? ''),
+                'cover_id'           => $cover['id'],
+                'cover_url'          => $cover['url'],
+                'cover_alt'          => $cover['alt'],
+                'cover_placeholder'  => $cover['placeholder'],
+            ];
+        }
+
+        return [
+            'items'    => $items,
+            'page'     => $page,
+            'pages'    => $pages,
+            'total'    => $total,
+            'per_page' => $per_page,
+        ];
+    }
+
+    public static function get(int $group_id): ?object
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+
+        if ($group_id <= 0) {
+            return null;
+        }
+
+        $table = "{$wpdb->prefix}jp_groups";
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare("SELECT * FROM $table WHERE id = %d", $group_id)
+        );
+
+        return $row ?: null;
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function all(array $args = []): array
+    {
+        global $wpdb;
+
+        $defaults = [
+            'status' => 'all',
+            'search' => '',
+            'limit'  => 100,
+        ];
+
+        $args = array_merge($defaults, $args);
+
+        $status = sanitize_key((string) $args['status']);
+        $search = sanitize_text_field((string) $args['search']);
+        $limit  = absint($args['limit']);
+
+        if ($limit <= 0 || $limit > 500) {
+            $limit = 100;
+        }
+
+        $groups_table  = "{$wpdb->prefix}jp_groups";
+        $members_table = "{$wpdb->prefix}jp_group_members";
+        $pools_table   = "{$wpdb->prefix}jp_pools";
+        $users_table   = $wpdb->users;
+
+        $where   = ['1=1'];
+        $prepare = [];
+
+        if ($status !== '' && $status !== 'all' && in_array($status, self::get_allowed_statuses(), true)) {
+            $where[]   = 'g.status = %s';
+            $prepare[] = $status;
+        }
+
+        if ($search !== '') {
+            $like      = '%' . $wpdb->esc_like($search) . '%';
+            $where[]   = '(g.title LIKE %s OR g.description LIKE %s OR u.display_name LIKE %s)';
+            $prepare[] = $like;
+            $prepare[] = $like;
+            $prepare[] = $like;
+        }
+
+        $sql = "SELECT g.*, u.display_name AS owner_name, u.user_email AS owner_email,
+                       p.title AS pool_title, p.slug AS pool_slug,
+                       (SELECT COUNT(*) FROM $members_table m WHERE m.group_id = g.id AND m.status = 'active') AS members_count
+                FROM $groups_table g
+                LEFT JOIN $users_table u ON u.ID = g.owner_id
+                LEFT JOIN $pools_table p ON p.id = g.pool_id
+                WHERE " . implode(' AND ', $where) . '
+                ORDER BY g.created_at DESC
+                LIMIT ' . $limit;
+
+        if ($prepare) {
+            $sql = $wpdb->prepare($sql, $prepare);
+        }
+
+        $rows = $wpdb->get_results($sql, ARRAY_A) ?: [];
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $cover = self::resolve_cover(isset($row['cover_id']) ? (int) $row['cover_id'] : 0);
+            $groups[] = [
+                'id'                 => isset($row['id']) ? (int) $row['id'] : 0,
+                'owner_id'           => isset($row['owner_id']) ? (int) $row['owner_id'] : 0,
+                'owner_name'         => (string) ($row['owner_name'] ?? ''),
+                'owner_email'        => (string) ($row['owner_email'] ?? ''),
+                'title'              => (string) ($row['title'] ?? ''),
+                'service_name'       => (string) ($row['service_name'] ?? ''),
+                'service_url'        => (string) ($row['service_url'] ?? ''),
+                'status'             => (string) ($row['status'] ?? self::STATUS_PENDING),
+                'visibility'         => (string) ($row['visibility'] ?? 'public'),
+                'slug'               => (string) ($row['slug'] ?? ''),
+                'pool_id'            => isset($row['pool_id']) ? (int) $row['pool_id'] : 0,
+                'pool_title'         => (string) ($row['pool_title'] ?? ''),
+                'pool_slug'          => (string) ($row['pool_slug'] ?? ''),
+                'price_regular'      => isset($row['price_regular']) ? (float) $row['price_regular'] : 0.0,
+                'price_promotional'  => isset($row['price_promotional']) ? (float) $row['price_promotional'] : null,
+                'member_price'       => isset($row['member_price']) ? (float) $row['member_price'] : null,
+                'slots_total'        => isset($row['slots_total']) ? (int) $row['slots_total'] : 0,
+                'slots_reserved'     => isset($row['slots_reserved']) ? (int) $row['slots_reserved'] : 0,
+                'support_channel'    => (string) ($row['support_channel'] ?? ''),
+                'delivery_time'      => (string) ($row['delivery_time'] ?? ''),
+                'access_method'      => (string) ($row['access_method'] ?? ''),
+                'category'           => (string) ($row['category'] ?? ''),
+                'instant_access'     => isset($row['instant_access']) ? (bool) $row['instant_access'] : false,
+                'rules'              => (string) ($row['rules'] ?? ''),
+                'description'        => (string) ($row['description'] ?? ''),
+                'review_note'        => (string) ($row['review_note'] ?? ''),
+                'reviewed_at'        => (string) ($row['reviewed_at'] ?? ''),
+                'reviewed_by'        => isset($row['reviewed_by']) ? (int) $row['reviewed_by'] : 0,
+                'created_at'         => (string) ($row['created_at'] ?? ''),
+                'updated_at'         => (string) ($row['updated_at'] ?? ''),
+                'members_count'      => isset($row['members_count']) ? (int) $row['members_count'] : 0,
+                'cover_id'           => $cover['id'],
+                'cover_url'          => $cover['url'],
+                'cover_alt'          => $cover['alt'],
+                'cover_placeholder'  => $cover['placeholder'],
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function counts_by_status(): array
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_groups";
+
+        $rows = $wpdb->get_results("SELECT status, COUNT(*) AS total FROM $table GROUP BY status", ARRAY_A) ?: [];
+
+        $counts = [
+            self::STATUS_PENDING  => 0,
+            self::STATUS_APPROVED => 0,
+            self::STATUS_REJECTED => 0,
+            self::STATUS_ARCHIVED => 0,
+        ];
+
+        foreach ($rows as $row) {
+            $status = isset($row['status']) ? (string) $row['status'] : '';
+            $total  = isset($row['total']) ? (int) $row['total'] : 0;
+
+            if (isset($counts[$status])) {
+                $counts[$status] = $total;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     */
+    public static function update_status(int $group_id, string $status, array $args = []): bool
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+        $status   = sanitize_key($status);
+
+        if ($group_id <= 0 || !in_array($status, self::get_allowed_statuses(), true)) {
+            return false;
+        }
+
+        $table = "{$wpdb->prefix}jp_groups";
+
+        $columns = ['status = %s'];
+        $prepare = [$status];
+
+        $review_note = isset($args['review_note']) ? sanitize_textarea_field((string) $args['review_note']) : '';
+        $reviewed_by = isset($args['reviewed_by']) ? absint($args['reviewed_by']) : 0;
+        $reviewed_at = isset($args['reviewed_at']) ? sanitize_text_field((string) $args['reviewed_at']) : '';
+
+        if ($status === self::STATUS_PENDING) {
+            $columns[] = 'reviewed_by = NULL';
+            $columns[] = 'reviewed_at = NULL';
+            $columns[] = 'review_note = NULL';
+        } else {
+            if ($reviewed_by > 0) {
+                $columns[] = 'reviewed_by = %d';
+                $prepare[] = $reviewed_by;
+            } else {
+                $columns[] = 'reviewed_by = NULL';
+            }
+
+            if ($reviewed_at === '') {
+                $reviewed_at = current_time('mysql');
+            }
+
+            $columns[] = 'reviewed_at = %s';
+            $prepare[] = $reviewed_at;
+
+            if ($review_note !== '') {
+                $columns[] = 'review_note = %s';
+                $prepare[] = $review_note;
+            } else {
+                $columns[] = 'review_note = NULL';
+            }
+        }
+
+        $columns[] = 'updated_at = %s';
+        $prepare[] = current_time('mysql');
+
+        $prepare[] = $group_id;
+
+        $sql = 'UPDATE ' . $table . ' SET ' . implode(', ', $columns) . ' WHERE id = %d';
+
+        $result = $wpdb->query($wpdb->prepare($sql, $prepare));
+
+        return (bool) $result;
+    }
+
+    public static function get_status_label(string $status): string
+    {
+        return match ($status) {
+            self::STATUS_APPROVED => __('Aprovado', 'juntaplay'),
+            self::STATUS_REJECTED => __('Recusado', 'juntaplay'),
+            self::STATUS_ARCHIVED => __('Arquivado', 'juntaplay'),
+            default               => __('Em análise', 'juntaplay'),
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function get_allowed_statuses(): array
+    {
+        return [
+            self::STATUS_PENDING,
+            self::STATUS_APPROVED,
+            self::STATUS_REJECTED,
+            self::STATUS_ARCHIVED,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function get_pool_choices(): array
+    {
+        global $wpdb;
+
+        $table   = "{$wpdb->prefix}jp_pools";
+        $results = $wpdb->get_results("SELECT id, title FROM $table WHERE status IN ('publish','published','active') ORDER BY created_at DESC", ARRAY_A) ?: [];
+
+        $choices = [];
+        foreach ($results as $row) {
+            $choices[(int) $row['id']] = (string) ($row['title'] ?? '');
+        }
+
+        return $choices;
+    }
+
+    public static function generate_email_validation_code(int $group_id): ?string
+    {
+        global $wpdb;
+
+        $group_id = absint($group_id);
+
+        if ($group_id <= 0) {
+            return null;
+        }
+
+        $code = (string) wp_rand(100000, 999999);
+        $hash = wp_hash_password($code);
+
+        $table   = "{$wpdb->prefix}jp_groups";
+        $updated = $wpdb->update(
+            $table,
+            [
+                'email_validation_hash'    => $hash,
+                'email_validation_sent_at' => current_time('mysql'),
+                'email_validated_at'       => null,
+            ],
+            ['id' => $group_id],
+            ['%s', '%s', '%s'],
+            ['%d']
+        );
+
+        return $updated !== false ? $code : null;
+    }
+
+    public static function slug_exists(string $slug): bool
+    {
+        global $wpdb;
+
+        $slug = sanitize_title($slug);
+
+        if ($slug === '') {
+            return false;
+        }
+
+        $table = "{$wpdb->prefix}jp_groups";
+
+        return (int) $wpdb->get_var(
+            $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE slug = %s", $slug)
+        ) > 0;
+    }
+
+    private static function generate_unique_slug(string $title): string
+    {
+        global $wpdb;
+
+        $base = sanitize_title($title);
+        if ($base === '') {
+            $base = 'grupo-' . substr((string) wp_generate_uuid4(), 0, 8);
+        }
+
+        $slug   = $base;
+        $suffix = 2;
+        $table  = "{$wpdb->prefix}jp_groups";
+
+        while ((int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE slug = %s", $slug)) > 0) {
+            $slug = $base . '-' . $suffix;
+            ++$suffix;
+        }
+
+        return $slug;
+    }
+
+    private static function ensure_unique_slug(string $base): string
+    {
+        global $wpdb;
+
+        $slug   = $base;
+        $suffix = 2;
+        $table  = "{$wpdb->prefix}jp_groups";
+
+        while ((int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE slug = %s", $slug)) > 0) {
+            $slug = $base . '-' . $suffix;
+            ++$suffix;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * @return array{id: int, url: string, alt: string, placeholder: bool}
+     */
+    private static function resolve_cover(int $attachment_id): array
+    {
+        $attachment_id = $attachment_id > 0 ? $attachment_id : 0;
+        $url           = '';
+        $alt           = '';
+
+        if ($attachment_id > 0) {
+            $attachment = wp_prepare_attachment_for_js($attachment_id);
+
+            if (is_array($attachment)) {
+                $url = (string) ($attachment['sizes']['large']['url'] ?? $attachment['sizes']['medium_large']['url'] ?? $attachment['url'] ?? '');
+                $alt = (string) ($attachment['alt'] ?? $attachment['title'] ?? '');
+            }
+
+            if ($url === '') {
+                $url = (string) wp_get_attachment_image_url($attachment_id, 'large');
+            }
+
+            if ($alt === '') {
+                $alt = (string) get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+            }
+        }
+
+        if ($url === '') {
+            $url = self::get_default_cover_url();
+        }
+
+        if ($alt === '') {
+            $alt = __('Capa do grupo', 'juntaplay');
+        }
+
+        return [
+            'id'          => $attachment_id,
+            'url'         => $url,
+            'alt'         => $alt,
+            'placeholder' => $attachment_id <= 0,
+        ];
+    }
+
+    private static function get_default_cover_url(): string
+    {
+        return defined('JP_GROUP_COVER_PLACEHOLDER') ? JP_GROUP_COVER_PLACEHOLDER : '';
+    }
+}

--- a/juntaplay/includes/Data/Notifications.php
+++ b/juntaplay/includes/Data/Notifications.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use wpdb;
+
+use function absint;
+use function current_time;
+use function sanitize_text_field;
+
+defined('ABSPATH') || exit;
+
+class Notifications
+{
+    public const STATUS_UNREAD = 'unread';
+    public const STATUS_READ   = 'read';
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function add(int $user_id, array $data): int
+    {
+        global $wpdb;
+
+        $user_id = absint($user_id);
+        if ($user_id <= 0) {
+            return 0;
+        }
+
+        $table    = "{$wpdb->prefix}jp_notifications";
+        $type     = isset($data['type']) ? sanitize_text_field((string) $data['type']) : 'general';
+        $title    = isset($data['title']) ? sanitize_text_field((string) $data['title']) : '';
+        $message  = isset($data['message']) ? (string) $data['message'] : '';
+        $url      = isset($data['action_url']) ? (string) $data['action_url'] : '';
+        $status   = isset($data['status']) ? sanitize_text_field((string) $data['status']) : self::STATUS_UNREAD;
+
+        if ($title === '' || $message === '') {
+            return 0;
+        }
+
+        $payload = [
+            'user_id'    => $user_id,
+            'type'       => $type,
+            'title'      => $title,
+            'message'    => $message,
+            'action_url' => $url !== '' ? $url : null,
+            'status'     => $status,
+            'created_at' => current_time('mysql'),
+        ];
+
+        $formats = ['%d', '%s', '%s', '%s', '%s', '%s', '%s'];
+
+        $inserted = $wpdb->insert($table, $payload, $formats);
+
+        return $inserted ? (int) $wpdb->insert_id : 0;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_recent(int $user_id, int $limit = 10): array
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_notifications";
+        $limit = max(1, min(50, $limit));
+
+        $query = $wpdb->prepare(
+            "SELECT * FROM $table WHERE user_id = %d ORDER BY created_at DESC LIMIT %d",
+            $user_id,
+            $limit
+        );
+
+        $rows = $wpdb->get_results($query, ARRAY_A) ?: [];
+        $items = [];
+
+        foreach ($rows as $row) {
+            $items[] = [
+                'id'         => isset($row['id']) ? (int) $row['id'] : 0,
+                'user_id'    => isset($row['user_id']) ? (int) $row['user_id'] : 0,
+                'type'       => (string) ($row['type'] ?? 'general'),
+                'title'      => (string) ($row['title'] ?? ''),
+                'message'    => (string) ($row['message'] ?? ''),
+                'action_url' => (string) ($row['action_url'] ?? ''),
+                'status'     => (string) ($row['status'] ?? self::STATUS_UNREAD),
+                'created_at' => (string) ($row['created_at'] ?? ''),
+                'read_at'    => (string) ($row['read_at'] ?? ''),
+            ];
+        }
+
+        return $items;
+    }
+
+    public static function count_unread(int $user_id): int
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_notifications";
+
+        $query = $wpdb->prepare(
+            "SELECT COUNT(*) FROM $table WHERE user_id = %d AND status = %s",
+            $user_id,
+            self::STATUS_UNREAD
+        );
+
+        return (int) $wpdb->get_var($query);
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    public static function mark_read(int $user_id, array $ids): int
+    {
+        global $wpdb;
+
+        $ids = array_filter(array_map('absint', $ids));
+
+        if (!$ids) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $table        = "{$wpdb->prefix}jp_notifications";
+
+        $query = $wpdb->prepare(
+            "UPDATE $table
+             SET status = %s, read_at = %s
+             WHERE user_id = %d AND id IN ($placeholders)",
+            ...array_merge([self::STATUS_READ, current_time('mysql'), $user_id], $ids)
+        );
+
+        return $query ? (int) $wpdb->query($query) : 0;
+    }
+}

--- a/juntaplay/includes/Data/Pools.php
+++ b/juntaplay/includes/Data/Pools.php
@@ -1,0 +1,274 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+use WC_Product_Simple;
+
+use function absint;
+use function apply_filters;
+use function array_map;
+use function get_post_status;
+use function sanitize_key;
+use function sanitize_text_field;
+use function sanitize_title;
+use function wp_parse_args;
+use function wp_prepare_attachment_for_js;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Pools
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function get_category_labels(): array
+    {
+        $categories = [
+            'boloes'      => __('Bolões e rifas', 'juntaplay'),
+            'video'       => __('Vídeo e streaming', 'juntaplay'),
+            'music'       => __('Música e áudio', 'juntaplay'),
+            'education'   => __('Cursos e educação', 'juntaplay'),
+            'reading'     => __('Leitura e revistas', 'juntaplay'),
+            'office'      => __('Escritório e produtividade', 'juntaplay'),
+            'software'    => __('Software e ferramentas', 'juntaplay'),
+            'games'       => __('Jogos e esportes', 'juntaplay'),
+            'ai'          => __('Ferramentas de IA', 'juntaplay'),
+            'security'    => __('Segurança e VPN', 'juntaplay'),
+            'marketplace' => __('Mercado e delivery', 'juntaplay'),
+            'lifestyle'   => __('Lifestyle e clubes', 'juntaplay'),
+            'other'       => __('Outros serviços', 'juntaplay'),
+        ];
+
+        return apply_filters('juntaplay/pools/categories', $categories);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function create_or_update(array $data): int
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_pools";
+        $slug  = isset($data['slug']) ? sanitize_title((string) $data['slug']) : '';
+
+        $existing = $slug !== ''
+            ? $wpdb->get_var($wpdb->prepare("SELECT id FROM $table WHERE slug = %s", $slug))
+            : null;
+
+        $category = isset($data['category']) ? sanitize_key((string) $data['category']) : '';
+        $categories = self::get_category_labels();
+        if ($category !== '' && !isset($categories[$category])) {
+            $category = 'other';
+        }
+
+        $payload = [
+            'title'        => sanitize_text_field($data['title'] ?? ''),
+            'slug'         => $slug,
+            'price'        => isset($data['price']) ? (float) $data['price'] : 0.0,
+            'quota_start'  => isset($data['quota_start']) ? (int) $data['quota_start'] : 1,
+            'quota_end'    => isset($data['quota_end']) ? (int) $data['quota_end'] : 1,
+            'quotas_total' => max(0, (int) ($data['quota_end'] ?? 1) - (int) ($data['quota_start'] ?? 1) + 1),
+            'category'     => $category,
+            'excerpt'      => isset($data['excerpt']) ? sanitize_text_field((string) $data['excerpt']) : null,
+            'thumbnail_id' => isset($data['thumbnail_id']) ? absint($data['thumbnail_id']) : null,
+            'is_featured'  => !empty($data['is_featured']) ? 1 : 0,
+            'status'       => isset($data['status']) ? sanitize_key((string) $data['status']) : 'publish',
+        ];
+
+        if ($existing) {
+            $wpdb->update($table, $payload, ['id' => (int) $existing]);
+
+            return (int) $existing;
+        }
+
+        $wpdb->insert($table, $payload);
+
+        return (int) $wpdb->insert_id;
+    }
+
+    /**
+     * @param array<string, mixed> $args
+     * @return array<string, mixed>
+     */
+    public static function query(array $args = []): array
+    {
+        global $wpdb;
+
+        $defaults = [
+            'page'      => 1,
+            'per_page'  => 12,
+            'search'    => '',
+            'category'  => '',
+            'min_price' => null,
+            'max_price' => null,
+            'status'    => 'publish',
+            'featured'  => null,
+            'order'     => 'DESC',
+            'orderby'   => 'created_at',
+        ];
+
+        $args = wp_parse_args($args, $defaults);
+
+        $page     = max(1, (int) $args['page']);
+        $per_page = max(1, min(24, (int) $args['per_page']));
+        $offset   = ($page - 1) * $per_page;
+
+        $table  = "{$wpdb->prefix}jp_pools";
+        $where  = [];
+        $params = [];
+
+        if ($args['status']) {
+            $where[]  = 'status = %s';
+            $params[] = (string) $args['status'];
+        }
+
+        if ($args['category']) {
+            $where[]  = 'category = %s';
+            $params[] = sanitize_key((string) $args['category']);
+        }
+
+        if ($args['featured'] !== null) {
+            $where[]  = 'is_featured = %d';
+            $params[] = !empty($args['featured']) ? 1 : 0;
+        }
+
+        if ($args['search']) {
+            $where[] = '(title LIKE %s OR slug LIKE %s)';
+            $like    = '%' . $wpdb->esc_like((string) $args['search']) . '%';
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        if ($args['min_price'] !== null) {
+            $where[]  = 'price >= %f';
+            $params[] = (float) $args['min_price'];
+        }
+
+        if ($args['max_price'] !== null) {
+            $where[]  = 'price <= %f';
+            $params[] = (float) $args['max_price'];
+        }
+
+        $where_sql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+
+        $orderby = in_array($args['orderby'], ['created_at', 'price', 'title', 'quotas_paid'], true)
+            ? $args['orderby']
+            : 'created_at';
+        $order = strtoupper((string) $args['order']) === 'ASC' ? 'ASC' : 'DESC';
+
+        $query = $wpdb->prepare(
+            "SELECT SQL_CALC_FOUND_ROWS *
+             FROM $table
+             $where_sql
+             ORDER BY $orderby $order
+             LIMIT %d OFFSET %d",
+            ...array_merge($params, [$per_page, $offset])
+        );
+
+        $rows  = $query ? $wpdb->get_results($query, ARRAY_A) : [];
+        $total = (int) $wpdb->get_var('SELECT FOUND_ROWS()');
+        $pages = (int) ceil($total / $per_page);
+
+        $items = array_map([self::class, 'map_row'], $rows ?: []);
+
+        return [
+            'items'    => $items,
+            'total'    => $total,
+            'pages'    => $pages,
+            'page'     => $page,
+            'per_page' => $per_page,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private static function map_row(array $row): array
+    {
+        $total  = isset($row['quotas_total']) ? max(0, (int) $row['quotas_total']) : 0;
+        $paid   = isset($row['quotas_paid']) ? max(0, (int) $row['quotas_paid']) : 0;
+        $remain = max(0, $total - $paid);
+        $progress = $total > 0 ? min(100, (int) round(($paid / $total) * 100)) : 0;
+
+        $thumbnail_id = isset($row['thumbnail_id']) ? (int) $row['thumbnail_id'] : 0;
+        $thumbnail    = null;
+
+        if ($thumbnail_id > 0) {
+            $attachment = wp_prepare_attachment_for_js($thumbnail_id);
+            if (is_array($attachment) && !empty($attachment['url'])) {
+                $thumbnail = $attachment['url'];
+            }
+        }
+
+        return [
+            'id'           => isset($row['id']) ? (int) $row['id'] : 0,
+            'title'        => (string) ($row['title'] ?? ''),
+            'slug'         => (string) ($row['slug'] ?? ''),
+            'price'        => isset($row['price']) ? (float) $row['price'] : 0.0,
+            'product_id'   => isset($row['product_id']) ? (int) $row['product_id'] : 0,
+            'quota_start'  => isset($row['quota_start']) ? (int) $row['quota_start'] : 1,
+            'quota_end'    => isset($row['quota_end']) ? (int) $row['quota_end'] : 1,
+            'quotas_total' => $total,
+            'quotas_paid'  => $paid,
+            'quotas_free'  => $remain,
+            'progress'     => $progress,
+            'category'     => (string) ($row['category'] ?? ''),
+            'excerpt'      => (string) ($row['excerpt'] ?? ''),
+            'thumbnail_id' => $thumbnail_id,
+            'thumbnail'    => $thumbnail,
+            'is_featured'  => !empty($row['is_featured']),
+            'status'       => (string) ($row['status'] ?? 'draft'),
+            'created_at'   => (string) ($row['created_at'] ?? ''),
+            'updated_at'   => (string) ($row['updated_at'] ?? ''),
+        ];
+    }
+
+    public static function ensure_product(int $pool_id): void
+    {
+        if (!class_exists('WC_Product_Simple')) {
+            return;
+        }
+
+        $pool = self::get($pool_id);
+
+        if (!$pool) {
+            return;
+        }
+
+        if (!empty($pool->product_id) && get_post_status((int) $pool->product_id)) {
+            return;
+        }
+
+        $product = new WC_Product_Simple();
+        $product->set_name($pool->title);
+        $product->set_status('publish');
+        $product->set_catalog_visibility('hidden');
+        $product->set_virtual(true);
+        $product->set_sold_individually(false);
+        $product->set_regular_price((string) $pool->price);
+        $product->save();
+
+        wp_set_object_terms($product->get_id(), 'juntaplay_pool_product', 'product_type');
+
+        global $wpdb;
+
+        $wpdb->update(
+            "{$wpdb->prefix}jp_pools",
+            ['product_id' => $product->get_id()],
+            ['id' => $pool_id]
+        );
+
+        update_post_meta($product->get_id(), '_juntaplay_pool_id', $pool_id);
+    }
+
+    public static function get(int $pool_id)
+    {
+        global $wpdb;
+
+        return $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}jp_pools WHERE id = %d", $pool_id));
+    }
+}

--- a/juntaplay/includes/Data/Quotas.php
+++ b/juntaplay/includes/Data/Quotas.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Data;
+
+defined('ABSPATH') || exit;
+
+use function array_map;
+use function preg_replace;
+use function str_contains;
+use function wp_parse_args;
+
+class Quotas
+{
+    /**
+     * @param array<string, mixed> $args
+     * @return array<string, mixed>
+     */
+    public static function list_numbers(int $pool_id, array $args = []): array
+    {
+        global $wpdb;
+
+        $defaults = [
+            'page'      => 1,
+            'per_page'  => 120,
+            'status'    => 'available',
+            'search'    => '',
+            'sort'      => 'ASC',
+        ];
+
+        $args = wp_parse_args($args, $defaults);
+
+        $page     = max(1, (int) $args['page']);
+        $per_page = max(20, min(240, (int) $args['per_page']));
+        $offset   = ($page - 1) * $per_page;
+
+        $table   = "{$wpdb->prefix}jp_quotas";
+        $where   = ['pool_id = %d'];
+        $params  = [$pool_id];
+
+        if ($args['status'] && $args['status'] !== 'all') {
+            if ($args['status'] === 'open') {
+                $where[] = "status IN ('available','reserved')";
+            } else {
+                $where[]  = 'status = %s';
+                $params[] = (string) $args['status'];
+            }
+        }
+
+        if ($args['search']) {
+            $search = preg_replace('/[^0-9\-]/', '', (string) $args['search']);
+            if (str_contains((string) $search, '-')) {
+                [$start, $end] = array_map('intval', explode('-', (string) $search, 2));
+                if ($start > 0 && $end >= $start) {
+                    $where[]  = 'number BETWEEN %d AND %d';
+                    $params[] = $start;
+                    $params[] = $end;
+                }
+            } elseif ($search !== '') {
+                $where[]  = 'number = %d';
+                $params[] = (int) $search;
+            }
+        }
+
+        $where_sql = implode(' AND ', $where);
+        $sort      = strtoupper((string) $args['sort']) === 'DESC' ? 'DESC' : 'ASC';
+
+        $query = $wpdb->prepare(
+            "SELECT SQL_CALC_FOUND_ROWS number, status, reserved_until
+             FROM $table
+             WHERE $where_sql
+             ORDER BY number $sort
+             LIMIT %d OFFSET %d",
+            ...array_merge($params, [$per_page, $offset])
+        );
+
+        $rows  = $query ? $wpdb->get_results($query, ARRAY_A) : [];
+        $total = (int) $wpdb->get_var('SELECT FOUND_ROWS()');
+        $pages = (int) ceil($total / $per_page);
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'number' => isset($row['number']) ? (int) $row['number'] : 0,
+                'status' => (string) ($row['status'] ?? 'available'),
+            ];
+        }
+
+        return [
+            'items'    => $items,
+            'total'    => $total,
+            'pages'    => $pages,
+            'page'     => $page,
+            'per_page' => $per_page,
+        ];
+    }
+
+    public static function reserve(int $pool_id, array $numbers, int $user_id, int $minutes = 15): array
+    {
+        global $wpdb;
+
+        $table   = "{$wpdb->prefix}jp_quotas";
+        $reserved = [];
+        $expires = gmdate('Y-m-d H:i:s', time() + ($minutes * 60));
+
+        foreach ($numbers as $number) {
+            $number  = (int) $number;
+            $updated = $wpdb->query($wpdb->prepare(
+                "UPDATE $table
+                 SET status='reserved', user_id=%d, reserved_until=%s
+                 WHERE pool_id=%d AND number=%d AND status='available'
+                 LIMIT 1",
+                $user_id,
+                $expires,
+                $pool_id,
+                $number
+            ));
+
+            if ($updated) {
+                $reserved[] = $number;
+            }
+        }
+
+        return $reserved;
+    }
+
+    public static function pay(int $pool_id, array $numbers, int $order_id, int $user_id): void
+    {
+        global $wpdb;
+
+        if (empty($numbers)) {
+            return;
+        }
+
+        $table = "{$wpdb->prefix}jp_quotas";
+        $in    = implode(',', array_map('intval', $numbers));
+
+        $wpdb->query(
+            "UPDATE $table
+             SET status='paid', order_id={$order_id}, user_id={$user_id}, reserved_until=NULL
+             WHERE pool_id={$pool_id} AND number IN ($in) AND status IN ('reserved','available')"
+        );
+    }
+
+    public static function release_by_order(int $order_id): void
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_quotas";
+        $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE $table
+                 SET status='available', user_id=NULL, order_id=NULL, reserved_until=NULL
+                 WHERE order_id=%d",
+                $order_id
+            )
+        );
+    }
+
+    public static function seed(int $pool_id): void
+    {
+        global $wpdb;
+
+        $pool = Pools::get($pool_id);
+
+        if (!$pool) {
+            return;
+        }
+
+        $table      = "{$wpdb->prefix}jp_quotas";
+        $start      = (int) $pool->quota_start;
+        $end        = (int) $pool->quota_end;
+        $numbers    = range($start, $end);
+        $existing   = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE pool_id = %d", $pool_id));
+
+        if ($existing >= count($numbers)) {
+            return;
+        }
+
+        $chunks = array_chunk($numbers, 500);
+
+        foreach ($chunks as $chunk) {
+            $values = [];
+
+            foreach ($chunk as $number) {
+                $number = (int) $number;
+                $values[] = $wpdb->prepare('(%d,%d,%s)', $pool_id, $number, 'available');
+            }
+
+            $sql = "INSERT IGNORE INTO $table (pool_id, number, status) VALUES " . implode(',', $values);
+            $wpdb->query($sql);
+        }
+    }
+}

--- a/juntaplay/includes/Front/Ajax.php
+++ b/juntaplay/includes/Front/Ajax.php
@@ -1,0 +1,581 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Front;
+
+use JuntaPlay\Admin\Settings;
+use JuntaPlay\Data\CreditTransactions;
+use JuntaPlay\Data\CreditWithdrawals;
+use JuntaPlay\Data\Notifications as NotificationsData;
+use JuntaPlay\Data\Groups;
+use JuntaPlay\Data\Pools;
+use JuntaPlay\Data\Quotas;
+
+use function absint;
+use function add_action;
+use function add_query_arg;
+use function array_map;
+use function check_ajax_referer;
+use function get_avatar_url;
+use function get_current_user_id;
+use function get_option;
+use function get_permalink;
+use function max;
+use function min;
+use function mysql2date;
+use function number_format_i18n;
+use function sanitize_key;
+use function sanitize_text_field;
+use function sprintf;
+use function home_url;
+use function rawurlencode;
+use function wp_date;
+use function wp_send_json_error;
+use function wp_send_json_success;
+use function wp_unslash;
+use function wp_strip_all_tags;
+use function wc_get_checkout_url;
+use function wc_price;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Ajax
+{
+    public function __construct(private Profile $profile)
+    {
+        add_action('wp_ajax_juntaplay_pools', [$this, 'pools']);
+        add_action('wp_ajax_nopriv_juntaplay_pools', [$this, 'pools']);
+        add_action('wp_ajax_juntaplay_pool_numbers', [$this, 'pool_numbers']);
+        add_action('wp_ajax_nopriv_juntaplay_pool_numbers', [$this, 'pool_numbers']);
+        add_action('wp_ajax_juntaplay_groups_directory', [$this, 'groups_directory']);
+        add_action('wp_ajax_nopriv_juntaplay_groups_directory', [$this, 'groups_directory']);
+        add_action('wp_ajax_juntaplay_credit_deposit', [$this, 'credit_deposit']);
+    }
+
+    public function pools(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $page     = isset($_GET['page']) ? absint($_GET['page']) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $per_page = isset($_GET['per_page']) ? absint($_GET['per_page']) : 12; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $search   = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $category = isset($_GET['category']) ? sanitize_key(wp_unslash($_GET['category'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $featured = isset($_GET['featured']) ? sanitize_text_field(wp_unslash($_GET['featured'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $orderby  = isset($_GET['orderby']) ? sanitize_key(wp_unslash($_GET['orderby'])) : 'created_at'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $order    = isset($_GET['order']) ? sanitize_key(wp_unslash($_GET['order'])) : 'desc'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $min_price = isset($_GET['min_price']) ? floatval(wp_unslash($_GET['min_price'])) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $max_price = isset($_GET['max_price']) ? floatval(wp_unslash($_GET['max_price'])) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        $result = Pools::query([
+            'page'      => $page,
+            'per_page'  => $per_page,
+            'search'    => $search,
+            'category'  => $category,
+            'min_price' => $min_price,
+            'max_price' => $max_price,
+            'featured'  => $featured !== '' ? in_array($featured, ['1', 'yes', 'true'], true) : null,
+            'orderby'   => $orderby,
+            'order'     => $order,
+        ]);
+
+        $categories = Pools::get_category_labels();
+        $items      = array_map(function (array $pool) use ($categories) {
+            return $this->format_pool($pool, $categories);
+        }, $result['items']);
+
+        wp_send_json_success([
+            'items'      => $items,
+            'page'       => $result['page'],
+            'pages'      => $result['pages'],
+            'total'      => $result['total'],
+            'categories' => $categories,
+        ]);
+    }
+
+    public function pool_numbers(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $pool_id = isset($_GET['pool_id']) ? absint($_GET['pool_id']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ($pool_id <= 0) {
+            wp_send_json_error(['message' => __('Campanha não encontrada.', 'juntaplay')], 404);
+        }
+
+        $page    = isset($_GET['page']) ? absint($_GET['page']) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $per     = isset($_GET['per_page']) ? absint($_GET['per_page']) : 120; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $status  = isset($_GET['status']) ? sanitize_key(wp_unslash($_GET['status'])) : 'available'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $search  = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $sort    = isset($_GET['sort']) ? sanitize_key(wp_unslash($_GET['sort'])) : 'ASC'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        $result = Quotas::list_numbers($pool_id, [
+            'page'     => $page,
+            'per_page' => $per,
+            'status'   => $status,
+            'search'   => $search,
+            'sort'     => $sort,
+        ]);
+
+        wp_send_json_success($result);
+    }
+
+    public function groups_directory(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $page      = isset($_GET['page']) ? absint($_GET['page']) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $per_page  = isset($_GET['per_page']) ? absint($_GET['per_page']) : 12; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $search    = isset($_GET['search']) ? sanitize_text_field(wp_unslash($_GET['search'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $category  = isset($_GET['category']) ? sanitize_key(wp_unslash($_GET['category'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $orderby   = isset($_GET['orderby']) ? sanitize_key(wp_unslash($_GET['orderby'])) : 'created'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $order     = isset($_GET['order']) ? sanitize_key(wp_unslash($_GET['order'])) : 'desc'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $instant   = isset($_GET['instant_access']) ? sanitize_key(wp_unslash($_GET['instant_access'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $min_price = isset($_GET['min_price']) ? floatval(wp_unslash($_GET['min_price'])) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $max_price = isset($_GET['max_price']) ? floatval(wp_unslash($_GET['max_price'])) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        $result = Groups::query_public([
+            'page'           => $page,
+            'per_page'       => $per_page,
+            'search'         => $search,
+            'category'       => $category,
+            'orderby'        => $orderby,
+            'order'          => $order,
+            'instant_access' => $instant !== '' ? in_array($instant, ['1', 'yes', 'true'], true) : null,
+            'price_min'      => $min_price,
+            'price_max'      => $max_price,
+        ]);
+
+        $categories = Groups::get_category_labels();
+        $items      = array_map(function (array $group) use ($categories) {
+            return $this->format_group($group, $categories);
+        }, $result['items']);
+
+        wp_send_json_success([
+            'items'      => $items,
+            'page'       => $result['page'],
+            'pages'      => $result['pages'],
+            'total'      => $result['total'],
+            'categories' => $categories,
+        ]);
+    }
+
+    public function init(): void
+    {
+        add_action('wp_ajax_juntaplay_reserve', [$this, 'reserve']);
+        add_action('wp_ajax_nopriv_juntaplay_reserve', [$this, 'reserve']);
+        add_action('wp_ajax_juntaplay_credit_transactions', [$this, 'credit_transactions']);
+        add_action('wp_ajax_juntaplay_credit_transaction', [$this, 'credit_transaction']);
+        add_action('wp_ajax_juntaplay_credit_send_code', [$this, 'credit_send_code']);
+        add_action('wp_ajax_juntaplay_credit_withdraw', [$this, 'credit_withdraw']);
+        add_action('wp_ajax_juntaplay_notifications_feed', [$this, 'notifications_feed']);
+        add_action('wp_ajax_juntaplay_notifications_mark', [$this, 'notifications_mark']);
+    }
+
+    public function reserve(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $pool_id = absint($_POST['pool_id'] ?? 0);
+        $numbers = array_map('intval', $_POST['numbers'] ?? []);
+        $user_id = get_current_user_id() ?: 0;
+
+        if (!$pool_id || empty($numbers)) {
+            wp_send_json_error(['message' => __('Dados insuficientes para reservar cotas.', 'juntaplay')], 400);
+        }
+
+        $settings = get_option(Settings::OPTION_RESERVE, ['minutes' => 15]);
+        $minutes  = (int) ($settings['minutes'] ?? 15);
+
+        $reserved = Quotas::reserve($pool_id, $numbers, $user_id, $minutes);
+
+        if (count($reserved) !== count($numbers)) {
+            wp_send_json_error([
+                'message' => __('Algumas cotas já foram reservadas. Atualize e tente novamente.', 'juntaplay'),
+                'reserved' => $reserved,
+            ], 409);
+        }
+
+        wp_send_json_success(['reserved' => $reserved]);
+    }
+
+    public function credit_transactions(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('É necessário estar logado para visualizar as movimentações.', 'juntaplay')], 401);
+        }
+
+        $page     = isset($_GET['page']) ? absint($_GET['page']) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $per_page = isset($_GET['per_page']) ? absint($_GET['per_page']) : 10; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $page     = max(1, $page);
+        $per_page = max(5, min(50, $per_page));
+
+        $filters = [];
+        if (!empty($_GET['type'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $filters['type'] = sanitize_key(wp_unslash($_GET['type']));
+        }
+
+        if (!empty($_GET['status'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $filters['status'] = sanitize_key(wp_unslash($_GET['status']));
+        }
+
+        $result = CreditTransactions::get_for_user($user_id, $page, $per_page, $filters);
+
+        $items = array_map([$this, 'format_transaction'], $result['items']);
+
+        wp_send_json_success([
+            'items' => $items,
+            'page'  => $result['page'],
+            'pages' => $result['pages'],
+            'total' => $result['total'],
+        ]);
+    }
+
+    public function credit_transaction(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Sua sessão expirou. Faça login novamente.', 'juntaplay')], 401);
+        }
+
+        $transaction_id = isset($_GET['id']) ? absint($_GET['id']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ($transaction_id <= 0) {
+            wp_send_json_error(['message' => __('Transação não encontrada.', 'juntaplay')], 404);
+        }
+
+        $transaction = CreditTransactions::get($transaction_id, $user_id);
+
+        if (!$transaction) {
+            wp_send_json_error(['message' => __('Transação não encontrada.', 'juntaplay')], 404);
+        }
+
+        wp_send_json_success(['transaction' => $this->format_transaction($transaction, true)]);
+    }
+
+    public function credit_send_code(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Sessão expirada. Faça login novamente.', 'juntaplay')], 401);
+        }
+
+        $result = $this->profile->send_withdraw_code($user_id);
+
+        if (!empty($result['error'])) {
+            wp_send_json_error(['message' => (string) $result['error']], 400);
+        }
+
+        wp_send_json_success([
+            'message'     => (string) ($result['message'] ?? __('Código enviado com sucesso.', 'juntaplay')),
+            'expires'     => $result['expires'] ?? '',
+            'destination' => $result['destination'] ?? '',
+        ]);
+    }
+
+    public function credit_withdraw(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Sessão expirada. Faça login novamente.', 'juntaplay')], 401);
+        }
+
+        $amount_raw = isset($_POST['amount']) ? wp_unslash($_POST['amount']) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $method     = isset($_POST['method']) ? sanitize_key(wp_unslash($_POST['method'])) : 'pix'; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $code       = isset($_POST['code']) ? sanitize_text_field(wp_unslash($_POST['code'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+        $result = $this->profile->handle_withdrawal_request($user_id, [
+            'amount' => $amount_raw,
+            'method' => $method,
+            'code'   => $code,
+        ]);
+
+        if (!empty($result['error'])) {
+            $status = isset($result['status']) ? (int) $result['status'] : 400;
+            wp_send_json_error(['message' => (string) $result['error'], 'field' => $result['field'] ?? ''], $status);
+        }
+
+        wp_send_json_success([
+            'message'        => (string) ($result['message'] ?? __('Solicitação registrada com sucesso.', 'juntaplay')),
+            'withdrawal_id'  => $result['withdrawal_id'] ?? 0,
+            'unread'         => NotificationsData::count_unread($user_id),
+        ]);
+    }
+
+    public function credit_deposit(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Faça login para adicionar créditos.', 'juntaplay')], 401);
+        }
+
+        $amount_raw = isset($_POST['amount']) ? wp_unslash($_POST['amount']) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+        $result = $this->profile->initiate_deposit($user_id, $amount_raw);
+
+        if (!empty($result['error'])) {
+            $status = isset($result['status']) ? (int) $result['status'] : 400;
+            wp_send_json_error([
+                'message' => (string) $result['error'],
+                'field'   => $result['field'] ?? '',
+            ], $status);
+        }
+
+        wp_send_json_success([
+            'message'  => (string) ($result['message'] ?? __('Recarga adicionada ao carrinho.', 'juntaplay')),
+            'redirect' => (string) ($result['redirect'] ?? wc_get_checkout_url()),
+        ]);
+    }
+
+    public function notifications_feed(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Faça login para ver suas notificações.', 'juntaplay')], 401);
+        }
+
+        $notifications = NotificationsData::get_recent($user_id, 15);
+        $items         = [];
+
+        foreach ($notifications as $notification) {
+            $items[] = [
+                'id'         => $notification['id'],
+                'title'      => $notification['title'],
+                'message'    => $notification['message'],
+                'status'     => $notification['status'],
+                'created_at' => $notification['created_at'],
+                'time'       => $this->format_datetime($notification['created_at']),
+                'action_url' => $notification['action_url'],
+            ];
+        }
+
+        wp_send_json_success([
+            'items'  => $items,
+            'unread' => NotificationsData::count_unread($user_id),
+        ]);
+    }
+
+    public function notifications_mark(): void
+    {
+        check_ajax_referer('jp_nonce', 'nonce');
+
+        $user_id = get_current_user_id();
+        if (!$user_id) {
+            wp_send_json_error(['message' => __('Sessão expirada.', 'juntaplay')], 401);
+        }
+
+        $ids = isset($_POST['ids']) ? (array) $_POST['ids'] : []; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $ids = array_map('absint', $ids);
+
+        if ($ids) {
+            NotificationsData::mark_read($user_id, $ids);
+        }
+
+        wp_send_json_success(['unread' => NotificationsData::count_unread($user_id)]);
+    }
+
+    /**
+     * @param array<string, mixed> $transaction
+     */
+    private function format_transaction(array $transaction, bool $with_context = false): array
+    {
+        $amount      = isset($transaction['amount']) ? (float) $transaction['amount'] : 0.0;
+        $created_raw = (string) ($transaction['created_at'] ?? '');
+        $context     = isset($transaction['context']) && is_array($transaction['context']) ? $transaction['context'] : [];
+
+        $amount_formatted = $this->format_currency($amount);
+
+        $formatted = [
+            'id'         => (int) ($transaction['id'] ?? 0),
+            'type'       => (string) ($transaction['type'] ?? ''),
+            'type_label' => $this->translate_transaction_type((string) ($transaction['type'] ?? '')),
+            'status'     => (string) ($transaction['status'] ?? ''),
+            'status_label' => $this->translate_transaction_status((string) ($transaction['status'] ?? '')),
+            'amount'     => $amount_formatted,
+            'amount_raw' => $amount,
+            'amount_formatted' => $amount_formatted,
+            'created_at' => $created_raw,
+            'time'       => $this->format_datetime($created_raw),
+            'reference'  => (string) ($transaction['reference'] ?? ''),
+        ];
+
+        if ($with_context) {
+            $formatted['context'] = $context;
+            $formatted['balance_after'] = isset($transaction['balance_after']) ? $this->format_currency((float) $transaction['balance_after']) : '';
+        }
+
+        return $formatted;
+    }
+
+    private function translate_transaction_type(string $type): string
+    {
+        return match ($type) {
+            CreditTransactions::TYPE_DEPOSIT => __('Entrada de créditos', 'juntaplay'),
+            CreditTransactions::TYPE_WITHDRAWAL => __('Retirada', 'juntaplay'),
+            CreditTransactions::TYPE_BONUS => __('Bônus promocional', 'juntaplay'),
+            CreditTransactions::TYPE_PURCHASE => __('Compra de cotas', 'juntaplay'),
+            CreditTransactions::TYPE_REFUND => __('Reembolso', 'juntaplay'),
+            default => __('Ajuste de saldo', 'juntaplay'),
+        };
+    }
+
+    private function translate_transaction_status(string $status): string
+    {
+        return match ($status) {
+            CreditTransactions::STATUS_PENDING => __('Pendente', 'juntaplay'),
+            CreditTransactions::STATUS_FAILED => __('Cancelado', 'juntaplay'),
+            default => __('Concluído', 'juntaplay'),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $pool
+     * @param array<string, string> $categories
+     * @return array<string, mixed>
+     */
+    private function format_pool(array $pool, array $categories): array
+    {
+        $category     = isset($pool['category']) ? (string) $pool['category'] : '';
+        $category_lbl = $category !== '' && isset($categories[$category]) ? $categories[$category] : '';
+
+        return [
+            'id'            => (int) ($pool['id'] ?? 0),
+            'title'         => (string) ($pool['title'] ?? ''),
+            'slug'          => (string) ($pool['slug'] ?? ''),
+            'excerpt'       => (string) ($pool['excerpt'] ?? ''),
+            'thumbnail'     => (string) ($pool['thumbnail'] ?? ''),
+            'is_featured'   => !empty($pool['is_featured']),
+            'category'      => $category,
+            'categoryLabel' => $category_lbl,
+            'price'         => (float) ($pool['price'] ?? 0.0),
+            'priceLabel'    => $this->format_currency((float) ($pool['price'] ?? 0.0)),
+            'quotasTotal'   => (int) ($pool['quotas_total'] ?? 0),
+            'quotasPaid'    => (int) ($pool['quotas_paid'] ?? 0),
+            'quotasFree'    => (int) ($pool['quotas_free'] ?? 0),
+            'progress'      => (int) ($pool['progress'] ?? 0),
+            'permalink'     => $this->resolve_pool_link($pool),
+        ];
+    }
+
+    private function resolve_pool_link(array $pool): string
+    {
+        $product_id = isset($pool['product_id']) ? (int) $pool['product_id'] : 0;
+
+        if ($product_id > 0) {
+            $permalink = get_permalink($product_id);
+            if ($permalink) {
+                return (string) $permalink;
+            }
+        }
+
+        $slug = isset($pool['slug']) ? (string) $pool['slug'] : '';
+        if ($slug !== '') {
+            return home_url('/campanha/' . $slug);
+        }
+
+        return home_url('/campanhas');
+    }
+
+    /**
+     * @param array<string, mixed> $group
+     * @param array<string, string> $categories
+     * @return array<string, mixed>
+     */
+    private function format_group(array $group, array $categories): array
+    {
+        $category     = isset($group['category']) ? (string) $group['category'] : '';
+        $category_lbl = $category !== '' && isset($categories[$category]) ? $categories[$category] : '';
+        $owner_id     = isset($group['owner_id']) ? (int) $group['owner_id'] : 0;
+        $price        = isset($group['effective_price']) ? (float) $group['effective_price'] : 0.0;
+
+        return [
+            'id'              => (int) ($group['id'] ?? 0),
+            'slug'            => (string) ($group['slug'] ?? ''),
+            'title'           => (string) ($group['title'] ?? ''),
+            'service'         => (string) ($group['service_name'] ?? ''),
+            'serviceUrl'      => (string) ($group['service_url'] ?? ''),
+            'category'        => $category,
+            'categoryLabel'   => $category_lbl,
+            'instantAccess'   => !empty($group['instant_access']),
+            'coverUrl'        => (string) ($group['cover_url'] ?? ''),
+            'coverAlt'        => (string) ($group['cover_alt'] ?? ''),
+            'coverPlaceholder'=> !empty($group['cover_placeholder']),
+            'price'           => $price,
+            'priceLabel'      => $this->format_currency($price),
+            'memberPrice'     => isset($group['member_price']) ? (float) $group['member_price'] : null,
+            'memberPriceLabel'=> isset($group['member_price']) && $group['member_price'] !== null
+                ? $this->format_currency((float) $group['member_price'])
+                : '',
+            'membersCount'    => (int) ($group['members_count'] ?? 0),
+            'slotsTotal'      => (int) ($group['slots_total'] ?? 0),
+            'slotsAvailable'  => (int) ($group['slots_available'] ?? 0),
+            'support'         => (string) ($group['support_channel'] ?? ''),
+            'delivery'        => (string) ($group['delivery_time'] ?? ''),
+            'accessMethod'    => (string) ($group['access_method'] ?? ''),
+            'description'     => (string) ($group['description'] ?? ''),
+            'rules'           => (string) ($group['rules'] ?? ''),
+            'ownerName'       => (string) ($group['owner_name'] ?? ''),
+            'ownerEmail'      => (string) ($group['owner_email'] ?? ''),
+            'ownerAvatar'     => $owner_id > 0 ? (string) get_avatar_url($owner_id, ['size' => 96]) : '',
+            'permalink'       => $this->resolve_group_link($group),
+            'created'         => $this->format_datetime((string) ($group['created_at'] ?? '')),
+            'updated'         => $this->format_datetime((string) ($group['updated_at'] ?? '')),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $group
+     */
+    private function resolve_group_link(array $group): string
+    {
+        $page_id = (int) get_option('juntaplay_page_grupos');
+        $base    = $page_id ? get_permalink($page_id) : home_url('/grupos');
+
+        if (!$base) {
+            $base = home_url('/grupos');
+        }
+
+        $slug = isset($group['slug']) ? (string) $group['slug'] : '';
+
+        if ($slug === '') {
+            return $base;
+        }
+
+        return add_query_arg('grupo', rawurlencode($slug), $base);
+    }
+
+    private function format_currency(float $amount): string
+    {
+        if (function_exists('wc_price')) {
+            return wp_strip_all_tags((string) wc_price($amount));
+        }
+
+        return 'R$ ' . number_format_i18n($amount, 2);
+    }
+
+    private function format_datetime(string $datetime): string
+    {
+        if ($datetime === '') {
+            return '';
+        }
+
+        $timestamp = mysql2date('U', $datetime, false);
+
+        if (!$timestamp) {
+            return $datetime;
+        }
+
+        return wp_date(__('d/m/Y \à\s H\hi', 'juntaplay'), $timestamp);
+    }
+}

--- a/juntaplay/includes/Front/Auth.php
+++ b/juntaplay/includes/Front/Auth.php
@@ -1,0 +1,1163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JuntaPlay\Front;
+
+use WP_Error;
+use WP_User;
+use JuntaPlay\Admin\Settings;
+
+use function __;
+use function add_action;
+use function add_filter;
+use function apply_filters;
+use function add_query_arg;
+use function delete_transient;
+use function delete_user_meta;
+use function email_exists;
+use function get_option;
+use function get_permalink;
+use function get_transient;
+use function get_user_by;
+use function get_user_meta;
+use function get_bloginfo;
+use function home_url;
+use function implode;
+use function is_email;
+use function is_user_logged_in;
+use function is_wp_error;
+use function sanitize_email;
+use function sanitize_key;
+use function sanitize_text_field;
+use function sanitize_textarea_field;
+use function sanitize_user;
+use function set_transient;
+use function username_exists;
+use function update_user_meta;
+use function wp_authenticate_username_password;
+use function wp_check_password;
+use function wp_create_user;
+use function wp_generate_password;
+use function wp_generate_uuid4;
+use function wp_hash_password;
+use function wp_json_decode;
+use function wp_logout;
+use function wp_mail;
+use function preg_replace;
+use function strlen;
+use function substr;
+use function str_repeat;
+use function trim;
+use function wp_remote_get;
+use function wp_remote_post;
+use function wp_remote_retrieve_body;
+use function wp_login_url;
+use function wp_safe_redirect;
+use function wp_set_auth_cookie;
+use function wp_set_current_user;
+use function wp_signon;
+use function wp_unslash;
+use function wp_update_user;
+use function wp_verify_nonce;
+use function wp_validate_redirect;
+use function wp_rand;
+use function do_action;
+use function rawurlencode;
+use function remove_query_arg;
+use function esc_url;
+use function esc_url_raw;
+use function time;
+use function explode;
+use function _n;
+use function max;
+use function min;
+use const MINUTE_IN_SECONDS;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Auth
+{
+    /** @var string[] */
+    private array $login_errors = [];
+
+    /** @var string[] */
+    private array $register_errors = [];
+
+    /** @var string[] */
+    private array $two_factor_errors = [];
+
+    /** @var array<string, mixed>|null */
+    private ?array $two_factor_context = null;
+
+    /**
+     * Active view (login|register)
+     */
+    private string $active_view = 'login';
+
+    private const TWO_FACTOR_TRANSIENT_PREFIX = 'juntaplay_2fa_';
+    private const SOCIAL_TRANSIENT_PREFIX     = 'juntaplay_social_';
+
+    /**
+     * Initialize hooks.
+     */
+    public function init(): void
+    {
+        add_action('init', [$this, 'detect_view']);
+        add_action('init', [$this, 'maybe_handle_register']);
+        add_action('init', [$this, 'maybe_handle_login']);
+        add_action('init', [$this, 'maybe_handle_two_factor']);
+        add_action('init', [$this, 'maybe_handle_social_login']);
+        add_filter('juntaplay/login/providers', [$this, 'filter_social_providers']);
+    }
+
+    /**
+     * Attempt to authenticate when the login form is submitted.
+     */
+    public function maybe_handle_login(): void
+    {
+        if (!isset($_POST['jp_login_action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        $this->active_view = 'login';
+
+        if (is_user_logged_in()) {
+            $redirect = $this->get_redirect_url();
+            if ($redirect) {
+                wp_safe_redirect($redirect);
+                exit;
+            }
+            return;
+        }
+
+        if (!isset($_POST['jp_login_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['jp_login_nonce'])), 'juntaplay_login')) { // phpcs:ignore WordPress.Security.NonceVerification
+            $this->login_errors[] = __('Sua sessão expirou. Atualize a página e tente novamente.', 'juntaplay');
+            return;
+        }
+
+        $username = '';
+        $password = '';
+        $remember = false;
+
+        if (isset($_POST['jp_login_username'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            $username = sanitize_text_field(wp_unslash($_POST['jp_login_username'])); // phpcs:ignore WordPress.Security.NonceVerification
+        }
+
+        if (isset($_POST['jp_login_password'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            $password = wp_unslash($_POST['jp_login_password']); // phpcs:ignore WordPress.Security.NonceVerification
+        }
+
+        if (isset($_POST['jp_login_remember'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            $remember = (bool) sanitize_text_field(wp_unslash($_POST['jp_login_remember'])); // phpcs:ignore WordPress.Security.NonceVerification
+        }
+
+        if ($username === '' || $password === '') {
+            $this->login_errors[] = __('Informe e-mail/usuário e senha para continuar.', 'juntaplay');
+            return;
+        }
+
+        $user = wp_authenticate_username_password(null, $username, $password);
+
+        if ($user instanceof WP_Error) {
+            $this->login_errors[] = $user->get_error_message();
+            return;
+        }
+
+        if (!($user instanceof WP_User)) {
+            $this->login_errors[] = __('Não foi possível autenticar no momento. Tente novamente.', 'juntaplay');
+            return;
+        }
+
+        $redirect = $this->get_redirect_url();
+        if (!$redirect) {
+            $redirect = $this->get_default_redirect();
+        }
+
+        if ($this->should_require_two_factor($user)) {
+            $challenge = $this->start_two_factor_challenge($user, $remember, $redirect);
+
+            if (!$challenge) {
+                $this->login_errors[] = __('Não foi possível gerar o código de verificação. Tente novamente.', 'juntaplay');
+                return;
+            }
+
+            wp_safe_redirect($this->build_two_factor_url($challenge));
+            exit;
+        }
+
+        $signon = wp_signon(
+            [
+                'user_login'    => $username,
+                'user_password' => $password,
+                'remember'      => $remember,
+            ],
+            false
+        );
+
+        if ($signon instanceof WP_Error) {
+            $this->login_errors[] = $signon->get_error_message();
+            return;
+        }
+
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    public function maybe_handle_two_factor(): void
+    {
+        $challenge = '';
+
+        if (isset($_GET['challenge'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $challenge = sanitize_text_field(wp_unslash($_GET['challenge'])); // phpcs:ignore WordPress.Security.NonceVerification
+            $this->load_two_factor_context($challenge);
+        }
+
+        if (!isset($_POST['jp_two_factor_action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        $action = sanitize_key(wp_unslash($_POST['jp_two_factor_action'])); // phpcs:ignore WordPress.Security.NonceVerification
+        if (isset($_POST['jp_two_factor_challenge'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            $challenge = sanitize_text_field(wp_unslash($_POST['jp_two_factor_challenge'])); // phpcs:ignore WordPress.Security.NonceVerification
+        }
+
+        if (!isset($_POST['jp_two_factor_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['jp_two_factor_nonce'])), 'juntaplay_two_factor')) { // phpcs:ignore WordPress.Security.NonceVerification
+            $this->two_factor_errors[] = __('Sua sessão expirou. Faça login novamente.', 'juntaplay');
+            return;
+        }
+
+        if ($action === 'resend') {
+            $this->handle_two_factor_resend($challenge);
+
+            return;
+        }
+
+        $code = isset($_POST['jp_two_factor_code'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_two_factor_code'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $this->handle_two_factor_verify($challenge, $code);
+    }
+
+    /**
+     * Return any captured errors.
+     *
+     * @return string[]
+     */
+    public function get_login_errors(): array
+    {
+        return $this->login_errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function get_two_factor_errors(): array
+    {
+        return $this->two_factor_errors;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_two_factor_context(): array
+    {
+        return $this->two_factor_context ?? [];
+    }
+
+    /**
+     * Retrieve register errors.
+     *
+     * @return string[]
+     */
+    public function get_register_errors(): array
+    {
+        return $this->register_errors;
+    }
+
+    /**
+     * Current active view for the auth screen.
+     */
+    public function get_active_view(): string
+    {
+        return $this->active_view;
+    }
+
+    /**
+     * Retrieve the redirect destination from the request.
+     */
+    public function get_redirect_url(): string
+    {
+        $redirect = isset($_REQUEST['redirect_to']) ? wp_unslash($_REQUEST['redirect_to']) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $validated = wp_validate_redirect($redirect, '');
+
+        return is_string($validated) ? $validated : '';
+    }
+
+    /**
+     * Capture the initial desired view (login/register) from the request.
+     */
+    public function detect_view(): void
+    {
+        $view = '';
+
+        if (isset($_REQUEST['jp_auth_view'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $view = sanitize_key(wp_unslash($_REQUEST['jp_auth_view'])); // phpcs:ignore WordPress.Security.NonceVerification
+        } elseif (isset($_GET['action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $view = sanitize_key(wp_unslash($_GET['action'])); // phpcs:ignore WordPress.Security.NonceVerification
+        }
+
+        if ($view === 'register') {
+            $this->active_view = 'register';
+        }
+
+        if (isset($_GET['jp_social_error'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $message = sanitize_textarea_field(wp_unslash($_GET['jp_social_error'])); // phpcs:ignore WordPress.Security.NonceVerification
+            if ($message !== '') {
+                $this->login_errors[] = $message;
+                $this->active_view    = 'login';
+            }
+        }
+    }
+
+    /**
+     * Handle customer registration when the form is submitted.
+     */
+    public function maybe_handle_register(): void
+    {
+        if (!isset($_POST['jp_register_action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        $this->active_view = 'register';
+
+        if (!get_option('users_can_register')) {
+            $this->register_errors[] = __('No momento não é possível criar novas contas.', 'juntaplay');
+            return;
+        }
+
+        if (!isset($_POST['jp_register_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['jp_register_nonce'])), 'juntaplay_register')) { // phpcs:ignore WordPress.Security.NonceVerification
+            $this->register_errors[] = __('Sua sessão expirou. Atualize a página e tente novamente.', 'juntaplay');
+            return;
+        }
+
+        $name      = isset($_POST['jp_register_name']) ? sanitize_text_field(wp_unslash($_POST['jp_register_name'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $email     = isset($_POST['jp_register_email']) ? sanitize_email(wp_unslash($_POST['jp_register_email'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $password  = isset($_POST['jp_register_password']) ? (string) wp_unslash($_POST['jp_register_password']) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $confirm   = isset($_POST['jp_register_password_confirm']) ? (string) wp_unslash($_POST['jp_register_password_confirm']) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $accept    = isset($_POST['jp_register_accept']) ? (bool) sanitize_text_field(wp_unslash($_POST['jp_register_accept'])) : false; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+        $redirect  = $this->get_redirect_url();
+
+        if ($name === '') {
+            $this->register_errors[] = __('Informe seu nome completo.', 'juntaplay');
+        }
+
+        if ($email === '' || !is_email($email)) {
+            $this->register_errors[] = __('Informe um e-mail válido.', 'juntaplay');
+        }
+
+        if ($email && email_exists($email)) {
+            $this->register_errors[] = __('Este e-mail já está cadastrado. Faça login ou utilize a recuperação de senha.', 'juntaplay');
+        }
+
+        if ($password === '' || strlen($password) < 6) {
+            $this->register_errors[] = __('Defina uma senha com pelo menos 6 caracteres.', 'juntaplay');
+        }
+
+        if ($password !== $confirm) {
+            $this->register_errors[] = __('As senhas informadas não coincidem.', 'juntaplay');
+        }
+
+        $acceptance_required = (bool) apply_filters('juntaplay/register/require_accept', true);
+        if ($acceptance_required && !$accept) {
+            $this->register_errors[] = __('Confirme que leu e aceita os termos para continuar.', 'juntaplay');
+        }
+
+        if (!empty($this->register_errors)) {
+            return;
+        }
+
+        $username = sanitize_user(current(explode('@', $email)), true);
+        if ($username === '') {
+            $username = sanitize_user($email, true);
+        }
+
+        $original_username = $username;
+        $suffix            = 1;
+
+        while (username_exists($username)) {
+            $username = $original_username . $suffix;
+            $suffix++;
+        }
+
+        $user_id = wp_create_user($username, $password, $email);
+
+        if ($user_id instanceof WP_Error) {
+            $this->register_errors[] = $user_id->get_error_message();
+            return;
+        }
+
+        $updated = wp_update_user([
+            'ID'           => $user_id,
+            'display_name' => $name,
+            'first_name'   => $name,
+        ]);
+
+        if ($updated instanceof WP_Error) {
+            $this->register_errors[] = $updated->get_error_message();
+            return;
+        }
+
+        do_action('juntaplay/register/success', $user_id);
+
+        $signon = wp_signon([
+            'user_login'    => $username,
+            'user_password' => $password,
+            'remember'      => true,
+        ], false);
+
+        if ($signon instanceof WP_Error) {
+            $this->login_errors[] = $signon->get_error_message();
+            $this->active_view    = 'login';
+            return;
+        }
+
+        if (!$redirect) {
+            $redirect = $this->get_default_redirect();
+        }
+
+        wp_safe_redirect($redirect);
+        exit;
+    }
+
+    private function should_require_two_factor(WP_User $user): bool
+    {
+        $method = $this->get_two_factor_method($user);
+
+        if (!in_array($method, ['email', 'whatsapp'], true)) {
+            return false;
+        }
+
+        return (bool) apply_filters('juntaplay/login/require_two_factor', true, $user, $method);
+    }
+
+    private function get_two_factor_method(WP_User $user): string
+    {
+        $method = (string) get_user_meta($user->ID, 'juntaplay_two_factor_method', true);
+
+        if (!in_array($method, ['email', 'whatsapp'], true)) {
+            $method = 'email';
+        }
+
+        return $method;
+    }
+
+    private function start_two_factor_challenge(WP_User $user, bool $remember, string $redirect, ?string $existing = null): ?string
+    {
+        $method      = $this->get_two_factor_method($user);
+        $destination = $this->resolve_two_factor_destination($user, $method);
+
+        if ($destination['display'] === '' && $destination['email'] === '') {
+            $this->two_factor_errors[] = __('Configure um e-mail ou telefone válido para receber o código de verificação.', 'juntaplay');
+
+            return null;
+        }
+
+        $code    = (string) wp_rand(100000, 999999);
+        $hash    = wp_hash_password($code);
+        $expires = time() + (int) apply_filters('juntaplay/two_factor/expiration', MINUTE_IN_SECONDS * 10, $user);
+
+        update_user_meta($user->ID, 'juntaplay_two_factor_login_hash', $hash);
+        update_user_meta($user->ID, 'juntaplay_two_factor_login_expires', $expires);
+        update_user_meta($user->ID, 'juntaplay_two_factor_login_attempts', 0);
+
+        $challenge = $existing ?: wp_generate_uuid4();
+
+        $state = [
+            'user_id'     => $user->ID,
+            'remember'    => $remember,
+            'redirect'    => $this->sanitize_redirect($redirect),
+            'method'      => $method,
+            'destination' => $destination['display'],
+            'target'      => $destination['target'],
+            'email'       => $destination['email'],
+            'issued_at'   => time(),
+            'expires'     => $expires,
+        ];
+
+        if (!$this->deliver_two_factor_code($user, $method, $code, $state)) {
+            $this->two_factor_errors[] = __('Não foi possível enviar o código de verificação agora. Tente novamente em instantes.', 'juntaplay');
+            delete_user_meta($user->ID, 'juntaplay_two_factor_login_hash');
+            delete_user_meta($user->ID, 'juntaplay_two_factor_login_expires');
+            delete_user_meta($user->ID, 'juntaplay_two_factor_login_attempts');
+
+            return null;
+        }
+
+        set_transient(self::TWO_FACTOR_TRANSIENT_PREFIX . $challenge, $state, MINUTE_IN_SECONDS * 10);
+        $this->assign_two_factor_context($state, $challenge);
+
+        return $challenge;
+    }
+
+    private function build_two_factor_url(string $challenge): string
+    {
+        $page_id = (int) get_option('juntaplay_page_verificar-acesso');
+        $base    = $page_id ? get_permalink($page_id) : home_url('/verificar-acesso');
+
+        if (!$base) {
+            $base = home_url('/verificar-acesso');
+        }
+
+        return add_query_arg('challenge', rawurlencode($challenge), $base);
+    }
+
+    private function load_two_factor_context(string $challenge): void
+    {
+        $state = $this->get_two_factor_state($challenge);
+
+        if (!$state) {
+            $this->two_factor_context = null;
+
+            return;
+        }
+
+        $this->assign_two_factor_context($state, $challenge);
+    }
+
+    private function handle_two_factor_resend(string $challenge): void
+    {
+        $state = $this->get_two_factor_state($challenge);
+
+        if (!$state) {
+            $this->two_factor_errors[] = __('Sua sessão de verificação expirou. Faça login novamente.', 'juntaplay');
+
+            return;
+        }
+
+        $user = get_user_by('id', (int) $state['user_id']);
+        if (!$user instanceof WP_User) {
+            $this->two_factor_errors[] = __('Não foi possível identificar sua conta. Faça login novamente.', 'juntaplay');
+
+            return;
+        }
+
+        $challenge = $this->start_two_factor_challenge($user, !empty($state['remember']), (string) ($state['redirect'] ?? ''), $challenge);
+
+        if ($challenge) {
+            $context               = $this->two_factor_context ?? [];
+            $context['resent']     = true;
+            $this->two_factor_context = $context;
+        }
+    }
+
+    private function handle_two_factor_verify(string $challenge, string $code): void
+    {
+        $state = $this->get_two_factor_state($challenge);
+
+        if (!$state) {
+            $this->two_factor_errors[] = __('Sua sessão de verificação expirou. Faça login novamente.', 'juntaplay');
+
+            return;
+        }
+
+        $user = get_user_by('id', (int) $state['user_id']);
+        if (!$user instanceof WP_User) {
+            $this->two_factor_errors[] = __('Não foi possível identificar sua conta. Faça login novamente.', 'juntaplay');
+
+            return;
+        }
+
+        $clean_code = preg_replace('/\D+/', '', $code);
+        if ($clean_code === '' || strlen($clean_code) < 4) {
+            $this->two_factor_errors[] = __('Informe o código recebido para continuar.', 'juntaplay');
+            $this->assign_two_factor_context($state, $challenge);
+
+            return;
+        }
+
+        $hash     = (string) get_user_meta($user->ID, 'juntaplay_two_factor_login_hash', true);
+        $expires  = (int) get_user_meta($user->ID, 'juntaplay_two_factor_login_expires', true);
+        $attempts = (int) get_user_meta($user->ID, 'juntaplay_two_factor_login_attempts', true);
+
+        if ($hash === '' || $expires <= time()) {
+            $this->two_factor_errors[] = __('Este código expirou. Solicitamos um novo automaticamente.', 'juntaplay');
+            $this->handle_two_factor_resend($challenge);
+
+            return;
+        }
+
+        if (!wp_check_password($clean_code, $hash)) {
+            ++$attempts;
+            update_user_meta($user->ID, 'juntaplay_two_factor_login_attempts', $attempts);
+
+            $this->two_factor_errors[] = __('Código inválido. Verifique e tente novamente.', 'juntaplay');
+            $this->assign_two_factor_context($state, $challenge, ['attempts' => $attempts]);
+
+            return;
+        }
+
+        delete_user_meta($user->ID, 'juntaplay_two_factor_login_hash');
+        delete_user_meta($user->ID, 'juntaplay_two_factor_login_expires');
+        delete_user_meta($user->ID, 'juntaplay_two_factor_login_attempts');
+        delete_transient(self::TWO_FACTOR_TRANSIENT_PREFIX . $challenge);
+
+        wp_set_current_user($user->ID);
+        wp_set_auth_cookie($user->ID, !empty($state['remember']));
+        do_action('wp_login', $user->user_login, $user);
+
+        $redirect = isset($state['redirect']) ? (string) $state['redirect'] : $this->get_default_redirect();
+        wp_safe_redirect($this->sanitize_redirect($redirect));
+        exit;
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     */
+    private function deliver_two_factor_code(WP_User $user, string $method, string $code, array $state): bool
+    {
+        $minutes   = (int) apply_filters('juntaplay/two_factor/expiration_minutes', 10, $user);
+        $site_name = get_bloginfo('name');
+        $destination_label = $state['destination'] !== '' ? $state['destination'] : __('seu contato cadastrado', 'juntaplay');
+        $email     = $state['email'] !== '' ? (string) $state['email'] : (string) $user->user_email;
+
+        $lines = [
+            sprintf(__('Use o código %1$s para confirmar seu acesso ao %2$s.', 'juntaplay'), $code, $site_name),
+            sprintf(_n('Ele expira em %d minuto.', 'Ele expira em %d minutos.', $minutes, 'juntaplay'), $minutes),
+            sprintf(__('Enviamos para: %s', 'juntaplay'), $destination_label),
+            '',
+            __('Se não foi você, ignore esta mensagem.', 'juntaplay'),
+        ];
+
+        $subject = sprintf(__('Código de verificação — %s', 'juntaplay'), $site_name);
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+
+        $sent = true;
+        if ($email !== '') {
+            $sent = wp_mail($email, $subject, trim(implode("\n", $lines)), $headers);
+        }
+
+        if ($method === 'whatsapp') {
+            do_action('juntaplay/two_factor/whatsapp', $user->ID, $code, $state);
+        }
+
+        return (bool) $sent;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function get_two_factor_state(string $challenge): ?array
+    {
+        if ($challenge === '') {
+            return null;
+        }
+
+        $state = get_transient(self::TWO_FACTOR_TRANSIENT_PREFIX . $challenge);
+
+        if (!is_array($state) || empty($state['user_id'])) {
+            return null;
+        }
+
+        return $state;
+    }
+
+    /**
+     * @param array<string, mixed> $state
+     */
+    private function assign_two_factor_context(array $state, string $challenge, array $extra = []): void
+    {
+        $context            = array_merge($state, $extra);
+        $context['challenge'] = $challenge;
+        unset($context['target'], $context['email'], $context['user_id']);
+        $this->two_factor_context = $context;
+    }
+
+    /**
+     * @return array{display: string, target: string, email: string}
+     */
+    private function resolve_two_factor_destination(WP_User $user, string $method): array
+    {
+        $email  = (string) $user->user_email;
+        $target = '';
+        $display = '';
+
+        if ($method === 'whatsapp') {
+            $phone = (string) get_user_meta($user->ID, 'juntaplay_whatsapp', true);
+            if ($phone === '') {
+                $phone = (string) get_user_meta($user->ID, 'billing_phone', true);
+            }
+
+            if ($phone !== '') {
+                $target  = $phone;
+                $display = $this->mask_phone($phone);
+            }
+        }
+
+        if ($display === '' && $email !== '') {
+            $display = $this->mask_email($email);
+        }
+
+        return [
+            'display' => $display,
+            'target'  => $target,
+            'email'   => $email,
+        ];
+    }
+
+    private function mask_email(string $email): string
+    {
+        if (!is_email($email)) {
+            return $email;
+        }
+
+        [$user_part, $domain] = explode('@', $email, 2);
+        $user_part = trim($user_part);
+
+        if ($user_part === '') {
+            return $email;
+        }
+
+        $visible = substr($user_part, 0, min(2, strlen($user_part)));
+        $mask    = str_repeat('•', max(1, strlen($user_part) - strlen($visible)));
+
+        return $visible . $mask . '@' . $domain;
+    }
+
+    private function mask_phone(string $phone): string
+    {
+        $digits = preg_replace('/\D+/', '', $phone);
+
+        if ($digits === '') {
+            return $phone;
+        }
+
+        $length = strlen($digits);
+        $prefix = substr($digits, 0, min(2, $length - 4));
+        $suffix = substr($digits, -4);
+        $mask   = str_repeat('•', max(0, $length - strlen($prefix) - strlen($suffix)));
+
+        return $prefix . $mask . $suffix;
+    }
+
+    private function sanitize_redirect(string $redirect): string
+    {
+        $validated = wp_validate_redirect($redirect, $this->get_default_redirect());
+
+        return is_string($validated) ? $validated : $this->get_default_redirect();
+    }
+
+    public function maybe_handle_social_login(): void
+    {
+        if (!isset($_GET['juntaplay_social'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            return;
+        }
+
+        $provider = sanitize_key(wp_unslash($_GET['juntaplay_social'])); // phpcs:ignore WordPress.Security.NonceVerification
+
+        if ($provider === '' || is_user_logged_in()) {
+            return;
+        }
+
+        if (!$this->is_social_enabled($provider)) {
+            $this->redirect_with_error(__('Login social indisponível no momento.', 'juntaplay'));
+        }
+
+        if (isset($_GET['callback'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $this->handle_social_callback($provider);
+
+            return;
+        }
+
+        $redirect = $this->get_redirect_url();
+        if (!$redirect) {
+            $redirect = $this->get_default_redirect();
+        }
+
+        $this->start_social_flow($provider, $redirect, false);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $providers
+     * @return array<int, array<string, mixed>>
+     */
+    public function filter_social_providers(array $providers): array
+    {
+        $output = [];
+
+        foreach ($providers as $provider) {
+            $key = isset($provider['key']) ? sanitize_key((string) $provider['key']) : '';
+
+            if ($key === '' || !$this->is_social_enabled($key)) {
+                continue;
+            }
+
+            $provider['href'] = esc_url($this->get_social_login_url($key));
+            $output[]         = $provider;
+        }
+
+        return $output;
+    }
+
+    private function start_social_flow(string $provider, string $redirect, bool $remember): void
+    {
+        $settings = $this->get_provider_settings($provider);
+
+        if (empty($settings['client_id']) || empty($settings['client_secret'])) {
+            $this->redirect_with_error(__('Configuração do provedor ausente. Informe as credenciais no painel.', 'juntaplay'));
+        }
+
+        $callback = $this->get_social_callback_url($provider);
+        $state    = wp_generate_uuid4();
+
+        set_transient(self::SOCIAL_TRANSIENT_PREFIX . $state, [
+            'provider' => $provider,
+            'redirect' => $this->sanitize_redirect($redirect),
+            'remember' => $remember,
+        ], MINUTE_IN_SECONDS * 10);
+
+        $authorize = $this->build_social_authorize_url($provider, $settings, $callback, $state);
+
+        if ($authorize === '') {
+            $this->redirect_with_error(__('Não foi possível iniciar o login social.', 'juntaplay'));
+        }
+
+        wp_safe_redirect($authorize);
+        exit;
+    }
+
+    private function handle_social_callback(string $provider): void
+    {
+        $state_key = isset($_GET['state']) ? sanitize_text_field(wp_unslash($_GET['state'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+        if ($state_key === '') {
+            $this->redirect_with_error(__('Sua sessão expirou. Tente novamente.', 'juntaplay'));
+        }
+
+        $state = get_transient(self::SOCIAL_TRANSIENT_PREFIX . $state_key);
+        delete_transient(self::SOCIAL_TRANSIENT_PREFIX . $state_key);
+
+        if (!is_array($state) || ($state['provider'] ?? '') !== $provider) {
+            $this->redirect_with_error(__('Solicitação inválida. Tente novamente.', 'juntaplay'));
+        }
+
+        if (isset($_GET['error'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $reason = isset($_GET['error_description']) ? sanitize_text_field(wp_unslash($_GET['error_description'])) : sanitize_text_field(wp_unslash($_GET['error'])); // phpcs:ignore WordPress.Security.NonceVerification
+            $this->redirect_with_error($reason !== '' ? $reason : __('Autorização cancelada pelo provedor.', 'juntaplay'));
+        }
+
+        $code = isset($_GET['code']) ? sanitize_text_field(wp_unslash($_GET['code'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+        if ($code === '') {
+            $this->redirect_with_error(__('Não recebemos o código de autorização. Tente novamente.', 'juntaplay'));
+        }
+
+        $settings = $this->get_provider_settings($provider);
+        $callback = $this->get_social_callback_url($provider);
+        $token    = $this->exchange_social_token($provider, $settings, $code, $callback);
+
+        if (!$token) {
+            $this->redirect_with_error(__('Não foi possível validar o token de acesso.', 'juntaplay'));
+        }
+
+        $profile = $this->fetch_social_profile($provider, $settings, $token);
+
+        if (!$profile) {
+            $this->redirect_with_error(__('Não conseguimos obter seus dados de perfil.', 'juntaplay'));
+        }
+
+        $redirect = isset($state['redirect']) ? (string) $state['redirect'] : $this->get_default_redirect();
+        $remember = !empty($state['remember']);
+
+        $this->complete_social_login($provider, $profile, $redirect, $remember);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     */
+    private function complete_social_login(string $provider, array $profile, string $redirect, bool $remember): void
+    {
+        $email = isset($profile['email']) ? sanitize_email((string) $profile['email']) : '';
+
+        if ($email === '') {
+            $this->redirect_with_error(__('Não recebemos seu e-mail do provedor. Verifique as permissões e tente novamente.', 'juntaplay'));
+        }
+
+        $user = get_user_by('email', $email);
+
+        if (!$user) {
+            $login    = sanitize_user(current(explode('@', $email)), true);
+            $original = $login !== '' ? $login : sanitize_user($email, true);
+
+            if ($original === '') {
+                $original = 'user';
+            }
+
+            $suffix = 1;
+            $login  = $original;
+
+            while (username_exists($login)) {
+                $login = $original . $suffix;
+                ++$suffix;
+            }
+
+            $user_id = wp_create_user($login, wp_generate_password(20, true), $email);
+
+            if ($user_id instanceof WP_Error) {
+                $this->redirect_with_error($user_id->get_error_message());
+            }
+
+            $display = isset($profile['name']) ? trim((string) $profile['name']) : '';
+            if ($display !== '') {
+                wp_update_user([
+                    'ID'           => (int) $user_id,
+                    'display_name' => $display,
+                    'first_name'   => $display,
+                ]);
+            }
+
+            $user = get_user_by('id', (int) $user_id);
+        }
+
+        if (!$user instanceof WP_User) {
+            $this->redirect_with_error(__('Não foi possível concluir o login. Tente novamente.', 'juntaplay'));
+        }
+
+        $meta_key = 'juntaplay_social_' . $provider . '_id';
+        if (!empty($profile['id'])) {
+            update_user_meta($user->ID, $meta_key, (string) $profile['id']);
+        }
+
+        if (!empty($profile['avatar'])) {
+            update_user_meta($user->ID, 'juntaplay_social_' . $provider . '_avatar', esc_url_raw((string) $profile['avatar']));
+        }
+
+        wp_set_current_user($user->ID);
+        wp_set_auth_cookie($user->ID, $remember);
+        do_action('wp_login', $user->user_login, $user);
+
+        wp_safe_redirect($this->sanitize_redirect($redirect));
+        exit;
+    }
+
+    private function get_social_login_url(string $provider): string
+    {
+        $base = add_query_arg('juntaplay_social', $provider, $this->get_login_page_url());
+
+        if (isset($_REQUEST['redirect_to'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $redirect = sanitize_text_field(wp_unslash($_REQUEST['redirect_to'])); // phpcs:ignore WordPress.Security.NonceVerification
+            $base     = add_query_arg('redirect_to', rawurlencode($redirect), $base);
+        }
+
+        return $base;
+    }
+
+    private function get_social_callback_url(string $provider): string
+    {
+        return add_query_arg([
+            'juntaplay_social' => $provider,
+            'callback'         => '1',
+        ], home_url('/'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function get_social_settings(): array
+    {
+        $settings = get_option(Settings::OPTION_SOCIAL, []);
+
+        return is_array($settings) ? $settings : [];
+    }
+
+    private function is_social_enabled(string $provider): bool
+    {
+        $settings = $this->get_provider_settings($provider);
+
+        return !empty($settings['enabled']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function get_provider_settings(string $provider): array
+    {
+        $settings = $this->get_social_settings();
+
+        return isset($settings[$provider]) && is_array($settings[$provider]) ? $settings[$provider] : [];
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function build_social_authorize_url(string $provider, array $settings, string $callback, string $state): string
+    {
+        $client_id = isset($settings['client_id']) ? (string) $settings['client_id'] : '';
+
+        if ($client_id === '') {
+            return '';
+        }
+
+        if ($provider === 'google') {
+            $scopes = rawurlencode('openid email profile');
+
+            return sprintf(
+                'https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=%1$s&redirect_uri=%2$s&scope=%3$s&state=%4$s&prompt=select_account',
+                rawurlencode($client_id),
+                rawurlencode($callback),
+                $scopes,
+                rawurlencode($state)
+            );
+        }
+
+        if ($provider === 'facebook') {
+            return sprintf(
+                'https://www.facebook.com/v16.0/dialog/oauth?client_id=%1$s&redirect_uri=%2$s&state=%3$s&scope=email',
+                rawurlencode($client_id),
+                rawurlencode($callback),
+                rawurlencode($state)
+            );
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @return array<string, mixed>|null
+     */
+    private function exchange_social_token(string $provider, array $settings, string $code, string $callback): ?array
+    {
+        $client_id     = isset($settings['client_id']) ? (string) $settings['client_id'] : '';
+        $client_secret = isset($settings['client_secret']) ? (string) $settings['client_secret'] : '';
+
+        if ($client_id === '' || $client_secret === '') {
+            return null;
+        }
+
+        if ($provider === 'google') {
+            $response = wp_remote_post('https://oauth2.googleapis.com/token', [
+                'timeout' => 15,
+                'body'    => [
+                    'code'          => $code,
+                    'client_id'     => $client_id,
+                    'client_secret' => $client_secret,
+                    'redirect_uri'  => $callback,
+                    'grant_type'    => 'authorization_code',
+                ],
+            ]);
+        } else {
+            $response = wp_remote_get(add_query_arg([
+                'client_id'     => $client_id,
+                'client_secret' => $client_secret,
+                'redirect_uri'  => $callback,
+                'code'          => $code,
+            ], 'https://graph.facebook.com/v16.0/oauth/access_token'), [
+                'timeout' => 15,
+            ]);
+        }
+
+        if (is_wp_error($response)) {
+            return null;
+        }
+
+        $data = wp_json_decode((string) wp_remote_retrieve_body($response), true);
+
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $token
+     * @return array<string, mixed>|null
+     */
+    private function fetch_social_profile(string $provider, array $settings, array $token): ?array
+    {
+        $access_token = isset($token['access_token']) ? (string) $token['access_token'] : '';
+
+        if ($access_token === '') {
+            return null;
+        }
+
+        if ($provider === 'google') {
+            $response = wp_remote_get('https://www.googleapis.com/oauth2/v3/userinfo', [
+                'timeout' => 15,
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $access_token,
+                ],
+            ]);
+        } else {
+            $url      = add_query_arg([
+                'fields'       => 'id,name,email,picture.type(large)',
+                'access_token' => $access_token,
+            ], 'https://graph.facebook.com/me');
+            $response = wp_remote_get($url, [
+                'timeout' => 15,
+            ]);
+        }
+
+        if (is_wp_error($response)) {
+            return null;
+        }
+
+        $data = wp_json_decode((string) wp_remote_retrieve_body($response), true);
+
+        if (!is_array($data)) {
+            return null;
+        }
+
+        if ($provider === 'facebook' && isset($data['picture']['data']['url'])) {
+            $data['avatar'] = $data['picture']['data']['url'];
+        }
+
+        return $data;
+    }
+
+    private function redirect_with_error(string $message): void
+    {
+        $login_url = add_query_arg('jp_social_error', rawurlencode($message), $this->get_login_page_url());
+        wp_safe_redirect($login_url);
+        exit;
+    }
+
+    private function get_login_page_url(): string
+    {
+        $login_page_id = (int) get_option('juntaplay_page_entrar');
+        $login_url     = $login_page_id ? get_permalink($login_page_id) : '';
+
+        if ($login_url) {
+            return $login_url;
+        }
+
+        $login_url = wp_login_url();
+
+        return $login_url ?: home_url('/entrar');
+    }
+
+    /**
+     * Determine the default redirect destination after login/register.
+     */
+    public function get_default_redirect(): string
+    {
+        $dashboard_id = (int) get_option('juntaplay_page_painel');
+        if ($dashboard_id) {
+            $dashboard = get_permalink($dashboard_id);
+            if ($dashboard) {
+                return $dashboard;
+            }
+        }
+
+        $my_quotas_id = (int) get_option('juntaplay_page_minhas-cotas');
+        if ($my_quotas_id) {
+            $my_quotas = get_permalink($my_quotas_id);
+            if ($my_quotas) {
+                return $my_quotas;
+            }
+        }
+
+        return home_url('/');
+    }
+}

--- a/juntaplay/includes/Front/Profile.php
+++ b/juntaplay/includes/Front/Profile.php
@@ -1,0 +1,3813 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JuntaPlay\Front;
+
+use JuntaPlay\Data\CreditTransactions;
+use JuntaPlay\Data\CreditWithdrawals;
+use JuntaPlay\Data\GroupComplaints;
+use JuntaPlay\Data\GroupMembers;
+use JuntaPlay\Data\Groups;
+use JuntaPlay\Data\Pools;
+use JuntaPlay\Woo\Credits as WooCredits;
+use WP_Error;
+use WP_User;
+
+use WP_Session_Tokens;
+use function __;
+use function _n;
+use function add_action;
+use function add_query_arg;
+use function absint;
+use function apply_filters;
+use function do_action;
+use function esc_url_raw;
+use function email_exists;
+use function in_array;
+use function current_time;
+use function date_i18n;
+use function delete_user_meta;
+use function get_current_user_id;
+use function get_bloginfo;
+use function get_option;
+use function get_permalink;
+use function get_userdata;
+use function get_user_meta;
+use function gmdate;
+use function human_time_diff;
+use function home_url;
+use function is_email;
+use function is_string;
+use function is_user_logged_in;
+use function number_format_i18n;
+use function preg_replace;
+use function sanitize_email;
+use function sanitize_key;
+use function sanitize_textarea_field;
+use function sanitize_text_field;
+use function strtotime;
+use function strlen;
+use function strpos;
+use function substr;
+use function strtoupper;
+use function time;
+use function update_user_meta;
+use function wp_check_password;
+use function is_wp_error;
+use function media_handle_upload;
+use function wp_delete_attachment;
+use function wp_destroy_other_sessions;
+use function wp_generate_uuid4;
+use function wp_get_current_user;
+use function wp_get_attachment_image_url;
+use function wp_get_session_token;
+use function wp_parse_url;
+use function wp_strip_all_tags;
+use function wp_set_auth_cookie;
+use function wp_unslash;
+use function wp_update_user;
+use function wp_hash_password;
+use function wp_rand;
+use function wp_mail;
+use function wp_verify_nonce;
+use function trailingslashit;
+use function WC;
+use function wc_get_checkout_url;
+use function wc_load_cart;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Profile
+{
+    /** @var array<string, string[]> */
+    private array $errors = [];
+
+    /** @var string[] */
+    private array $notices = [];
+
+    private ?string $active_section = null;
+
+    /** @var array<string, mixed>|null */
+    private ?array $cached_profile = null;
+
+    /** @var array<string, string> */
+    private array $group_draft = [];
+
+    /** @var array<int, array<string, mixed>> */
+    private array $group_complaint_summary = [];
+
+    /** @var array<int, array<string, string>> */
+    private array $group_complaint_draft = [];
+
+    /** @var array<int, string[]> */
+    private array $group_complaint_success = [];
+
+    public function init(): void
+    {
+        add_action('init', [$this, 'maybe_handle_update']);
+    }
+
+    public function maybe_handle_update(): void
+    {
+        if (!isset($_POST['jp_profile_action'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            return;
+        }
+
+        if (!is_user_logged_in()) {
+            $this->add_error('general', __('Faça login para atualizar o perfil.', 'juntaplay'));
+            return;
+        }
+
+        $section = isset($_POST['jp_profile_section'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_section'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $this->active_section = $section !== '' ? $section : null;
+
+        if (!isset($_POST['jp_profile_nonce'])
+            || !wp_verify_nonce(
+                sanitize_text_field(wp_unslash($_POST['jp_profile_nonce'] ?? '')),
+                'juntaplay_profile_update'
+            )
+        ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            $this->add_error($section ?: 'general', __('Sua sessão expirou. Atualize a página e tente novamente.', 'juntaplay'));
+            return;
+        }
+
+        $user_id = get_current_user_id();
+
+        if (!$user_id) {
+            $this->add_error('general', __('Não foi possível localizar o usuário autenticado.', 'juntaplay'));
+            return;
+        }
+
+        switch ($section) {
+            case 'name':
+                $this->update_name($user_id);
+                break;
+            case 'email':
+                $this->update_email($user_id);
+                break;
+            case 'phone':
+                $this->update_phone($user_id);
+                break;
+            case 'whatsapp':
+                $this->update_whatsapp($user_id);
+                break;
+            case 'tax_type':
+                $this->update_tax_type($user_id);
+                break;
+            case 'tax_document':
+                $this->update_tax_document($user_id);
+                break;
+            case 'tax_company':
+                $this->update_tax_company($user_id);
+                break;
+            case 'tax_state_registration':
+                $this->update_tax_state_registration($user_id);
+                break;
+            case 'tax_address':
+                $this->update_tax_address($user_id);
+                break;
+            case 'tax_city':
+                $this->update_tax_city($user_id);
+                break;
+            case 'tax_state':
+                $this->update_tax_state($user_id);
+                break;
+            case 'tax_postcode':
+                $this->update_tax_postcode($user_id);
+                break;
+            case 'password':
+                $this->update_password($user_id);
+                break;
+            case 'two_factor':
+                $this->update_two_factor($user_id);
+                break;
+            case 'login_alerts':
+                $this->update_login_alerts($user_id);
+                break;
+            case 'sessions':
+                $this->update_sessions($user_id);
+                break;
+            case 'credit_auto':
+                $this->update_credit_auto($user_id);
+                break;
+            case 'credit_payment_method':
+                $this->update_credit_payment_method($user_id);
+                break;
+            case 'credit_pix_key':
+                $this->update_credit_pix_key($user_id);
+                break;
+            case 'credit_bank_account':
+                $this->update_credit_bank_account($user_id);
+                break;
+            case 'credit_withdrawal':
+                $this->submit_credit_withdrawal_form($user_id);
+                break;
+            case 'group_create':
+                $this->create_group($user_id);
+                break;
+            case 'group_complaint':
+                $this->submit_group_complaint($user_id);
+                break;
+            default:
+                $this->add_error('general', __('Atualização inválida.', 'juntaplay'));
+        }
+    }
+
+    public function get_active_section(): ?string
+    {
+        return $this->active_section;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function get_errors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function get_notices(): array
+    {
+        return $this->notices;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get_profile_data(): array
+    {
+        if ($this->cached_profile !== null) {
+            return $this->cached_profile;
+        }
+
+        $user = wp_get_current_user();
+
+        if (!$user instanceof WP_User || !$user->exists()) {
+            $this->cached_profile = [];
+
+            return $this->cached_profile;
+        }
+
+        $phone                = (string) get_user_meta($user->ID, 'billing_phone', true);
+        $whatsapp             = (string) get_user_meta($user->ID, 'juntaplay_whatsapp', true);
+        $tax_type             = (string) get_user_meta($user->ID, 'juntaplay_tax_type', true);
+        $tax_document         = (string) get_user_meta($user->ID, 'juntaplay_tax_document', true);
+        $tax_company          = (string) get_user_meta($user->ID, 'billing_company', true);
+        $tax_state_regist     = (string) get_user_meta($user->ID, 'juntaplay_tax_state_registration', true);
+        $tax_address          = (string) get_user_meta($user->ID, 'billing_address_1', true);
+        $tax_city             = (string) get_user_meta($user->ID, 'billing_city', true);
+        $tax_state            = (string) get_user_meta($user->ID, 'billing_state', true);
+        $tax_postcode         = (string) get_user_meta($user->ID, 'billing_postcode', true);
+        $two_factor           = (string) get_user_meta($user->ID, 'juntaplay_two_factor_method', true);
+        $login_alerts         = (string) get_user_meta($user->ID, 'juntaplay_login_alerts', true);
+        $password_changed_at  = (string) get_user_meta($user->ID, 'juntaplay_password_changed_at', true);
+        $sessions_active      = $this->get_sessions_count($user);
+        $credit_balance       = $this->to_float(get_user_meta($user->ID, 'juntaplay_credit_balance', true));
+        $credit_reserved      = $this->to_float(get_user_meta($user->ID, 'juntaplay_credit_reserved', true));
+        $credit_bonus         = $this->to_float(get_user_meta($user->ID, 'juntaplay_credit_bonus', true));
+        $credit_bonus_expiry  = (string) get_user_meta($user->ID, 'juntaplay_credit_bonus_expires_at', true);
+        $credit_updated_at    = (string) get_user_meta($user->ID, 'juntaplay_credit_updated_at', true);
+        $credit_last_recharge = (string) get_user_meta($user->ID, 'juntaplay_credit_last_recharge', true);
+        $credit_auto_status   = (string) get_user_meta($user->ID, 'juntaplay_credit_auto_status', true);
+        $credit_auto_amount   = $this->to_float(get_user_meta($user->ID, 'juntaplay_credit_auto_amount', true));
+        $credit_auto_threshold = $this->to_float(get_user_meta($user->ID, 'juntaplay_credit_auto_threshold', true));
+        $credit_payment_method = (string) get_user_meta($user->ID, 'juntaplay_credit_payment_method', true);
+        $credit_pix_key       = (string) get_user_meta($user->ID, 'juntaplay_credit_pix_key', true);
+        $credit_bank_holder   = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_holder', true);
+        $credit_bank_document = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_document', true);
+        $credit_bank_name     = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_name', true);
+        $credit_bank_type     = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_type', true);
+        $credit_bank_agency   = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_agency', true);
+        $credit_bank_account  = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_account', true);
+        $credit_bank_account_type = (string) get_user_meta($user->ID, 'juntaplay_credit_bank_account_type', true);
+        $credit_withdraw_pending  = CreditWithdrawals::get_pending_total((int) $user->ID);
+        $withdraw_code_expires    = (int) get_user_meta($user->ID, 'juntaplay_withdraw_code_expires', true);
+
+        if ($whatsapp === '') {
+            $whatsapp = $phone;
+        }
+
+        if ($tax_type === '') {
+            $tax_type = 'pf';
+        }
+
+        if (!in_array($two_factor, ['email', 'whatsapp'], true)) {
+            $two_factor = 'off';
+        }
+
+        if ($login_alerts !== 'no') {
+            $login_alerts = 'yes';
+        }
+
+        if ($credit_auto_status !== 'on') {
+            $credit_auto_status = 'off';
+        }
+
+        if (!in_array($credit_payment_method, ['pix', 'card', 'boleto'], true)) {
+            $credit_payment_method = 'pix';
+        }
+
+        if (!in_array($credit_bank_type, ['pf', 'pj'], true)) {
+            $credit_bank_type = 'pf';
+        }
+
+        if (!in_array($credit_bank_account_type, ['checking', 'savings'], true)) {
+            $credit_bank_account_type = 'checking';
+        }
+
+        $groups_data = Groups::get_groups_for_user((int) $user->ID);
+        $pool_choices = Groups::get_pool_choices();
+
+        $profile = [
+            'name'                   => $user->display_name ?: $user->user_login,
+            'email'                  => $user->user_email,
+            'phone'                  => $phone,
+            'whatsapp'               => $whatsapp,
+            'tax_type'               => $tax_type,
+            'tax_document'           => $tax_document,
+            'tax_company'            => $tax_company,
+            'tax_state_registration' => $tax_state_regist,
+            'tax_address'            => $tax_address,
+            'tax_city'               => $tax_city,
+            'tax_state'              => $tax_state,
+            'tax_postcode'           => $tax_postcode,
+            'two_factor_method'      => $two_factor,
+            'login_alerts'           => $login_alerts,
+            'password_changed_at'    => $password_changed_at,
+            'sessions_active'        => $sessions_active,
+            'credit_balance'         => $credit_balance,
+            'credit_reserved'        => $credit_reserved,
+            'credit_bonus'           => $credit_bonus,
+            'credit_bonus_expiry'    => $credit_bonus_expiry,
+            'credit_updated_at'      => $credit_updated_at,
+            'credit_last_recharge'   => $credit_last_recharge,
+            'credit_auto_status'     => $credit_auto_status,
+            'credit_auto_amount'     => $credit_auto_amount,
+            'credit_auto_threshold'  => $credit_auto_threshold,
+            'credit_payment_method'  => $credit_payment_method,
+            'credit_pix_key'         => $credit_pix_key,
+            'credit_bank_holder'     => $credit_bank_holder,
+            'credit_bank_document'   => $credit_bank_document,
+            'credit_bank_name'       => $credit_bank_name,
+            'credit_bank_type'       => $credit_bank_type,
+            'credit_bank_agency'     => $credit_bank_agency,
+            'credit_bank_account'    => $credit_bank_account,
+            'credit_bank_account_type' => $credit_bank_account_type,
+            'credit_withdraw_pending'  => $credit_withdraw_pending,
+            'withdraw_code_expires'    => $withdraw_code_expires,
+            'groups'                 => [
+                'owned'  => $groups_data['owned'] ?? [],
+                'member' => $groups_data['member'] ?? [],
+            ],
+            'group_pool_options'     => $pool_choices,
+        ];
+
+        $this->cached_profile = apply_filters('juntaplay/profile/data', $profile, $user);
+
+        return $this->cached_profile;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function get_sections(): array
+    {
+        $data = $this->get_profile_data();
+
+        $groups_owned  = [];
+        $groups_member = [];
+        $group_counts  = [
+            'owned'    => 0,
+            'member'   => 0,
+            'pending'  => 0,
+            'approved' => 0,
+            'rejected' => 0,
+            'archived' => 0,
+            'total'    => 0,
+        ];
+
+        $raw_owned  = [];
+        $raw_member = [];
+
+        if (isset($data['groups']) && is_array($data['groups'])) {
+            $raw_owned = isset($data['groups']['owned']) && is_array($data['groups']['owned']) ? $data['groups']['owned'] : [];
+            foreach ($raw_owned as $group) {
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $normalized     = $this->prepare_group_entry($group, true);
+                $groups_owned[] = $normalized;
+
+                $this->tally_group_counts($group_counts, $normalized);
+            }
+
+            $raw_member = isset($data['groups']['member']) && is_array($data['groups']['member']) ? $data['groups']['member'] : [];
+            foreach ($raw_member as $group) {
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $normalized       = $this->prepare_group_entry($group, false);
+                $groups_member[]  = $normalized;
+
+                $this->tally_group_counts($group_counts, $normalized);
+            }
+        }
+
+        $group_counts['owned']  = count($groups_owned);
+        $group_counts['member'] = count($groups_member);
+        $group_counts['total']  = $group_counts['owned'] + $group_counts['member'];
+
+        $group_ids = $this->collect_group_ids($raw_owned, $raw_member);
+        $user_id   = get_current_user_id();
+
+        if ($user_id) {
+            $summary = GroupComplaints::get_summary_for_user($user_id, $group_ids);
+            $this->group_complaint_summary = $this->decorate_group_complaint_summary($summary);
+        } else {
+            $this->group_complaint_summary = [];
+        }
+
+        $pool_choices = [];
+        if (isset($data['group_pool_options']) && is_array($data['group_pool_options'])) {
+            $pool_choices = $data['group_pool_options'];
+        }
+
+        $sections = [
+            'contact' => [
+                'title'       => __('Informações de contato', 'juntaplay'),
+                'description' => __('Mantenha seus contatos atualizados para que possamos falar com você rapidamente.', 'juntaplay'),
+                'items'       => [
+                    'name' => [
+                        'label'       => __('Nome completo', 'juntaplay'),
+                        'description' => __('Como aparecerá no painel e nos e-mails.', 'juntaplay'),
+                        'value'       => $data['name'] ?? '',
+                        'placeholder' => __('Seu nome completo', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'email' => [
+                        'label'       => __('E-mail', 'juntaplay'),
+                        'description' => __('Receba confirmações e novidades do JuntaPlay.', 'juntaplay'),
+                        'value'       => $data['email'] ?? '',
+                        'placeholder' => __('seu@email.com', 'juntaplay'),
+                        'type'        => 'email',
+                    ],
+                    'phone' => [
+                        'label'       => __('Telefone', 'juntaplay'),
+                        'description' => __('Contato principal para suporte e reservas.', 'juntaplay'),
+                        'value'       => $data['phone'] ?? '',
+                        'placeholder' => __('(00) 90000-0000', 'juntaplay'),
+                        'type'        => 'tel',
+                    ],
+                    'whatsapp' => [
+                        'label'       => __('WhatsApp', 'juntaplay'),
+                        'description' => __('Canal rápido para avisos e confirmações.', 'juntaplay'),
+                        'value'       => $data['whatsapp'] ?? '',
+                        'placeholder' => __('(00) 90000-0000', 'juntaplay'),
+                        'type'        => 'tel',
+                    ],
+                ],
+            ],
+            'fiscal' => [
+                'title'       => __('Dados fiscais', 'juntaplay'),
+                'description' => __('Utilizamos estes dados para emissão de notas, comprovantes e relatórios financeiros.', 'juntaplay'),
+                'notice'      => __('Revise seus dados antes de participar de uma campanha para evitar atrasos na validação de pagamento.', 'juntaplay'),
+                'items'       => [
+                    'tax_type' => [
+                        'label'         => __('Cadastro', 'juntaplay'),
+                        'description'   => __('Selecione se você atua como pessoa física ou jurídica.', 'juntaplay'),
+                        'value'         => $data['tax_type'] ?? 'pf',
+                        'display_value' => $this->format_tax_type((string) ($data['tax_type'] ?? 'pf')),
+                        'type'          => 'select',
+                        'options'       => [
+                            'pf' => __('Pessoa física', 'juntaplay'),
+                            'pj' => __('Pessoa jurídica', 'juntaplay'),
+                        ],
+                    ],
+                    'tax_document' => [
+                        'label'       => __('Documento fiscal', 'juntaplay'),
+                        'description' => __('Informe seu CPF ou CNPJ para emissão de recibos.', 'juntaplay'),
+                        'value'       => $data['tax_document'] ?? '',
+                        'display_value' => $this->format_tax_document((string) ($data['tax_document'] ?? '')),
+                        'placeholder' => __('Digite seu CPF ou CNPJ', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_company' => [
+                        'label'       => __('Razão social / Nome da empresa', 'juntaplay'),
+                        'description' => __('Obrigatório para pessoas jurídicas.', 'juntaplay'),
+                        'value'       => $data['tax_company'] ?? '',
+                        'placeholder' => __('Informe a razão social', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_state_registration' => [
+                        'label'       => __('Inscrição estadual', 'juntaplay'),
+                        'description' => __('Caso isento, informe “Isento”.', 'juntaplay'),
+                        'value'       => $data['tax_state_registration'] ?? '',
+                        'placeholder' => __('Número ou “Isento”', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_address' => [
+                        'label'       => __('Endereço', 'juntaplay'),
+                        'description' => __('Rua, número e complemento utilizados para faturamento.', 'juntaplay'),
+                        'value'       => $data['tax_address'] ?? '',
+                        'placeholder' => __('Rua Exemplo, 123 - Bairro', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_city' => [
+                        'label'       => __('Cidade', 'juntaplay'),
+                        'value'       => $data['tax_city'] ?? '',
+                        'placeholder' => __('Sua cidade', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_state' => [
+                        'label'       => __('Estado (UF)', 'juntaplay'),
+                        'value'       => $data['tax_state'] ?? '',
+                        'display_value' => strtoupper((string) ($data['tax_state'] ?? '')),
+                        'placeholder' => __('UF', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                    'tax_postcode' => [
+                        'label'       => __('CEP', 'juntaplay'),
+                        'value'       => $data['tax_postcode'] ?? '',
+                        'display_value' => $this->format_postcode((string) ($data['tax_postcode'] ?? '')),
+                        'placeholder' => __('00000-000', 'juntaplay'),
+                        'type'        => 'text',
+                    ],
+                ],
+            ],
+            'groups' => [
+                'title'       => __('Meus grupos', 'juntaplay'),
+                'description' => __('Acompanhe os grupos que você criou ou entrou ao comprar cotas.', 'juntaplay'),
+                'summary'     => [
+                    [
+                        'label' => __('Grupos aprovados', 'juntaplay'),
+                        'value' => number_format_i18n($group_counts['approved']),
+                        'tone'  => 'positive',
+                    ],
+                    [
+                        'label' => __('Aguardando análise', 'juntaplay'),
+                        'value' => number_format_i18n($group_counts['pending']),
+                        'tone'  => 'warning',
+                    ],
+                    [
+                        'label' => __('Participando', 'juntaplay'),
+                        'value' => number_format_i18n($group_counts['member']),
+                        'tone'  => 'info',
+                    ],
+                    [
+                        'label' => __('Reclamações abertas', 'juntaplay'),
+                        'value' => number_format_i18n($this->count_open_complaints()),
+                        'tone'  => $this->count_open_complaints() > 0 ? 'warning' : 'info',
+                        'hint'  => $this->format_complaint_hint(),
+                    ],
+                ],
+                'items'       => [
+                    'groups_hub' => [
+                        'label'       => __('Grupos ativos', 'juntaplay'),
+                        'description' => __('Visualize os grupos, convide amigos e acompanhe o status de aprovação.', 'juntaplay'),
+                        'type'        => 'custom',
+                        'editable'    => false,
+                        'template'    => 'profile-groups.php',
+                        'context'     => [
+                            'groups_owned'   => $groups_owned,
+                            'groups_member'  => $groups_member,
+                            'group_counts'   => $group_counts,
+                            'pool_choices'   => $pool_choices,
+                            'group_categories' => $this->get_group_categories(),
+                            'group_suggestions' => $this->get_group_suggestions(),
+                            'form_errors'    => $this->errors['group_create'] ?? [],
+                            'form_values'    => $this->group_draft,
+                            'complaint_errors'  => $this->get_group_complaint_errors(),
+                            'complaint_drafts'  => $this->group_complaint_draft,
+                            'complaint_success' => $this->group_complaint_success,
+                            'complaint_reasons' => GroupComplaints::get_reasons(),
+                            'complaint_limits'  => $this->get_complaint_limits(),
+                            'complaint_summary' => $this->group_complaint_summary,
+                        ],
+                    ],
+                ],
+            ],
+            'credits' => [
+                'title'       => __('Créditos e saldo', 'juntaplay'),
+                'description' => __('Gerencie sua carteira pré-paga, configure recargas automáticas e mantenha seus dados de saque em dia.', 'juntaplay'),
+                'summary'     => [
+                    [
+                        'label' => __('Saldo disponível', 'juntaplay'),
+                        'value' => $this->format_currency((float) ($data['credit_balance'] ?? 0.0)),
+                        'tone'  => 'positive',
+                        'hint'  => $this->combine_hints([
+                            $this->format_credit_updated_at((string) ($data['credit_updated_at'] ?? '')),
+                            $this->format_credit_last_recharge((string) ($data['credit_last_recharge'] ?? '')),
+                        ]),
+                    ],
+                    [
+                        'label' => __('Reservado em pedidos', 'juntaplay'),
+                        'value' => $this->format_currency((float) ($data['credit_reserved'] ?? 0.0)),
+                        'tone'  => 'warning',
+                        'hint'  => __('Valores bloqueados aguardando confirmação de pagamento.', 'juntaplay'),
+                    ],
+                    [
+                        'label' => __('Bônus disponível', 'juntaplay'),
+                        'value' => $this->format_currency((float) ($data['credit_bonus'] ?? 0.0)),
+                        'tone'  => 'accent',
+                        'hint'  => $this->format_credit_bonus_hint((string) ($data['credit_bonus_expiry'] ?? '')),
+                    ],
+                    [
+                        'label' => __('Saques em análise', 'juntaplay'),
+                        'value' => $this->format_currency((float) ($data['credit_withdraw_pending'] ?? 0.0)),
+                        'tone'  => ((float) ($data['credit_withdraw_pending'] ?? 0.0)) > 0 ? 'warning' : 'info',
+                        'hint'  => __('Solicitações aguardando processamento financeiro.', 'juntaplay'),
+                    ],
+                ],
+                'items'       => [
+                    'credit_history' => [
+                        'label'       => __('Carteira e extrato', 'juntaplay'),
+                        'description' => __('Visualize movimentações, solicite retiradas e acompanhe pendências.', 'juntaplay'),
+                        'type'        => 'custom',
+                        'editable'    => false,
+                        'template'    => 'profile-credit-history.php',
+                        'context'     => $this->build_credit_history_context($data),
+                    ],
+                    'credit_auto' => [
+                        'label'         => __('Recarga automática', 'juntaplay'),
+                        'description'   => __('Adicione créditos automaticamente quando o saldo estiver baixo.', 'juntaplay'),
+                        'display_value' => $this->format_credit_auto($data),
+                        'fields'        => [
+                            [
+                                'name'    => 'credit_auto_status',
+                                'label'   => __('Status', 'juntaplay'),
+                                'type'    => 'select',
+                                'value'   => (string) ($data['credit_auto_status'] ?? 'off'),
+                                'options' => [
+                                    'on'  => __('Ativada', 'juntaplay'),
+                                    'off' => __('Desativada', 'juntaplay'),
+                                ],
+                            ],
+                            [
+                                'name'        => 'credit_auto_amount',
+                                'label'       => __('Valor da recarga (R$)', 'juntaplay'),
+                                'type'        => 'number',
+                                'value'       => $this->format_decimal((float) ($data['credit_auto_amount'] ?? 0.0)),
+                                'placeholder' => __('Ex.: 100,00', 'juntaplay'),
+                                'attributes'  => [
+                                    'step' => '0.01',
+                                    'min'  => '0',
+                                ],
+                            ],
+                            [
+                                'name'        => 'credit_auto_threshold',
+                                'label'       => __('Saldo mínimo para recarregar (R$)', 'juntaplay'),
+                                'type'        => 'number',
+                                'value'       => $this->format_decimal((float) ($data['credit_auto_threshold'] ?? 0.0)),
+                                'placeholder' => __('Ex.: 50,00', 'juntaplay'),
+                                'attributes'  => [
+                                    'step' => '0.01',
+                                    'min'  => '0',
+                                ],
+                                'help'        => __('Quando o saldo disponível ficar abaixo deste valor, uma nova recarga será sugerida.', 'juntaplay'),
+                            ],
+                        ],
+                        'submit_label' => __('Salvar preferências', 'juntaplay'),
+                    ],
+                    'credit_payment_method' => [
+                        'label'         => __('Forma de pagamento preferida', 'juntaplay'),
+                        'description'   => __('Defina o meio favorito para adicionar créditos rapidamente.', 'juntaplay'),
+                        'display_value' => $this->format_credit_payment_method((string) ($data['credit_payment_method'] ?? 'pix')),
+                        'type'          => 'select',
+                        'options'       => [
+                            'pix'    => __('Pix (instantâneo)', 'juntaplay'),
+                            'card'   => __('Cartão de crédito', 'juntaplay'),
+                            'boleto' => __('Boleto bancário', 'juntaplay'),
+                        ],
+                        'value'        => (string) ($data['credit_payment_method'] ?? 'pix'),
+                        'fields'       => [
+                            [
+                                'name'    => 'credit_payment_method',
+                                'type'    => 'select',
+                                'label'   => __('Forma de pagamento', 'juntaplay'),
+                                'value'   => (string) ($data['credit_payment_method'] ?? 'pix'),
+                                'options' => [
+                                    'pix'    => __('Pix (instantâneo)', 'juntaplay'),
+                                    'card'   => __('Cartão de crédito', 'juntaplay'),
+                                    'boleto' => __('Boleto bancário', 'juntaplay'),
+                                ],
+                            ],
+                        ],
+                        'submit_label' => __('Salvar forma de pagamento', 'juntaplay'),
+                    ],
+                    'credit_pix_key' => [
+                        'label'         => __('Chave Pix para resgates', 'juntaplay'),
+                        'description'   => __('Use uma chave Pix para receber estornos e premiações instantaneamente.', 'juntaplay'),
+                        'value'         => (string) ($data['credit_pix_key'] ?? ''),
+                        'display_value' => $this->format_credit_pix((string) ($data['credit_pix_key'] ?? '')),
+                        'placeholder'   => __('Seu CPF, CNPJ, e-mail ou chave aleatória', 'juntaplay'),
+                        'fields'        => [
+                            [
+                                'name'        => 'credit_pix_key',
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_pix_key'] ?? ''),
+                                'placeholder' => __('Informe sua chave Pix', 'juntaplay'),
+                                'help'        => __('Deixe em branco para remover a chave cadastrada.', 'juntaplay'),
+                            ],
+                        ],
+                    ],
+                    'credit_bank_account' => [
+                        'label'         => __('Dados bancários para saques', 'juntaplay'),
+                        'description'   => __('Informe a conta bancária para resgates manuais e transferências maiores.', 'juntaplay'),
+                        'display_value' => $this->format_credit_bank($data),
+                        'fields'        => [
+                            [
+                                'name'        => 'credit_bank_holder',
+                                'label'       => __('Titular da conta', 'juntaplay'),
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_bank_holder'] ?? ''),
+                                'placeholder' => __('Nome completo como consta no banco', 'juntaplay'),
+                            ],
+                            [
+                                'name'        => 'credit_bank_document',
+                                'label'       => __('Documento do titular', 'juntaplay'),
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_bank_document'] ?? ''),
+                                'placeholder' => __('CPF ou CNPJ do titular', 'juntaplay'),
+                            ],
+                            [
+                                'name'    => 'credit_bank_type',
+                                'label'   => __('Tipo de titularidade', 'juntaplay'),
+                                'type'    => 'select',
+                                'value'   => (string) ($data['credit_bank_type'] ?? 'pf'),
+                                'options' => [
+                                    'pf' => __('Pessoa física', 'juntaplay'),
+                                    'pj' => __('Pessoa jurídica', 'juntaplay'),
+                                ],
+                            ],
+                            [
+                                'name'        => 'credit_bank_name',
+                                'label'       => __('Banco', 'juntaplay'),
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_bank_name'] ?? ''),
+                                'placeholder' => __('Ex.: Nubank, Banco do Brasil, Itaú…', 'juntaplay'),
+                            ],
+                            [
+                                'name'        => 'credit_bank_agency',
+                                'label'       => __('Agência', 'juntaplay'),
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_bank_agency'] ?? ''),
+                                'placeholder' => __('Com dígito, se houver', 'juntaplay'),
+                            ],
+                            [
+                                'name'        => 'credit_bank_account',
+                                'label'       => __('Conta', 'juntaplay'),
+                                'type'        => 'text',
+                                'value'       => (string) ($data['credit_bank_account'] ?? ''),
+                                'placeholder' => __('Número da conta com dígito', 'juntaplay'),
+                            ],
+                            [
+                                'name'    => 'credit_bank_account_type',
+                                'label'   => __('Tipo de conta', 'juntaplay'),
+                                'type'    => 'select',
+                                'value'   => (string) ($data['credit_bank_account_type'] ?? 'checking'),
+                                'options' => [
+                                    'checking' => __('Conta corrente', 'juntaplay'),
+                                    'savings'  => __('Conta poupança', 'juntaplay'),
+                                ],
+                            ],
+                        ],
+                        'submit_label' => __('Salvar dados bancários', 'juntaplay'),
+                    ],
+                ],
+            ],
+            'security' => [
+                'title'       => __('Segurança da conta', 'juntaplay'),
+                'description' => __('Refine a proteção do seu login, configure verificações extras e controle quais dispositivos estão conectados.', 'juntaplay'),
+                'notice'      => __('Uma senha forte e a verificação em duas etapas mantêm suas cotas protegidas.', 'juntaplay'),
+                'items'       => [
+                    'password' => [
+                        'label'         => __('Senha de acesso', 'juntaplay'),
+                        'description'   => __('Use letras, números e símbolos para criar uma senha difícil de adivinhar.', 'juntaplay'),
+                        'value'         => $data['password_changed_at'] ?? '',
+                        'display_value' => $this->format_password_updated((string) ($data['password_changed_at'] ?? '')),
+                        'type'          => 'password',
+                        'fields'        => [
+                            [
+                                'name'        => 'password_current',
+                                'label'       => __('Senha atual', 'juntaplay'),
+                                'type'        => 'password',
+                                'placeholder' => __('Digite sua senha atual', 'juntaplay'),
+                                'autocomplete' => 'current-password',
+                            ],
+                            [
+                                'name'        => 'password_new',
+                                'label'       => __('Nova senha', 'juntaplay'),
+                                'type'        => 'password',
+                                'placeholder' => __('Crie uma nova senha', 'juntaplay'),
+                                'autocomplete' => 'new-password',
+                                'help'        => __('Mínimo de 8 caracteres com combinação de letras e números.', 'juntaplay'),
+                            ],
+                            [
+                                'name'        => 'password_confirm',
+                                'label'       => __('Confirmar nova senha', 'juntaplay'),
+                                'type'        => 'password',
+                                'placeholder' => __('Repita a nova senha', 'juntaplay'),
+                                'autocomplete' => 'new-password',
+                            ],
+                        ],
+                        'submit_label'  => __('Atualizar senha', 'juntaplay'),
+                    ],
+                    'two_factor' => [
+                        'label'         => __('Verificação em duas etapas', 'juntaplay'),
+                        'description'   => __('Solicite um código extra ao entrar para confirmar que é você.', 'juntaplay'),
+                        'value'         => $data['two_factor_method'] ?? 'off',
+                        'display_value' => $this->format_two_factor_method((string) ($data['two_factor_method'] ?? 'off')),
+                        'type'          => 'select',
+                        'options'       => [
+                            'off'      => __('Desativada', 'juntaplay'),
+                            'email'    => __('Código por e-mail', 'juntaplay'),
+                            'whatsapp' => __('Código por WhatsApp', 'juntaplay'),
+                        ],
+                    ],
+                    'login_alerts' => [
+                        'label'         => __('Alertas de login', 'juntaplay'),
+                        'description'   => __('Receba um aviso quando um novo dispositivo acessar sua conta.', 'juntaplay'),
+                        'value'         => $data['login_alerts'] ?? 'yes',
+                        'display_value' => $this->format_login_alerts((string) ($data['login_alerts'] ?? 'yes')),
+                        'type'          => 'select',
+                        'options'       => [
+                            'yes' => __('Enviar alerta por e-mail', 'juntaplay'),
+                            'no'  => __('Não enviar alertas', 'juntaplay'),
+                        ],
+                    ],
+                    'sessions' => [
+                        'label'         => __('Sessões ativas', 'juntaplay'),
+                        'description'   => __('Encerre acessos em outros navegadores e mantenha apenas esta sessão conectada.', 'juntaplay'),
+                        'value'         => (string) ($data['sessions_active'] ?? 1),
+                        'display_value' => $this->format_sessions_count((int) ($data['sessions_active'] ?? 1)),
+                        'type'          => 'action',
+                        'submit_label'  => __('Encerrar outras sessões', 'juntaplay'),
+                        'confirmation'  => __('Tem certeza de que deseja desconectar os outros dispositivos?', 'juntaplay'),
+                    ],
+                ],
+            ],
+        ];
+
+        if ($group_counts['rejected'] > 0) {
+            $sections['groups']['summary'][] = [
+                'label' => __('Grupos recusados', 'juntaplay'),
+                'value' => number_format_i18n($group_counts['rejected']),
+                'tone'  => 'danger',
+            ];
+        }
+
+        return apply_filters('juntaplay/profile/sections', $sections, $data);
+    }
+
+    public function send_withdraw_code(int $user_id): array
+    {
+        $user = get_userdata($user_id);
+
+        if (!$user instanceof WP_User || !$user->exists()) {
+            return ['error' => __('Não foi possível localizar sua conta.', 'juntaplay')];
+        }
+
+        $data   = $this->get_profile_data();
+        $method = isset($data['two_factor_method']) ? (string) $data['two_factor_method'] : 'email';
+
+        if (!in_array($method, ['email', 'whatsapp'], true)) {
+            $method = 'email';
+        }
+
+        $minutes = (int) apply_filters('juntaplay/credits/withdraw_code_minutes', 10);
+        if ($minutes <= 0) {
+            $minutes = 10;
+        }
+
+        $expires = time() + ($minutes * 60);
+        $code    = (string) wp_rand(100000, 999999);
+        $hash    = wp_hash_password($code);
+
+        update_user_meta($user_id, 'juntaplay_withdraw_code_hash', $hash);
+        update_user_meta($user_id, 'juntaplay_withdraw_code_expires', $expires);
+        update_user_meta($user_id, 'juntaplay_withdraw_code_attempts', 0);
+
+        $destination = $this->resolve_two_factor_destination($method, $data, (string) $user->user_email);
+        $site_name   = get_bloginfo('name');
+        $headers     = ['Content-Type: text/plain; charset=UTF-8'];
+
+        $body = implode("\n", [
+            sprintf(__('Olá %s, utilize o código abaixo para confirmar sua retirada no JuntaPlay.', 'juntaplay'), $user->display_name ?: $user->user_login),
+            '',
+            $code,
+            '',
+            sprintf(__('O código expira em %d minutos.', 'juntaplay'), $minutes),
+            __('Se você não solicitou, ignore esta mensagem.', 'juntaplay'),
+            '',
+            sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+        ]);
+
+        $subject = sprintf(__('Código de confirmação para retirada — %s', 'juntaplay'), $site_name);
+        $sent    = wp_mail((string) $user->user_email, $subject, $body, $headers);
+
+        if (!$sent) {
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_hash');
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_expires');
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_attempts');
+
+            return ['error' => __('Não foi possível enviar o código agora. Tente novamente em instantes.', 'juntaplay')];
+        }
+
+        $message = sprintf(__('Código enviado para %s. Ele expira em %d minutos.', 'juntaplay'), $destination !== '' ? $destination : $this->mask_email((string) $user->user_email), $minutes);
+
+        if ($method === 'whatsapp' && $destination === '') {
+            $message .= ' ' . __('Como medida temporária, o envio foi realizado para o e-mail cadastrado.', 'juntaplay');
+        }
+
+        return [
+            'message'     => $message,
+            'expires'     => gmdate('c', $expires),
+            'destination' => $destination !== '' ? $destination : $this->mask_email((string) $user->user_email),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @return array<string, mixed>
+     */
+    public function handle_withdrawal_request(int $user_id, array $request): array
+    {
+        $user = get_userdata($user_id);
+
+        if (!$user instanceof WP_User || !$user->exists()) {
+            return ['error' => __('Não foi possível localizar sua conta.', 'juntaplay'), 'status' => 401];
+        }
+
+        $amount_raw = $request['amount'] ?? '';
+        if (is_string($amount_raw)) {
+            $amount = $this->parse_decimal($amount_raw);
+        } else {
+            $amount = is_numeric($amount_raw) ? (float) $amount_raw : 0.0;
+        }
+
+        if ($amount <= 0) {
+            return ['error' => __('Informe um valor de saque válido.', 'juntaplay'), 'field' => 'amount', 'status' => 400];
+        }
+
+        $data    = $this->get_profile_data();
+        $balance = (float) ($data['credit_balance'] ?? 0.0);
+
+        if ($amount > $balance) {
+            return ['error' => __('Você não possui saldo suficiente para essa retirada.', 'juntaplay'), 'field' => 'amount', 'status' => 400];
+        }
+
+        $method = isset($request['method']) ? sanitize_key((string) $request['method']) : 'pix';
+        if (!in_array($method, ['pix', 'bank'], true)) {
+            $method = 'pix';
+        }
+
+        if ($method === 'pix') {
+            $pix_key = (string) get_user_meta($user_id, 'juntaplay_credit_pix_key', true);
+            if ($pix_key === '') {
+                return ['error' => __('Cadastre uma chave Pix antes de solicitar saques.', 'juntaplay'), 'field' => 'method', 'status' => 400];
+            }
+        } else {
+            $holder = (string) get_user_meta($user_id, 'juntaplay_credit_bank_holder', true);
+            $bank   = (string) get_user_meta($user_id, 'juntaplay_credit_bank_name', true);
+            $account = (string) get_user_meta($user_id, 'juntaplay_credit_bank_account', true);
+
+            if ($holder === '' || $bank === '' || $account === '') {
+                return ['error' => __('Preencha seus dados bancários para transferências.', 'juntaplay'), 'field' => 'method', 'status' => 400];
+            }
+        }
+
+        $code = isset($request['code']) ? trim((string) $request['code']) : '';
+        $hash = (string) get_user_meta($user_id, 'juntaplay_withdraw_code_hash', true);
+        $expires = (int) get_user_meta($user_id, 'juntaplay_withdraw_code_expires', true);
+        $attempts = (int) get_user_meta($user_id, 'juntaplay_withdraw_code_attempts', true);
+
+        if ($hash === '' || !$expires) {
+            return ['error' => __('Solicite um código de confirmação antes de concluir o saque.', 'juntaplay'), 'field' => 'code', 'status' => 400];
+        }
+
+        if ($expires < time()) {
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_hash');
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_expires');
+            delete_user_meta($user_id, 'juntaplay_withdraw_code_attempts');
+
+            return ['error' => __('O código informado expirou. Peça um novo código para continuar.', 'juntaplay'), 'field' => 'code', 'status' => 400];
+        }
+
+        if ($code === '' || !wp_check_password($code, $hash)) {
+            $attempts++;
+            update_user_meta($user_id, 'juntaplay_withdraw_code_attempts', $attempts);
+
+            if ($attempts >= 5) {
+                delete_user_meta($user_id, 'juntaplay_withdraw_code_hash');
+                delete_user_meta($user_id, 'juntaplay_withdraw_code_expires');
+                delete_user_meta($user_id, 'juntaplay_withdraw_code_attempts');
+
+                return ['error' => __('Limite de tentativas excedido. Solicite um novo código.', 'juntaplay'), 'field' => 'code', 'status' => 400];
+            }
+
+            return ['error' => __('Código inválido. Verifique e tente novamente.', 'juntaplay'), 'field' => 'code', 'status' => 400];
+        }
+
+        delete_user_meta($user_id, 'juntaplay_withdraw_code_hash');
+        delete_user_meta($user_id, 'juntaplay_withdraw_code_expires');
+        delete_user_meta($user_id, 'juntaplay_withdraw_code_attempts');
+
+        $balance_after = max(0.0, $balance - $amount);
+        update_user_meta($user_id, 'juntaplay_credit_balance', $this->store_decimal($balance_after));
+        update_user_meta($user_id, 'juntaplay_credit_updated_at', current_time('mysql'));
+
+        $destination = $this->build_withdraw_destination($user_id, $method);
+        $reference   = sprintf('JPW-%s', strtoupper(substr(wp_generate_uuid4(), 0, 8)));
+
+        $withdrawal_id = CreditWithdrawals::create([
+            'user_id'    => $user_id,
+            'amount'     => $amount,
+            'method'     => $method,
+            'status'     => CreditWithdrawals::STATUS_PENDING,
+            'destination'=> $destination,
+            'reference'  => $reference,
+        ]);
+
+        if (!$withdrawal_id) {
+            update_user_meta($user_id, 'juntaplay_credit_balance', $this->store_decimal($balance));
+
+            return ['error' => __('Não foi possível registrar sua solicitação. Tente novamente.', 'juntaplay'), 'status' => 500];
+        }
+
+        CreditTransactions::create([
+            'user_id'       => $user_id,
+            'type'          => CreditTransactions::TYPE_WITHDRAWAL,
+            'status'        => CreditTransactions::STATUS_PENDING,
+            'amount'        => -$amount,
+            'balance_after' => $balance_after,
+            'reference'     => $reference,
+            'context'       => [
+                'withdrawal_id' => $withdrawal_id,
+                'method'        => $method,
+            ],
+        ]);
+
+        $pending_total = CreditWithdrawals::get_pending_total($user_id);
+        update_user_meta($user_id, 'juntaplay_credit_withdraw_pending', $this->store_decimal($pending_total));
+
+        $this->invalidate_cache();
+
+        do_action('juntaplay/credits/withdrawal_requested', $user_id, $withdrawal_id, [
+            'amount'      => $amount,
+            'method'      => $method,
+            'reference'   => $reference,
+            'destination' => $destination,
+        ]);
+
+        return [
+            'message'       => __('Sua solicitação foi registrada. Avisaremos assim que for concluída.', 'juntaplay'),
+            'withdrawal_id' => $withdrawal_id,
+        ];
+    }
+
+    /**
+     * @param mixed $amount_raw
+     * @return array<string, mixed>
+     */
+    public function initiate_deposit(int $user_id, $amount_raw): array
+    {
+        if (!class_exists('WooCommerce') || !function_exists('WC')) {
+            return ['error' => __('A recarga de créditos está indisponível no momento.', 'juntaplay')];
+        }
+
+        $user = get_userdata($user_id);
+
+        if (!$user instanceof WP_User || !$user->exists()) {
+            return ['error' => __('Não foi possível localizar sua conta.', 'juntaplay')];
+        }
+
+        if (is_string($amount_raw)) {
+            $amount = $this->parse_decimal($amount_raw);
+        } elseif (is_numeric($amount_raw)) {
+            $amount = (float) $amount_raw;
+        } else {
+            $amount = 0.0;
+        }
+
+        $min = (float) apply_filters('juntaplay/credits/deposit_min', 25.0, $user_id);
+        $max = (float) apply_filters('juntaplay/credits/deposit_max', 5000.0, $user_id);
+
+        if ($amount <= 0 || $amount < $min) {
+            return ['error' => sprintf(__('O valor mínimo para recarga é %s.', 'juntaplay'), $this->format_currency($min)), 'field' => 'amount'];
+        }
+
+        if ($max > 0 && $amount > $max) {
+            return ['error' => sprintf(__('O valor máximo permitido para recarga é %s.', 'juntaplay'), $this->format_currency($max)), 'field' => 'amount'];
+        }
+
+        $product_id = WooCredits::get_product_id();
+
+        if ($product_id <= 0) {
+            return ['error' => __('Não foi possível preparar o produto de recarga.', 'juntaplay')];
+        }
+
+        if (!wc_get_checkout_url()) {
+            return ['error' => __('Checkout indisponível no momento. Tente novamente em instantes.', 'juntaplay')];
+        }
+
+        $woocommerce = WC();
+
+        if (!$woocommerce) {
+            return ['error' => __('Não foi possível iniciar seu carrinho de compras.', 'juntaplay')];
+        }
+
+        if (!isset($woocommerce->cart) || !$woocommerce->cart) {
+            wc_load_cart();
+        }
+
+        $cart = $woocommerce->cart;
+
+        if (!$cart) {
+            return ['error' => __('Não foi possível iniciar seu carrinho de compras.', 'juntaplay')];
+        }
+
+        foreach ($cart->get_cart() as $item_key => $item) {
+            if (!empty($item['juntaplay_deposit'])) {
+                $cart->remove_cart_item($item_key);
+            }
+        }
+
+        $reference = sprintf('JPD-%s', strtoupper(substr(wp_generate_uuid4(), 0, 8)));
+
+        $cart_item_data = [
+            'juntaplay_deposit' => [
+                'amount'    => $amount,
+                'reference' => $reference,
+                'display'   => $this->format_currency($amount),
+            ],
+        ];
+
+        $cart_item_key = $cart->add_to_cart($product_id, 1, 0, [], $cart_item_data);
+
+        if (!$cart_item_key) {
+            return ['error' => __('Não foi possível adicionar a recarga ao carrinho.', 'juntaplay')];
+        }
+
+        if (method_exists($cart, 'calculate_totals')) {
+            $cart->calculate_totals();
+        }
+
+        do_action('juntaplay/credits/deposit_initiated', $user_id, [
+            'amount'    => $amount,
+            'reference' => $reference,
+            'product_id'=> $product_id,
+        ]);
+
+        return [
+            'message'  => sprintf(__('Recarga de %s adicionada ao carrinho.', 'juntaplay'), $this->format_currency($amount)),
+            'redirect' => wc_get_checkout_url(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $group
+     * @return array<string, mixed>
+     */
+    private function prepare_group_entry(array $group, bool $is_owner): array
+    {
+        $status            = isset($group['status']) ? (string) $group['status'] : Groups::STATUS_PENDING;
+        $membership_status = isset($group['membership_status']) ? (string) $group['membership_status'] : 'active';
+        $role              = isset($group['membership_role']) ? (string) $group['membership_role'] : ($is_owner ? 'owner' : 'member');
+        $service_name      = isset($group['service_name']) ? (string) $group['service_name'] : '';
+        $service_url       = isset($group['service_url']) ? (string) $group['service_url'] : '';
+        $rules             = isset($group['rules']) ? (string) $group['rules'] : '';
+        $price_regular     = isset($group['price_regular']) ? (float) $group['price_regular'] : 0.0;
+        $price_promotional = isset($group['price_promotional']) ? (float) $group['price_promotional'] : 0.0;
+        $member_price      = isset($group['member_price']) ? (float) $group['member_price'] : 0.0;
+        $slots_total       = isset($group['slots_total']) ? (int) $group['slots_total'] : 0;
+        $slots_reserved    = isset($group['slots_reserved']) ? (int) $group['slots_reserved'] : 0;
+        $support_channel   = isset($group['support_channel']) ? (string) $group['support_channel'] : '';
+        $delivery_time     = isset($group['delivery_time']) ? (string) $group['delivery_time'] : '';
+        $access_method     = isset($group['access_method']) ? (string) $group['access_method'] : '';
+        $category          = isset($group['category']) ? (string) $group['category'] : '';
+        $instant_access    = !empty($group['instant_access']);
+        $slots_available   = max(0, $slots_total - $slots_reserved);
+
+        $status_meta = $this->describe_group_status($status, $membership_status, $is_owner);
+
+        $cover_url = isset($group['cover_url']) ? (string) $group['cover_url'] : '';
+        $cover_alt = isset($group['cover_alt']) ? (string) $group['cover_alt'] : '';
+        $cover_placeholder = !empty($group['cover_placeholder']);
+
+        if ($cover_url === '' && defined('JP_URL')) {
+            $cover_url = JP_GROUP_COVER_PLACEHOLDER;
+            $cover_placeholder = true;
+        }
+
+        if ($cover_alt === '') {
+            $cover_alt = __('Capa do grupo', 'juntaplay');
+        }
+
+        $group['status']            = $status;
+        $group['membership_status'] = $membership_status;
+        $group['membership_role']   = $role;
+        $group['status_label']      = $status_meta['label'];
+        $group['status_tone']       = $status_meta['tone'];
+        $group['status_message']    = $status_meta['message'];
+        $group['role_label']        = $this->format_group_role($role, $is_owner);
+        $group['role_tone']         = $is_owner ? 'positive' : 'info';
+        $group['created_human']     = $this->format_group_created_at((string) ($group['created_at'] ?? ''));
+        $group['pool_link']         = $this->build_group_pool_link((int) ($group['pool_id'] ?? 0), (string) ($group['pool_slug'] ?? ''));
+        $group['members_count']     = isset($group['members_count']) ? (int) $group['members_count'] : 0;
+        $group['review_note']       = isset($group['review_note']) ? (string) $group['review_note'] : '';
+        $group['reviewed_human']    = $this->format_group_reviewed_at((string) ($group['reviewed_at'] ?? ''));
+        $group['service_name']      = $service_name;
+        $group['service_url']       = $service_url;
+        $group['rules']             = $rules;
+        $group['price_regular']     = $price_regular;
+        $group['price_regular_display'] = $price_regular > 0 ? $this->format_currency($price_regular) : '';
+        $group['price_promotional'] = $price_promotional > 0 ? $price_promotional : 0.0;
+        $group['price_promotional_display'] = $price_promotional > 0 ? $this->format_currency($price_promotional) : '';
+        $group['member_price']      = $member_price;
+        $group['member_price_display'] = $member_price > 0 ? $this->format_currency($member_price) : '';
+        $group['slots_total']       = $slots_total;
+        $group['slots_reserved']    = $slots_reserved;
+        $group['slots_available']   = $slots_available;
+        $group['support_channel']   = $support_channel;
+        $group['delivery_time']     = $delivery_time;
+        $group['access_method']     = $access_method;
+        $group['category']          = $category;
+        $group['category_label']    = $this->format_group_category_label($category);
+        $group['instant_access']    = $instant_access;
+        $group['instant_access_label'] = $instant_access
+            ? __('Acesso instantâneo ativado', 'juntaplay')
+            : __('Acesso instantâneo desativado', 'juntaplay');
+        $group['slots_summary']     = sprintf(__('Total: %1$d vagas • Reservadas: %2$d • Disponíveis: %3$d', 'juntaplay'), $slots_total, $slots_reserved, $slots_available);
+        $group['members_preview']   = $this->build_group_members_preview((int) ($group['id'] ?? 0), $group['members_count']);
+
+        $reserved_for_owner = $slots_reserved > 0 ? $slots_reserved : 1;
+        $enrollment_basis   = $member_price > 0
+            ? $member_price
+            : ($price_promotional > 0 ? $price_promotional : $price_regular);
+        $enrollment_total   = $enrollment_basis > 0 ? $enrollment_basis * max(1, $reserved_for_owner) : 0.0;
+
+        $group['enrollment_total']         = $enrollment_total;
+        $group['enrollment_total_display'] = $enrollment_total > 0 ? $this->format_currency($enrollment_total) : '';
+        $group['blocked_notice']           = $status === Groups::STATUS_PENDING
+            ? __('Pagamentos ficam bloqueados até a aprovação do super administrador.', 'juntaplay')
+            : '';
+
+        $share = $this->build_group_share_snippet($group);
+        $group['share_domain']  = $share['domain'];
+        $group['share_snippet'] = $share['text'];
+
+        $group['payment_methods'] = $this->get_payment_methods();
+        $group['faq_items']       = $this->build_group_faq($group);
+        $group['cover_url']       = $cover_url;
+        $group['cover_alt']       = $cover_alt;
+        $group['cover_placeholder'] = $cover_placeholder;
+
+        $group_id = isset($group['id']) ? (int) $group['id'] : 0;
+        $summary  = $group_id > 0 && isset($this->group_complaint_summary[$group_id])
+            ? $this->group_complaint_summary[$group_id]
+            : [];
+
+        $group['complaints'] = [
+            'open'   => (int) ($summary['open'] ?? 0),
+            'total'  => (int) ($summary['total'] ?? 0),
+            'latest' => isset($summary['latest']) && is_array($summary['latest']) ? $summary['latest'] : [],
+        ];
+
+        return $group;
+    }
+
+    /**
+     * @param array<int, mixed> $owned
+     * @param array<int, mixed> $member
+     * @return int[]
+     */
+    private function collect_group_ids(array $owned, array $member): array
+    {
+        $ids = [];
+
+        foreach ([$owned, $member] as $collection) {
+            foreach ($collection as $group) {
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $id = isset($group['id']) ? (int) $group['id'] : 0;
+
+                if ($id > 0) {
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $summary
+     * @return array<int, array<string, mixed>>
+     */
+    private function decorate_group_complaint_summary(array $summary): array
+    {
+        foreach ($summary as $group_id => $data) {
+            if (!is_array($data)) {
+                continue;
+            }
+
+            $latest = isset($data['latest']) && is_array($data['latest']) ? $data['latest'] : null;
+
+            if (!$latest) {
+                continue;
+            }
+
+            $status_meta = GroupComplaints::describe_status((string) ($latest['status'] ?? GroupComplaints::STATUS_OPEN));
+
+            $latest['status_label']   = $status_meta['label'];
+            $latest['status_tone']    = $status_meta['tone'];
+            $latest['status_message'] = $status_meta['message'];
+            $latest['reason_label']   = GroupComplaints::get_reason_label((string) ($latest['reason'] ?? 'other'));
+            $latest['created_human']  = $this->format_group_created_at((string) ($latest['created_at'] ?? ''));
+            $latest['summary']        = $this->format_complaint_summary_line($latest);
+
+            $summary[$group_id]['latest'] = $latest;
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param array<string, mixed> $latest
+     */
+    private function format_complaint_summary_line(array $latest): string
+    {
+        $parts = [];
+
+        $reason = isset($latest['reason_label']) ? (string) $latest['reason_label'] : '';
+        if ($reason !== '') {
+            $parts[] = $reason;
+        }
+
+        $created = isset($latest['created_human']) ? (string) $latest['created_human'] : '';
+        if ($created !== '') {
+            $parts[] = $created;
+        }
+
+        $order = isset($latest['order_id']) ? (int) $latest['order_id'] : 0;
+        if ($order > 0) {
+            $parts[] = sprintf(__('Pedido #%d', 'juntaplay'), $order);
+        }
+
+        return implode(' • ', array_filter($parts));
+    }
+
+    private function count_open_complaints(): int
+    {
+        $total = 0;
+
+        foreach ($this->group_complaint_summary as $summary) {
+            if (!is_array($summary)) {
+                continue;
+            }
+
+            $total += (int) ($summary['open'] ?? 0);
+        }
+
+        return $total;
+    }
+
+    private function count_total_complaints(): int
+    {
+        $total = 0;
+
+        foreach ($this->group_complaint_summary as $summary) {
+            if (!is_array($summary)) {
+                continue;
+            }
+
+            $total += (int) ($summary['total'] ?? 0);
+        }
+
+        return $total;
+    }
+
+    private function format_complaint_hint(): string
+    {
+        $total = $this->count_total_complaints();
+
+        if ($total <= 0) {
+            return __('Nenhuma reclamação registrada até agora.', 'juntaplay');
+        }
+
+        $open = $this->count_open_complaints();
+
+        if ($open > 0) {
+            return sprintf(_n('Você tem %d reclamação em análise.', 'Você tem %d reclamações em análise.', $open, 'juntaplay'), $open);
+        }
+
+        return sprintf(_n('Você já resolveu %d reclamação.', 'Você já resolveu %d reclamações.', $total, 'juntaplay'), $total);
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    private function get_group_complaint_errors(): array
+    {
+        $errors = [];
+
+        foreach ($this->errors as $key => $messages) {
+            if (strpos((string) $key, 'group_complaint_') !== 0 || !is_array($messages)) {
+                continue;
+            }
+
+            $errors[(string) $key] = $messages;
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function get_complaint_limits(): array
+    {
+        $max_files = (int) apply_filters('juntaplay/groups/complaints/max_files', 3);
+        $max_size  = (int) apply_filters('juntaplay/groups/complaints/max_file_size', 5 * 1024 * 1024);
+
+        if ($max_files <= 0) {
+            $max_files = 3;
+        }
+
+        if ($max_size <= 0) {
+            $max_size = 5 * 1024 * 1024;
+        }
+
+        return [
+            'max_files' => $max_files,
+            'max_size'  => $max_size,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function build_group_members_preview(int $group_id, int $total_members): array
+    {
+        $preview = [
+            'names'     => [],
+            'remaining' => 0,
+        ];
+
+        if ($group_id <= 0) {
+            return $preview;
+        }
+
+        $members = GroupMembers::get_details($group_id, 5, 'active');
+
+        foreach ($members as $member) {
+            $name = trim((string) ($member['name'] ?? ''));
+            if ($name === '') {
+                $name = __('Participante', 'juntaplay');
+            }
+
+            if (($member['role'] ?? '') === 'owner') {
+                $name = sprintf(__('Administrador: %s', 'juntaplay'), $name);
+            }
+
+            $preview['names'][] = $name;
+        }
+
+        $count_preview = count($preview['names']);
+        $preview['remaining'] = max(0, $total_members - $count_preview);
+
+        return $preview;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function build_group_share_snippet(array $group): array
+    {
+        $domain = $this->get_share_domain();
+        $lines  = [];
+
+        if ($domain !== '') {
+            $lines[] = $domain;
+        }
+
+        $service = (string) ($group['service_name'] ?? '');
+        if ($service !== '') {
+            $lines[] = sprintf(__('Serviço: %s', 'juntaplay'), $service);
+        }
+
+        $title = (string) ($group['title'] ?? '');
+        if ($title !== '') {
+            $lines[] = sprintf(__('Nome do grupo: %s', 'juntaplay'), $title);
+        }
+
+        $lines[] = __('Tipo: Público', 'juntaplay');
+
+        $category = (string) ($group['category_label'] ?? '');
+        if ($category !== '') {
+            $lines[] = sprintf(__('Categoria: %s', 'juntaplay'), $category);
+        }
+
+        $service_url = (string) ($group['service_url'] ?? '');
+        if ($service_url !== '') {
+            $lines[] = sprintf(__('Site: %s', 'juntaplay'), $service_url);
+        }
+
+        $rules = (string) ($group['rules'] ?? '');
+        if ($rules !== '') {
+            $lines[] = sprintf(__('Regras: %s', 'juntaplay'), $rules);
+        }
+
+        $description = (string) ($group['description'] ?? '');
+        if ($description !== '') {
+            $lines[] = sprintf(__('Descrição: %s', 'juntaplay'), $description);
+        }
+
+        $price_display = (string) ($group['price_regular_display'] ?? '');
+        if ($price_display !== '') {
+            $lines[] = sprintf(__('Valor do serviço: %s', 'juntaplay'), $price_display);
+        }
+
+        $promo_flag = (string) ($group['price_promotional_display'] ?? '');
+        $is_promo   = (float) ($group['price_promotional'] ?? 0.0) > 0;
+        $lines[] = sprintf(__('É valor promocional?: %s', 'juntaplay'), $is_promo ? __('Sim', 'juntaplay') : __('Não', 'juntaplay'));
+        if ($is_promo && $promo_flag !== '') {
+            $lines[] = sprintf(__('Valor promocional: %s', 'juntaplay'), $promo_flag);
+        }
+
+        $slots_total = (int) ($group['slots_total'] ?? 0);
+        if ($slots_total > 0) {
+            $lines[] = sprintf(__('Vagas totais: %d', 'juntaplay'), $slots_total);
+        }
+
+        $slots_reserved = (int) ($group['slots_reserved'] ?? 0);
+        if ($slots_reserved > 0) {
+            $lines[] = sprintf(__('Reservadas para você: %d', 'juntaplay'), $slots_reserved);
+        }
+
+        $member_price = (string) ($group['member_price_display'] ?? '');
+        if ($member_price !== '') {
+            $lines[] = sprintf(__('Os membros vão pagar: %s', 'juntaplay'), $member_price);
+        }
+
+        $support = (string) ($group['support_channel'] ?? '');
+        if ($support !== '') {
+            $lines[] = sprintf(__('Suporte aos membros: %s', 'juntaplay'), $support);
+        }
+
+        $delivery = (string) ($group['delivery_time'] ?? '');
+        if ($delivery !== '') {
+            $lines[] = sprintf(__('Envio de acesso: %s', 'juntaplay'), $delivery);
+        }
+
+        $access = (string) ($group['access_method'] ?? '');
+        if ($access !== '') {
+            $lines[] = sprintf(__('Forma de acesso: %s', 'juntaplay'), $access);
+        }
+
+        $lines[] = sprintf(__('Acesso instantâneo: %s', 'juntaplay'), (string) ($group['instant_access_label'] ?? ''));
+
+        return [
+            'domain' => $domain,
+            'text'   => implode("\n", array_filter($lines)),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function build_group_faq(array $group): array
+    {
+        $faq    = [];
+        $access = (string) ($group['delivery_time'] ?? '');
+        $instant = !empty($group['instant_access']);
+        $members_total = (int) ($group['slots_total'] ?? 0);
+        $payment_methods = $this->get_payment_methods();
+        $payment_list = implode(', ', array_map('wp_strip_all_tags', $payment_methods));
+        $limits = $this->get_complaint_limits();
+        $max_files = (int) ($limits['max_files'] ?? 3);
+        $max_size  = (int) ($limits['max_size'] ?? (5 * 1024 * 1024));
+        $max_size_mb = number_format_i18n(max(1, $max_size / 1048576), 1);
+
+        if ($instant) {
+            $access_text = __('Assim que seu pagamento for confirmado o acesso é liberado automaticamente.', 'juntaplay');
+        } elseif ($access !== '') {
+            $access_text = sprintf(__('O administrador envia os dados em até %s após a confirmação do pagamento.', 'juntaplay'), $access);
+        } else {
+            $access_text = __('O administrador envia o acesso logo após o grupo ser aprovado.', 'juntaplay');
+        }
+
+        $faq[] = [
+            'question' => __('Quando terei acesso ao serviço?', 'juntaplay'),
+            'answer'   => $access_text,
+        ];
+
+        $faq[] = [
+            'question' => __('Quais as formas de pagamento aceitas?', 'juntaplay'),
+            'answer'   => $payment_list !== ''
+                ? sprintf(__('Utilizamos os meios de pagamento habilitados no WooCommerce: %s.', 'juntaplay'), $payment_list)
+                : __('Os pagamentos são processados pelos métodos ativos do WooCommerce da loja.', 'juntaplay'),
+        ];
+
+        $faq[] = [
+            'question' => __('O que é caução?', 'juntaplay'),
+            'answer'   => __('É o valor que fica bloqueado na sua carteira até que o administrador confirme o envio do serviço ou o grupo seja aprovado. Caso algo dê errado, devolvemos automaticamente.', 'juntaplay'),
+        ];
+
+        if ($members_total > 0) {
+            $faq[] = [
+                'question' => __('Com quem posso dividir uma assinatura?', 'juntaplay'),
+                'answer'   => sprintf(__('Este grupo comporta até %d participantes. Convide amigos ou familiares para preencher as vagas disponíveis.', 'juntaplay'), $members_total),
+            ];
+        }
+
+        $faq[] = [
+            'question' => __('Como faço uma reclamação?', 'juntaplay'),
+            'answer'   => __('Abra a aba “Abrir reclamação”, descreva o ocorrido e envie evidências. O administrador e a equipe JuntaPlay são notificados automaticamente.', 'juntaplay'),
+        ];
+
+        $faq[] = [
+            'question' => __('Posso anexar comprovantes?', 'juntaplay'),
+            'answer'   => sprintf(
+                __('Sim, você pode anexar até %1$d arquivos (imagens ou PDF) de até %2$s MB cada para agilizar a análise.', 'juntaplay'),
+                max(1, $max_files),
+                $max_size_mb
+            ),
+        ];
+
+        $faq[] = [
+            'question' => __('O que acontece depois que envio?', 'juntaplay'),
+            'answer'   => __('Você recebe um protocolo por e-mail e acompanhamos o caso até a solução. Valores envolvidos podem ficar bloqueados até a conclusão da análise.', 'juntaplay'),
+        ];
+
+        return $faq;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function get_payment_methods(): array
+    {
+        static $cached = null;
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $labels = [];
+
+        if (function_exists('WC')) {
+            $wc = WC();
+            $gateways = null;
+
+            if ($wc && isset($wc->payment_gateways) && method_exists($wc->payment_gateways, 'get_available_payment_gateways')) {
+                $gateways = $wc->payment_gateways->get_available_payment_gateways();
+            }
+
+            if (!$gateways && class_exists('\\WC_Payment_Gateways')) {
+                $gateways = \WC_Payment_Gateways::instance()->get_available_payment_gateways();
+            }
+
+            if (is_array($gateways)) {
+                foreach ($gateways as $gateway) {
+                    if (!$gateway) {
+                        continue;
+                    }
+
+                    $title = '';
+                    if (is_object($gateway) && method_exists($gateway, 'get_title')) {
+                        $title = (string) $gateway->get_title();
+                    } elseif (is_array($gateway) && isset($gateway['title'])) {
+                        $title = (string) $gateway['title'];
+                    }
+
+                    $title = wp_strip_all_tags($title);
+
+                    if ($title !== '') {
+                        $labels[] = $title;
+                    }
+                }
+            }
+        }
+
+        if (!$labels) {
+            $labels = [
+                __('Pix', 'juntaplay'),
+                __('Cartão de crédito', 'juntaplay'),
+                __('Boleto bancário', 'juntaplay'),
+            ];
+        }
+
+        $cached = array_values(array_unique(array_filter($labels)));
+
+        return $cached;
+    }
+
+    private function get_share_domain(): string
+    {
+        static $domain = null;
+
+        if ($domain !== null) {
+            return $domain;
+        }
+
+        $host = wp_parse_url(home_url(), PHP_URL_HOST);
+        if (!$host) {
+            $host = preg_replace('~^https?://~', '', home_url());
+        }
+
+        $domain = is_string($host) ? trim($host, '/') : '';
+
+        return $domain;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function get_group_categories(): array
+    {
+        return Groups::get_category_labels();
+    }
+
+    private function format_group_category_label(string $category): string
+    {
+        $categories = $this->get_group_categories();
+
+        if ($category === '') {
+            return '';
+        }
+
+        if (isset($categories[$category])) {
+            return $categories[$category];
+        }
+
+        return ucwords(str_replace(['-', '_'], ' ', $category));
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function get_group_suggestions(): array
+    {
+        $suggestions = [
+            [
+                'title'       => 'YouTube Premium',
+                'price'       => $this->format_currency(22.9),
+                'amount'      => '22.90',
+                'category'    => 'video',
+                'description' => __('Plano família com 6 perfis para dividir música e vídeos sem anúncios.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Mubi Cinemateca',
+                'price'       => $this->format_currency(19.9),
+                'amount'      => '19.90',
+                'category'    => 'video',
+                'description' => __('Seleção de filmes independentes e clássicos restaurados toda semana.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'NBA League Pass',
+                'price'       => $this->format_currency(119.9),
+                'amount'      => '119.90',
+                'category'    => 'games',
+                'description' => __('Temporada completa de jogos ao vivo com múltiplos dispositivos.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'PlayPlus Família',
+                'price'       => $this->format_currency(21.9),
+                'amount'      => '21.90',
+                'category'    => 'video',
+                'description' => __('Conteúdos exclusivos da Record TV com acesso simultâneo para a família.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Spotify Premium Família',
+                'price'       => $this->format_currency(24.9),
+                'amount'      => '24.90',
+                'category'    => 'music',
+                'description' => __('Música sem anúncios, mix família e controle parental em um só plano.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Tidal HiFi Max',
+                'price'       => $this->format_currency(29.9),
+                'amount'      => '29.90',
+                'category'    => 'music',
+                'description' => __('Áudio sem perdas e suporte a Dolby Atmos para entusiastas.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Brainly Premium',
+                'price'       => $this->format_currency(21.9),
+                'amount'      => '21.90',
+                'category'    => 'education',
+                'description' => __('Respostas verificadas, tutores online e revisão focada em vestibulares.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Ubook',
+                'price'       => $this->format_currency(14.9),
+                'amount'      => '14.90',
+                'category'    => 'reading',
+                'description' => __('Audiobooks e podcasts originais para maratonar no celular.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Super Interessante Digital',
+                'price'       => $this->format_currency(12.9),
+                'amount'      => '12.90',
+                'category'    => 'reading',
+                'description' => __('Revista de ciência e cultura com acesso ao acervo histórico completo.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Veja Saúde',
+                'price'       => $this->format_currency(9.9),
+                'amount'      => '9.90',
+                'category'    => 'reading',
+                'description' => __('Reportagens sobre saúde, bem-estar e alimentação com curadoria médica.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Perplexity Pro',
+                'price'       => $this->format_currency(79.9),
+                'amount'      => '79.90',
+                'category'    => 'ai',
+                'description' => __('Pesquisa com IA generativa, histórico compartilhado e exportação de respostas.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Canva Pro',
+                'price'       => $this->format_currency(31.9),
+                'amount'      => '31.90',
+                'category'    => 'office',
+                'description' => __('Templates premium, branding kit e bibliotecas colaborativas.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'Google One 2TB',
+                'price'       => $this->format_currency(24.9),
+                'amount'      => '24.90',
+                'category'    => 'office',
+                'description' => __('Armazenamento compartilhado, VPN e suporte especializado da Google.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'ExpressVPN',
+                'price'       => $this->format_currency(42.9),
+                'amount'      => '42.90',
+                'category'    => 'security',
+                'description' => __('Rede privada virtual com mais de 90 países e proteção para 5 dispositivos.', 'juntaplay'),
+            ],
+            [
+                'title'       => __('Bolão Mega da Virada', 'juntaplay'),
+                'price'       => $this->format_currency(20.0),
+                'amount'      => '20.00',
+                'category'    => 'boloes',
+                'description' => __('Cotas digitais com recibo individual e conferência transmitida ao vivo.', 'juntaplay'),
+            ],
+            [
+                'title'       => 'ChatGPT Team',
+                'price'       => $this->format_currency(27.5),
+                'amount'      => '27.50',
+                'category'    => 'ai',
+                'description' => __('Espaço colaborativo para times criarem assistentes e compartilharem prompts.', 'juntaplay'),
+            ],
+        ];
+
+        /**
+         * Permite ajustar os cards de inspiração exibidos na criação de grupos.
+         */
+        return apply_filters('juntaplay/groups/suggestions', $suggestions);
+    }
+
+    /**
+     * @param array<string, int>   $counts
+     * @param array<string, mixed> $group
+     */
+    private function tally_group_counts(array &$counts, array $group): void
+    {
+        if (!isset($counts['pending'], $counts['approved'], $counts['rejected'], $counts['archived'])) {
+            return;
+        }
+
+        $status            = isset($group['status']) ? (string) $group['status'] : Groups::STATUS_PENDING;
+        $membership_status = isset($group['membership_status']) ? (string) $group['membership_status'] : 'active';
+
+        if ($status === Groups::STATUS_PENDING) {
+            ++$counts['pending'];
+        }
+
+        if ($status === Groups::STATUS_APPROVED && $membership_status === 'active') {
+            ++$counts['approved'];
+        }
+
+        if ($status === Groups::STATUS_REJECTED) {
+            ++$counts['rejected'];
+        }
+
+        if ($status === Groups::STATUS_ARCHIVED) {
+            ++$counts['archived'];
+        }
+    }
+
+    /**
+     * @return array{label: string, tone: string, message: string}
+     */
+    private function describe_group_status(string $status, string $membership_status, bool $is_owner): array
+    {
+        $label   = '';
+        $tone    = 'info';
+        $message = '';
+
+        switch ($status) {
+            case Groups::STATUS_APPROVED:
+                $label   = __('Aprovado', 'juntaplay');
+                $tone    = 'positive';
+                $message = __('Grupo disponível para convites e compras.', 'juntaplay');
+                break;
+            case Groups::STATUS_REJECTED:
+                $label   = __('Recusado', 'juntaplay');
+                $tone    = 'danger';
+                $message = __('Entre em contato com o suporte para revisar as informações do grupo.', 'juntaplay');
+                break;
+            case Groups::STATUS_ARCHIVED:
+                $label   = __('Arquivado', 'juntaplay');
+                $tone    = 'muted';
+                $message = __('Grupo arquivado e indisponível para novas cotas.', 'juntaplay');
+                break;
+            case Groups::STATUS_PENDING:
+            default:
+                $label   = __('Em análise', 'juntaplay');
+                $tone    = 'warning';
+                $message = __('Aguarde a aprovação do super administrador. Você será avisado por e-mail.', 'juntaplay');
+                break;
+        }
+
+        if (!$is_owner && $membership_status !== 'active') {
+            $label   = __('Convite pendente', 'juntaplay');
+            $tone    = 'warning';
+            $message = __('O administrador do grupo ainda precisa aprovar sua participação.', 'juntaplay');
+        }
+
+        return [
+            'label'   => $label,
+            'tone'    => $tone,
+            'message' => $message,
+        ];
+    }
+
+    private function format_group_role(string $role, bool $is_owner): string
+    {
+        if ($is_owner || $role === 'owner') {
+            return __('Criador do grupo', 'juntaplay');
+        }
+
+        if ($role === 'manager') {
+            return __('Organizador', 'juntaplay');
+        }
+
+        return __('Participante', 'juntaplay');
+    }
+
+    private function format_group_created_at(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        $diff = human_time_diff($time, current_time('timestamp'));
+
+        return sprintf(__('Criado há %s', 'juntaplay'), $diff);
+    }
+
+    private function format_group_reviewed_at(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        $diff = human_time_diff($time, current_time('timestamp'));
+
+        return sprintf(__('Atualizado há %s', 'juntaplay'), $diff);
+    }
+
+    private function build_group_pool_link(int $pool_id, string $pool_slug): string
+    {
+        if ($pool_slug !== '') {
+            return trailingslashit(home_url('/campanha/' . ltrim($pool_slug, '/')));
+        }
+
+        if ($pool_id > 0) {
+            $page_id = (int) get_option('juntaplay_page_campanhas');
+            $base    = $page_id > 0 ? (string) get_permalink($page_id) : trailingslashit(home_url('/campanhas'));
+
+            return add_query_arg('pool', $pool_id, $base);
+        }
+
+        return '';
+    }
+
+    private function format_tax_type(string $type): string
+    {
+        return $type === 'pj'
+            ? __('Pessoa jurídica', 'juntaplay')
+            : __('Pessoa física', 'juntaplay');
+    }
+
+    private function format_tax_document(string $document): string
+    {
+        $digits = preg_replace('/\D+/', '', $document);
+
+        if (strlen($digits) === 11) {
+            return substr($digits, 0, 3) . '.' . substr($digits, 3, 3) . '.' . substr($digits, 6, 3) . '-' . substr($digits, 9, 2);
+        }
+
+        if (strlen($digits) === 14) {
+            return substr($digits, 0, 2) . '.' . substr($digits, 2, 3) . '.' . substr($digits, 5, 3) . '/' . substr($digits, 8, 4) . '-' . substr($digits, 12, 2);
+        }
+
+        return $document;
+    }
+
+    private function format_postcode(string $postcode): string
+    {
+        $digits = preg_replace('/\D+/', '', $postcode);
+
+        if (strlen($digits) === 8) {
+            return substr($digits, 0, 5) . '-' . substr($digits, 5, 3);
+        }
+
+        return $postcode;
+    }
+
+    private function format_password_updated(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return __('Nunca atualizada', 'juntaplay');
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return __('Atualizada recentemente', 'juntaplay');
+        }
+
+        $diff = human_time_diff($time, current_time('timestamp'));
+
+        return sprintf(__('Atualizada há %s', 'juntaplay'), $diff);
+    }
+
+    private function format_two_factor_method(string $method): string
+    {
+        switch ($method) {
+            case 'email':
+                return __('Código por e-mail', 'juntaplay');
+            case 'whatsapp':
+                return __('Código por WhatsApp', 'juntaplay');
+            default:
+                return __('Desativada', 'juntaplay');
+        }
+    }
+
+    private function format_login_alerts(string $status): string
+    {
+        return $status === 'no'
+            ? __('Alertas desativados', 'juntaplay')
+            : __('Alertas por e-mail ativados', 'juntaplay');
+    }
+
+    private function format_sessions_count(int $count): string
+    {
+        if ($count < 1) {
+            $count = 1;
+        }
+
+        return sprintf(_n('%d sessão ativa', '%d sessões ativas', $count, 'juntaplay'), $count);
+    }
+
+    private function format_currency(float $amount): string
+    {
+        $formatted = number_format_i18n($amount, 2);
+
+        return sprintf('R$ %s', $formatted);
+    }
+
+    private function money_to_input(float $amount): string
+    {
+        if ($amount <= 0) {
+            return '';
+        }
+
+        return number_format_i18n($amount, 2);
+    }
+
+    private function parse_money(string $raw): float
+    {
+        $value = trim($raw);
+
+        if ($value === '') {
+            return 0.0;
+        }
+
+        $filtered = preg_replace('/[^0-9,\.\-]/', '', $value);
+        if (!is_string($filtered) || $filtered === '' || $filtered === '-') {
+            return 0.0;
+        }
+
+        $has_comma = strpos($filtered, ',') !== false;
+        $has_dot   = strpos($filtered, '.') !== false;
+
+        if ($has_comma && $has_dot) {
+            $filtered = str_replace('.', '', $filtered);
+            $filtered = str_replace(',', '.', $filtered);
+        } elseif ($has_comma) {
+            $filtered = str_replace(',', '.', $filtered);
+        }
+
+        return round((float) $filtered, 2);
+    }
+
+    /**
+     * @param string[] $hints
+     */
+    private function combine_hints(array $hints): string
+    {
+        $filtered = array_values(array_filter(array_map('trim', $hints)));
+
+        return $filtered ? implode(' • ', $filtered) : '';
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function format_credit_auto(array $data): string
+    {
+        if (($data['credit_auto_status'] ?? 'off') !== 'on') {
+            return __('Desativada', 'juntaplay');
+        }
+
+        $amount    = $this->format_currency((float) ($data['credit_auto_amount'] ?? 0.0));
+        $threshold = $this->format_currency((float) ($data['credit_auto_threshold'] ?? 0.0));
+
+        return sprintf(__('Recarga de %1$s quando o saldo ficar abaixo de %2$s', 'juntaplay'), $amount, $threshold);
+    }
+
+    private function format_credit_payment_method(string $method): string
+    {
+        switch ($method) {
+            case 'card':
+                return __('Cartão de crédito', 'juntaplay');
+            case 'boleto':
+                return __('Boleto bancário', 'juntaplay');
+            case 'pix':
+            default:
+                return __('Pix (instantâneo)', 'juntaplay');
+        }
+    }
+
+    private function format_credit_pix(string $key): string
+    {
+        if ($key === '') {
+            return __('Nenhuma chave cadastrada', 'juntaplay');
+        }
+
+        if (strlen($key) > 24) {
+            $prefix = function_exists('mb_substr') ? mb_substr($key, 0, 12) : substr($key, 0, 12);
+            $suffix = function_exists('mb_substr') ? mb_substr($key, -6) : substr($key, -6);
+
+            return $prefix . '…' . $suffix;
+        }
+
+        return $key;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function format_credit_bank(array $data): string
+    {
+        $holder      = (string) ($data['credit_bank_holder'] ?? '');
+        $document    = (string) ($data['credit_bank_document'] ?? '');
+        $bank        = (string) ($data['credit_bank_name'] ?? '');
+        $agency      = (string) ($data['credit_bank_agency'] ?? '');
+        $account     = (string) ($data['credit_bank_account'] ?? '');
+        $accountType = (string) ($data['credit_bank_account_type'] ?? 'checking');
+
+        if ($holder === '' && $bank === '' && $agency === '' && $account === '') {
+            return __('Nenhuma conta cadastrada', 'juntaplay');
+        }
+
+        $parts = [];
+
+        if ($holder !== '') {
+            $parts[] = $holder;
+        }
+
+        if ($bank !== '') {
+            $parts[] = $bank;
+        }
+
+        if ($agency !== '') {
+            $parts[] = sprintf(__('Ag. %s', 'juntaplay'), $agency);
+        }
+
+        if ($account !== '') {
+            $parts[] = sprintf(__('Conta %1$s (%2$s)', 'juntaplay'), $account, $this->format_credit_account_type($accountType));
+        }
+
+        if ($document !== '') {
+            $parts[] = sprintf(__('Doc: %s', 'juntaplay'), $this->format_tax_document($document));
+        }
+
+        return implode(' • ', $parts);
+    }
+
+    private function format_credit_account_type(string $type): string
+    {
+        return $type === 'savings'
+            ? __('Poupança', 'juntaplay')
+            : __('Corrente', 'juntaplay');
+    }
+
+    private function format_credit_bonus_hint(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        $now = current_time('timestamp');
+
+        if ($time <= $now) {
+            return __('Bônus expirado', 'juntaplay');
+        }
+
+        $date = date_i18n(get_option('date_format'), $time);
+
+        return sprintf(__('Expira em %s', 'juntaplay'), $date);
+    }
+
+    private function format_credit_updated_at(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        $format = trim((string) get_option('date_format') . ' ' . (string) get_option('time_format'));
+
+        return sprintf(__('Atualizado em %s', 'juntaplay'), date_i18n($format, $time));
+    }
+
+    private function format_credit_last_recharge(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        return sprintf(__('Última recarga em %s', 'juntaplay'), date_i18n(get_option('date_format'), $time));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    private function build_credit_history_context(array $data): array
+    {
+        $user_id = get_current_user_id();
+
+        $deposit_enabled = class_exists('WooCommerce');
+        $deposit_min     = (float) apply_filters('juntaplay/credits/deposit_min', 25.0, $user_id);
+        $deposit_max     = (float) apply_filters('juntaplay/credits/deposit_max', 5000.0, $user_id);
+        $suggestions_raw = apply_filters('juntaplay/credits/deposit_suggestions', [50, 100, 150], $user_id);
+
+        $suggestions = [];
+        if (is_array($suggestions_raw)) {
+            foreach ($suggestions_raw as $value) {
+                if (is_numeric($value)) {
+                    $float = (float) $value;
+                    if ($float > 0) {
+                        $suggestions[] = $float;
+                    }
+                }
+            }
+        }
+
+        $context = [
+            'transactions'     => [],
+            'pagination'       => ['page' => 1, 'pages' => 1, 'total' => 0],
+            'withdrawals'      => [],
+            'two_factor'       => [
+                'method'        => 'email',
+                'label'         => $this->format_two_factor_label('email'),
+                'destination'   => '',
+                'code_expires'  => '',
+                'code_remaining'=> 0,
+            ],
+            'has_pix'          => !empty($data['credit_pix_key']),
+            'has_bank'         => !empty($data['credit_bank_holder']) && !empty($data['credit_bank_account']),
+            'balance_label'    => $this->format_currency((float) ($data['credit_balance'] ?? 0.0)),
+            'reserved_label'   => $this->format_currency((float) ($data['credit_reserved'] ?? 0.0)),
+            'bonus_label'      => $this->format_currency((float) ($data['credit_bonus'] ?? 0.0)),
+            'withdraw_pending' => $this->format_currency((float) ($data['credit_withdraw_pending'] ?? 0.0)),
+            'deposit'          => [
+                'enabled'     => $deposit_enabled,
+                'min'         => $this->format_currency($deposit_min),
+                'min_raw'     => $deposit_min,
+                'max'         => $deposit_max > 0 ? $this->format_currency($deposit_max) : '',
+                'max_raw'     => $deposit_max,
+                'suggestions' => array_map(fn (float $value): array => [
+                    'value' => $value,
+                    'label' => $this->format_currency($value),
+                ], $suggestions),
+            ],
+        ];
+
+        if (!$user_id) {
+            return $context;
+        }
+
+        $transactions_page = CreditTransactions::get_for_user($user_id, 1, 10, []);
+        $transactions      = [];
+
+        foreach ($transactions_page['items'] as $transaction) {
+            if (is_array($transaction)) {
+                $transactions[] = $this->decorate_transaction_entry($transaction);
+            }
+        }
+
+        $withdrawals = [];
+        foreach (CreditWithdrawals::get_for_user($user_id, 6) as $withdrawal) {
+            if (is_array($withdrawal)) {
+                $withdrawals[] = $this->decorate_withdrawal_entry($withdrawal);
+            }
+        }
+
+        $method = isset($data['two_factor_method']) ? (string) $data['two_factor_method'] : 'email';
+        if (!in_array($method, ['email', 'whatsapp'], true)) {
+            $method = 'email';
+        }
+
+        $current_user   = wp_get_current_user();
+        $fallback_email = $current_user instanceof WP_User ? (string) $current_user->user_email : '';
+        $destination    = $this->resolve_two_factor_destination($method, $data, $fallback_email);
+
+        $code_expires = isset($data['withdraw_code_expires'])
+            ? (int) $data['withdraw_code_expires']
+            : (int) get_user_meta($user_id, 'juntaplay_withdraw_code_expires', true);
+        $remaining    = $code_expires > 0 ? max(0, $code_expires - time()) : 0;
+
+        $context['transactions'] = $transactions;
+        $context['pagination']   = [
+            'page'  => $transactions_page['page'],
+            'pages' => $transactions_page['pages'],
+            'total' => $transactions_page['total'],
+        ];
+        $context['withdrawals']  = $withdrawals;
+        $context['two_factor']   = [
+            'method'        => $method,
+            'label'         => $this->format_two_factor_label($method),
+            'destination'   => $destination,
+            'code_expires'  => $code_expires > 0 ? gmdate('c', $code_expires) : '',
+            'code_remaining'=> $remaining,
+        ];
+
+        return $context;
+    }
+
+    /**
+     * @param array<string, mixed> $transaction
+     * @return array<string, mixed>
+     */
+    private function decorate_transaction_entry(array $transaction): array
+    {
+        $amount = isset($transaction['amount']) ? (float) $transaction['amount'] : 0.0;
+        $type   = (string) ($transaction['type'] ?? CreditTransactions::TYPE_ADJUSTMENT);
+        $status = (string) ($transaction['status'] ?? CreditTransactions::STATUS_COMPLETED);
+
+        return [
+            'id'            => isset($transaction['id']) ? (int) $transaction['id'] : 0,
+            'type'          => $type,
+            'type_label'    => $this->format_transaction_type_label($type),
+            'status'        => $status,
+            'status_label'  => $this->format_transaction_status_label($status),
+            'amount'        => $this->format_currency($amount),
+            'amount_raw'    => $amount,
+            'reference'     => (string) ($transaction['reference'] ?? ''),
+            'time'          => $this->format_datetime((string) ($transaction['created_at'] ?? '')),
+            'created_at'    => (string) ($transaction['created_at'] ?? ''),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $withdrawal
+     * @return array<string, mixed>
+     */
+    private function decorate_withdrawal_entry(array $withdrawal): array
+    {
+        $amount      = isset($withdrawal['amount']) ? (float) $withdrawal['amount'] : 0.0;
+        $status      = (string) ($withdrawal['status'] ?? CreditWithdrawals::STATUS_PENDING);
+        $destination = [];
+
+        if (isset($withdrawal['destination']) && is_array($withdrawal['destination'])) {
+            $destination = $withdrawal['destination'];
+        }
+
+        return [
+            'id'          => isset($withdrawal['id']) ? (int) $withdrawal['id'] : 0,
+            'status'      => $status,
+            'status_label'=> $this->format_withdrawal_status($status),
+            'amount'      => $this->format_currency($amount),
+            'reference'   => (string) ($withdrawal['reference'] ?? ''),
+            'time'        => $this->format_datetime((string) ($withdrawal['requested_at'] ?? '')),
+            'destination' => $this->format_withdraw_destination_label($destination),
+        ];
+    }
+
+    private function format_transaction_type_label(string $type): string
+    {
+        return match ($type) {
+            CreditTransactions::TYPE_DEPOSIT    => __('Entrada de créditos', 'juntaplay'),
+            CreditTransactions::TYPE_WITHDRAWAL => __('Retirada', 'juntaplay'),
+            CreditTransactions::TYPE_BONUS      => __('Bônus promocional', 'juntaplay'),
+            CreditTransactions::TYPE_PURCHASE   => __('Compra de cotas', 'juntaplay'),
+            CreditTransactions::TYPE_REFUND     => __('Reembolso', 'juntaplay'),
+            default                             => __('Ajuste de saldo', 'juntaplay'),
+        };
+    }
+
+    private function format_transaction_status_label(string $status): string
+    {
+        return match ($status) {
+            CreditTransactions::STATUS_PENDING => __('Pendente', 'juntaplay'),
+            CreditTransactions::STATUS_FAILED  => __('Cancelado', 'juntaplay'),
+            default                            => __('Concluído', 'juntaplay'),
+        };
+    }
+
+    private function format_withdrawal_status(string $status): string
+    {
+        return match ($status) {
+            CreditWithdrawals::STATUS_PENDING    => __('Em análise', 'juntaplay'),
+            CreditWithdrawals::STATUS_PROCESSING => __('Processando', 'juntaplay'),
+            CreditWithdrawals::STATUS_APPROVED   => __('Pago', 'juntaplay'),
+            CreditWithdrawals::STATUS_REJECTED   => __('Recusado', 'juntaplay'),
+            CreditWithdrawals::STATUS_CANCELED   => __('Cancelado', 'juntaplay'),
+            default                              => __('Em análise', 'juntaplay'),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $destination
+     */
+    private function format_withdraw_destination_label(array $destination): string
+    {
+        $method = isset($destination['method']) ? (string) $destination['method'] : 'pix';
+
+        if ($method === 'pix') {
+            return $this->format_credit_pix((string) ($destination['pix_key'] ?? ''));
+        }
+
+        $parts = [];
+        if (!empty($destination['bank'])) {
+            $parts[] = (string) $destination['bank'];
+        }
+        if (!empty($destination['agency'])) {
+            $parts[] = sprintf(__('Ag. %s', 'juntaplay'), (string) $destination['agency']);
+        }
+        if (!empty($destination['account'])) {
+            $parts[] = sprintf(__('Conta %s', 'juntaplay'), (string) $destination['account']);
+        }
+
+        return $parts ? implode(' • ', $parts) : __('Conta bancária cadastrada', 'juntaplay');
+    }
+
+    private function format_datetime(string $timestamp): string
+    {
+        if ($timestamp === '') {
+            return '';
+        }
+
+        $time = strtotime($timestamp);
+
+        if (!$time) {
+            return '';
+        }
+
+        $format = trim((string) get_option('date_format') . ' ' . (string) get_option('time_format'));
+
+        return date_i18n($format, $time);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function resolve_two_factor_destination(string $method, array $data, string $fallback_email): string
+    {
+        if ($method === 'whatsapp') {
+            $phone = isset($data['whatsapp']) ? (string) $data['whatsapp'] : '';
+            if ($phone === '') {
+                $phone = isset($data['phone']) ? (string) $data['phone'] : '';
+            }
+
+            if ($phone !== '') {
+                return $this->mask_phone($phone);
+            }
+        }
+
+        if ($fallback_email !== '') {
+            return $this->mask_email($fallback_email);
+        }
+
+        return '';
+    }
+
+    private function format_two_factor_label(string $method): string
+    {
+        return match ($method) {
+            'whatsapp' => __('Código por WhatsApp', 'juntaplay'),
+            'email'    => __('Código por e-mail', 'juntaplay'),
+            default    => __('Desativada', 'juntaplay'),
+        };
+    }
+
+    private function mask_email(string $email): string
+    {
+        if (!is_email($email)) {
+            return $email;
+        }
+
+        [$local, $domain] = explode('@', $email, 2);
+        $length = strlen($local);
+
+        if ($length <= 2) {
+            $masked = str_repeat('*', $length);
+        } else {
+            $masked = substr($local, 0, 2) . str_repeat('*', max(1, $length - 2));
+        }
+
+        return $masked . '@' . $domain;
+    }
+
+    private function mask_phone(string $phone): string
+    {
+        $digits = $this->normalize_phone($phone);
+
+        if ($digits === '') {
+            return $phone;
+        }
+
+        $last = substr($digits, -4);
+
+        if (strlen($digits) >= 11) {
+            $ddd = substr($digits, 0, 2);
+
+            return sprintf('(%s) *****-%s', $ddd, $last);
+        }
+
+        return sprintf('****-%s', $last);
+    }
+
+    private function normalize_phone(string $phone): string
+    {
+        $digits = preg_replace('/\D+/', '', $phone);
+
+        return is_string($digits) ? $digits : '';
+    }
+
+    private function build_withdraw_destination(int $user_id, string $method): array
+    {
+        if ($method === 'bank') {
+            return [
+                'method'       => 'bank',
+                'holder'       => (string) get_user_meta($user_id, 'juntaplay_credit_bank_holder', true),
+                'document'     => (string) get_user_meta($user_id, 'juntaplay_credit_bank_document', true),
+                'bank'         => (string) get_user_meta($user_id, 'juntaplay_credit_bank_name', true),
+                'agency'       => (string) get_user_meta($user_id, 'juntaplay_credit_bank_agency', true),
+                'account'      => (string) get_user_meta($user_id, 'juntaplay_credit_bank_account', true),
+                'account_type' => (string) get_user_meta($user_id, 'juntaplay_credit_bank_account_type', true),
+            ];
+        }
+
+        return [
+            'method'  => 'pix',
+            'pix_key' => (string) get_user_meta($user_id, 'juntaplay_credit_pix_key', true),
+        ];
+    }
+
+    private function parse_decimal(string $value): float
+    {
+        $normalized = preg_replace('/[^0-9,.-]/', '', $value);
+
+        if ($normalized === null || $normalized === '' || $normalized === '-' || $normalized === '--') {
+            return 0.0;
+        }
+
+        $comma = strrpos($normalized, ',');
+        $dot   = strrpos($normalized, '.');
+
+        if ($comma !== false && $dot !== false) {
+            if ($comma > $dot) {
+                $normalized = str_replace('.', '', $normalized);
+                $normalized = str_replace(',', '.', $normalized);
+            } else {
+                $normalized = str_replace(',', '', $normalized);
+            }
+        } elseif ($comma !== false) {
+            $normalized = str_replace(',', '.', $normalized);
+        }
+
+        return (float) $normalized;
+    }
+
+    private function format_decimal(float $value): string
+    {
+        return number_format($value, 2, '.', '');
+    }
+
+    private function store_decimal(float $value): string
+    {
+        return number_format($value, 2, '.', '');
+    }
+
+    private function to_float($value): float
+    {
+        if (is_array($value)) {
+            $value = reset($value);
+        }
+
+        if (is_string($value)) {
+            $value = str_replace(',', '.', preg_replace('/[^0-9,.-]/', '', $value) ?? '0');
+        }
+
+        return (float) $value;
+    }
+
+    private function get_sessions_count(WP_User $user): int
+    {
+        if (!class_exists(WP_Session_Tokens::class)) {
+            return 1;
+        }
+
+        $manager = WP_Session_Tokens::get_instance($user->ID);
+
+        if (!$manager) {
+            return 1;
+        }
+
+        $sessions = $manager->get_all();
+
+        if (!is_array($sessions)) {
+            return 1;
+        }
+
+        $count = count($sessions);
+
+        return $count > 0 ? $count : 1;
+    }
+
+    private function update_name(int $user_id): void
+    {
+        $name = isset($_POST['jp_profile_name'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_name'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($name === '') {
+            $this->add_error('name', __('Informe seu nome completo.', 'juntaplay'));
+
+            return;
+        }
+
+        $updated = wp_update_user([
+            'ID'           => $user_id,
+            'display_name' => $name,
+            'first_name'   => $name,
+        ]);
+
+        if ($updated instanceof WP_Error) {
+            $this->add_error('name', $updated->get_error_message());
+
+            return;
+        }
+
+        update_user_meta($user_id, 'first_name', $name);
+        update_user_meta($user_id, 'billing_first_name', $name);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Nome atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'name', ['name' => $name]);
+    }
+
+    private function update_email(int $user_id): void
+    {
+        $email = isset($_POST['jp_profile_email'])
+            ? sanitize_email(wp_unslash($_POST['jp_profile_email'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($email === '' || !is_email($email)) {
+            $this->add_error('email', __('Informe um e-mail válido.', 'juntaplay'));
+
+            return;
+        }
+
+        $existing = email_exists($email);
+        if ($existing && (int) $existing !== $user_id) {
+            $this->add_error('email', __('Este e-mail já está em uso.', 'juntaplay'));
+
+            return;
+        }
+
+        $updated = wp_update_user([
+            'ID'         => $user_id,
+            'user_email' => $email,
+        ]);
+
+        if ($updated instanceof WP_Error) {
+            $this->add_error('email', $updated->get_error_message());
+
+            return;
+        }
+
+        $this->invalidate_cache();
+        $this->add_notice(__('E-mail atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'email', ['email' => $email]);
+    }
+
+    private function update_phone(int $user_id): void
+    {
+        $phone = isset($_POST['jp_profile_phone'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_phone'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($phone === '') {
+            $this->add_error('phone', __('Informe um telefone para contato.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_phone', $phone);
+        update_user_meta($user_id, 'phone', $phone);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Telefone atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'phone', ['phone' => $phone]);
+    }
+
+    private function update_whatsapp(int $user_id): void
+    {
+        $whatsapp = isset($_POST['jp_profile_whatsapp'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_whatsapp'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($whatsapp === '') {
+            $this->add_error('whatsapp', __('Informe um número de WhatsApp válido.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_whatsapp', $whatsapp);
+        update_user_meta($user_id, 'billing_whatsapp', $whatsapp);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('WhatsApp atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'whatsapp', ['whatsapp' => $whatsapp]);
+    }
+
+    private function update_tax_type(int $user_id): void
+    {
+        $type = isset($_POST['jp_profile_tax_type'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_tax_type'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if (!in_array($type, ['pf', 'pj'], true)) {
+            $this->add_error('tax_type', __('Selecione o tipo de cadastro.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_tax_type', $type);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Tipo de cadastro atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_type', ['tax_type' => $type]);
+    }
+
+    private function update_tax_document(int $user_id): void
+    {
+        $document = isset($_POST['jp_profile_tax_document'])
+            ? preg_replace('/\D+/', '', wp_unslash($_POST['jp_profile_tax_document'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $document = is_string($document) ? $document : '';
+
+        if ($document === '') {
+            $this->add_error('tax_document', __('Informe um CPF ou CNPJ válido.', 'juntaplay'));
+
+            return;
+        }
+
+        $length = strlen($document);
+        if (!in_array($length, [11, 14], true)) {
+            $this->add_error('tax_document', __('O CPF/CNPJ deve conter 11 ou 14 dígitos.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_tax_document', $document);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Documento fiscal atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_document', ['tax_document' => $document]);
+    }
+
+    private function update_tax_company(int $user_id): void
+    {
+        $company = isset($_POST['jp_profile_tax_company'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_tax_company'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $type = (string) get_user_meta($user_id, 'juntaplay_tax_type', true);
+
+        if ($type === 'pj' && $company === '') {
+            $this->add_error('tax_company', __('Informe a razão social da empresa.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_company', $company);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Dados da empresa atualizados com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_company', ['tax_company' => $company]);
+    }
+
+    private function update_tax_state_registration(int $user_id): void
+    {
+        $state_registration = isset($_POST['jp_profile_tax_state_registration'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_tax_state_registration'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        update_user_meta($user_id, 'juntaplay_tax_state_registration', $state_registration);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Inscrição estadual atualizada com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action(
+            'juntaplay/profile/updated',
+            $user_id,
+            'tax_state_registration',
+            ['tax_state_registration' => $state_registration]
+        );
+    }
+
+    private function update_tax_address(int $user_id): void
+    {
+        $address = isset($_POST['jp_profile_tax_address'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_tax_address'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($address === '') {
+            $this->add_error('tax_address', __('Informe o endereço utilizado para faturamento.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_address_1', $address);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Endereço atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_address', ['tax_address' => $address]);
+    }
+
+    private function update_tax_city(int $user_id): void
+    {
+        $city = isset($_POST['jp_profile_tax_city'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_tax_city'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($city === '') {
+            $this->add_error('tax_city', __('Informe a cidade para faturamento.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_city', $city);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Cidade atualizada com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_city', ['tax_city' => $city]);
+    }
+
+    private function update_tax_state(int $user_id): void
+    {
+        $state = isset($_POST['jp_profile_tax_state'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_tax_state'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $state = strtoupper($state);
+
+        if ($state === '' || strlen($state) > 2) {
+            $this->add_error('tax_state', __('Informe a sigla do estado (UF).', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_state', $state);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Estado atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_state', ['tax_state' => $state]);
+    }
+
+    private function update_tax_postcode(int $user_id): void
+    {
+        $postcode = isset($_POST['jp_profile_tax_postcode'])
+            ? preg_replace('/\D+/', '', wp_unslash($_POST['jp_profile_tax_postcode'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $postcode = is_string($postcode) ? $postcode : '';
+
+        if ($postcode === '' || strlen($postcode) < 5) {
+            $this->add_error('tax_postcode', __('Informe um CEP válido.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'billing_postcode', $postcode);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('CEP atualizado com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'tax_postcode', ['tax_postcode' => $postcode]);
+    }
+
+    private function update_password(int $user_id): void
+    {
+        $user = wp_get_current_user();
+
+        if (!$user instanceof WP_User || (int) $user->ID !== $user_id) {
+            $this->add_error('password', __('Não foi possível validar o usuário autenticado.', 'juntaplay'));
+
+            return;
+        }
+
+        $current = isset($_POST['jp_profile_password_current'])
+            ? (string) wp_unslash($_POST['jp_profile_password_current']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $new_password = isset($_POST['jp_profile_password_new'])
+            ? (string) wp_unslash($_POST['jp_profile_password_new']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $confirm = isset($_POST['jp_profile_password_confirm'])
+            ? (string) wp_unslash($_POST['jp_profile_password_confirm']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        if ($current === '' || !wp_check_password($current, $user->user_pass, $user_id)) {
+            $this->add_error('password', __('A senha atual não confere.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($new_password === '') {
+            $this->add_error('password', __('Informe a nova senha.', 'juntaplay'));
+
+            return;
+        }
+
+        if (strlen($new_password) < 8) {
+            $this->add_error('password', __('A nova senha deve ter pelo menos 8 caracteres.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($new_password === $current) {
+            $this->add_error('password', __('A nova senha deve ser diferente da senha atual.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($new_password !== $confirm) {
+            $this->add_error('password', __('As senhas informadas não coincidem.', 'juntaplay'));
+
+            return;
+        }
+
+        $result = wp_update_user([
+            'ID'        => $user_id,
+            'user_pass' => $new_password,
+        ]);
+
+        if ($result instanceof WP_Error) {
+            $this->add_error('password', $result->get_error_message());
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_password_changed_at', current_time('mysql'));
+
+        if (function_exists('wp_destroy_other_sessions')) {
+            wp_destroy_other_sessions();
+        } elseif (class_exists(WP_Session_Tokens::class)) {
+            $token = wp_get_session_token();
+            if ($token) {
+                $manager = WP_Session_Tokens::get_instance($user_id);
+                if ($manager) {
+                    $manager->destroy_other_sessions($token);
+                }
+            }
+        }
+
+        if (function_exists('wp_set_auth_cookie')) {
+            wp_set_auth_cookie($user_id);
+        }
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Senha atualizada com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'password', []);
+    }
+
+    private function update_two_factor(int $user_id): void
+    {
+        $method = isset($_POST['jp_profile_two_factor'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_two_factor'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'off';
+
+        if (!in_array($method, ['off', 'email', 'whatsapp'], true)) {
+            $this->add_error('two_factor', __('Selecione uma opção válida.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_two_factor_method', $method);
+
+        $this->invalidate_cache();
+        $this->add_notice(
+            $method === 'off'
+                ? __('Verificação em duas etapas desativada.', 'juntaplay')
+                : __('Verificação em duas etapas atualizada.', 'juntaplay')
+        );
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'two_factor', ['two_factor' => $method]);
+    }
+
+    private function update_login_alerts(int $user_id): void
+    {
+        $status = isset($_POST['jp_profile_login_alerts'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_login_alerts'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'yes';
+
+        if (!in_array($status, ['yes', 'no'], true)) {
+            $this->add_error('login_alerts', __('Selecione uma opção válida.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_login_alerts', $status);
+
+        $this->invalidate_cache();
+        $this->add_notice(
+            $status === 'no'
+                ? __('Alertas de login desativados.', 'juntaplay')
+                : __('Alertas de login ativados.', 'juntaplay')
+        );
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'login_alerts', ['login_alerts' => $status]);
+    }
+
+    private function update_credit_auto(int $user_id): void
+    {
+        $status = isset($_POST['jp_profile_credit_auto_status'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_credit_auto_status'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'off';
+
+        if ($status !== 'on') {
+            $status = 'off';
+        }
+
+        $amount_raw = isset($_POST['jp_profile_credit_auto_amount'])
+            ? wp_unslash($_POST['jp_profile_credit_auto_amount']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $threshold_raw = isset($_POST['jp_profile_credit_auto_threshold'])
+            ? wp_unslash($_POST['jp_profile_credit_auto_threshold']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $amount    = is_string($amount_raw) ? $this->parse_decimal($amount_raw) : 0.0;
+        $threshold = is_string($threshold_raw) ? $this->parse_decimal($threshold_raw) : 0.0;
+
+        if ($status === 'on' && $amount <= 0) {
+            $this->add_error('credit_auto', __('Informe um valor de recarga válido.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($status === 'on' && $threshold < 0) {
+            $this->add_error('credit_auto', __('O saldo mínimo não pode ser negativo.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($amount < 0) {
+            $amount = 0.0;
+        }
+
+        $threshold = max(0.0, $threshold);
+
+        update_user_meta($user_id, 'juntaplay_credit_auto_status', $status);
+        update_user_meta($user_id, 'juntaplay_credit_auto_amount', $this->store_decimal($amount));
+        update_user_meta($user_id, 'juntaplay_credit_auto_threshold', $this->store_decimal($threshold));
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Preferências de recarga automática atualizadas.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action(
+            'juntaplay/profile/updated',
+            $user_id,
+            'credit_auto',
+            [
+                'status'    => $status,
+                'amount'    => $amount,
+                'threshold' => $threshold,
+            ]
+        );
+    }
+
+    private function update_credit_payment_method(int $user_id): void
+    {
+        $method = isset($_POST['jp_profile_credit_payment_method'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_credit_payment_method'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'pix';
+
+        if (!in_array($method, ['pix', 'card', 'boleto'], true)) {
+            $this->add_error('credit_payment_method', __('Selecione uma forma de pagamento válida.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_credit_payment_method', $method);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Forma de pagamento preferida atualizada.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'credit_payment_method', ['method' => $method]);
+    }
+
+    private function update_credit_pix_key(int $user_id): void
+    {
+        $key = isset($_POST['jp_profile_credit_pix_key'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_credit_pix_key'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $key = trim($key);
+
+        if ($key !== '' && strlen($key) < 6) {
+            $this->add_error('credit_pix_key', __('Informe uma chave Pix válida.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_credit_pix_key', $key);
+
+        $this->invalidate_cache();
+        $this->add_notice(
+            $key === ''
+                ? __('Chave Pix removida.', 'juntaplay')
+                : __('Chave Pix atualizada com sucesso.', 'juntaplay')
+        );
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'credit_pix_key', ['key' => $key]);
+    }
+
+    private function update_credit_bank_account(int $user_id): void
+    {
+        $holder = isset($_POST['jp_profile_credit_bank_holder'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_credit_bank_holder'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $document_raw = isset($_POST['jp_profile_credit_bank_document'])
+            ? wp_unslash($_POST['jp_profile_credit_bank_document']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $document = is_string($document_raw) ? preg_replace('/\D+/', '', $document_raw) : '';
+        $bank_type = isset($_POST['jp_profile_credit_bank_type'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_credit_bank_type'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'pf';
+        $bank = isset($_POST['jp_profile_credit_bank_name'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_credit_bank_name'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $agency_raw = isset($_POST['jp_profile_credit_bank_agency'])
+            ? wp_unslash($_POST['jp_profile_credit_bank_agency']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $agency = is_string($agency_raw) ? preg_replace('/[^0-9-]/', '', $agency_raw) : '';
+        $account_raw = isset($_POST['jp_profile_credit_bank_account'])
+            ? wp_unslash($_POST['jp_profile_credit_bank_account']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $account = is_string($account_raw) ? preg_replace('/[^0-9-]/', '', $account_raw) : '';
+        $account_type = isset($_POST['jp_profile_credit_bank_account_type'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_credit_bank_account_type'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'checking';
+
+        if (!in_array($bank_type, ['pf', 'pj'], true)) {
+            $bank_type = 'pf';
+        }
+
+        if (!in_array($account_type, ['checking', 'savings'], true)) {
+            $account_type = 'checking';
+        }
+
+        $all_empty = $holder === '' && ($document === '' || $document === null)
+            && $bank === '' && $agency === '' && $account === '';
+
+        if ($all_empty) {
+            update_user_meta($user_id, 'juntaplay_credit_bank_holder', '');
+            update_user_meta($user_id, 'juntaplay_credit_bank_document', '');
+            update_user_meta($user_id, 'juntaplay_credit_bank_type', 'pf');
+            update_user_meta($user_id, 'juntaplay_credit_bank_name', '');
+            update_user_meta($user_id, 'juntaplay_credit_bank_agency', '');
+            update_user_meta($user_id, 'juntaplay_credit_bank_account', '');
+            update_user_meta($user_id, 'juntaplay_credit_bank_account_type', 'checking');
+
+            $this->invalidate_cache();
+            $this->add_notice(__('Dados bancários removidos.', 'juntaplay'));
+            $this->active_section = null;
+
+            do_action('juntaplay/profile/updated', $user_id, 'credit_bank_account', ['removed' => true]);
+
+            return;
+        }
+
+        if ($holder === '' || $bank === '' || $agency === '' || $account === '') {
+            $this->add_error('credit_bank_account', __('Preencha todos os campos obrigatórios.', 'juntaplay'));
+
+            return;
+        }
+
+        if (!is_string($document) || $document === '' || !in_array(strlen($document), [11, 14], true)) {
+            $this->add_error('credit_bank_account', __('Informe um CPF ou CNPJ válido do titular.', 'juntaplay'));
+
+            return;
+        }
+
+        update_user_meta($user_id, 'juntaplay_credit_bank_holder', $holder);
+        update_user_meta($user_id, 'juntaplay_credit_bank_document', $document);
+        update_user_meta($user_id, 'juntaplay_credit_bank_type', $bank_type);
+        update_user_meta($user_id, 'juntaplay_credit_bank_name', $bank);
+        update_user_meta($user_id, 'juntaplay_credit_bank_agency', $agency);
+        update_user_meta($user_id, 'juntaplay_credit_bank_account', $account);
+        update_user_meta($user_id, 'juntaplay_credit_bank_account_type', $account_type);
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Dados bancários atualizados.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action(
+            'juntaplay/profile/updated',
+            $user_id,
+            'credit_bank_account',
+            [
+                'bank'          => $bank,
+                'agency'        => $agency,
+                'account'       => $account,
+                'account_type'  => $account_type,
+                'bank_type'     => $bank_type,
+                'holder'        => $holder,
+                'document'      => $document,
+            ]
+        );
+    }
+
+    private function submit_credit_withdrawal_form(int $user_id): void
+    {
+        $amount_raw = isset($_POST['jp_profile_withdraw_amount'])
+            ? wp_unslash($_POST['jp_profile_withdraw_amount']) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+        $method = isset($_POST['jp_profile_withdraw_method'])
+            ? sanitize_key(wp_unslash($_POST['jp_profile_withdraw_method'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : 'pix';
+        $code = isset($_POST['jp_profile_withdraw_code'])
+            ? sanitize_text_field(wp_unslash($_POST['jp_profile_withdraw_code'])) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            : '';
+
+        $result = $this->handle_withdrawal_request($user_id, [
+            'amount' => $amount_raw,
+            'method' => $method,
+            'code'   => $code,
+            'context' => 'form',
+        ]);
+
+        if (!empty($result['error'])) {
+            $this->add_error('credit_withdrawal', (string) $result['error']);
+            $this->active_section = 'credit_history';
+
+            return;
+        }
+
+        $this->notices[] = (string) ($result['message'] ?? __('Solicitação registrada com sucesso.', 'juntaplay'));
+        $this->active_section = null;
+    }
+
+    private function create_group(int $user_id): void
+    {
+        $name_raw        = isset($_POST['jp_profile_group_name']) ? wp_unslash($_POST['jp_profile_group_name']) : '';
+        $pool_raw        = isset($_POST['jp_profile_group_pool']) ? wp_unslash($_POST['jp_profile_group_pool']) : '';
+        $description_raw = isset($_POST['jp_profile_group_description']) ? wp_unslash($_POST['jp_profile_group_description']) : '';
+        $service_raw     = isset($_POST['jp_profile_group_service']) ? wp_unslash($_POST['jp_profile_group_service']) : '';
+        $service_url_raw = isset($_POST['jp_profile_group_service_url']) ? wp_unslash($_POST['jp_profile_group_service_url']) : '';
+        $rules_raw       = isset($_POST['jp_profile_group_rules']) ? wp_unslash($_POST['jp_profile_group_rules']) : '';
+        $cover_raw       = isset($_POST['jp_profile_group_cover']) ? wp_unslash($_POST['jp_profile_group_cover']) : '';
+        $price_raw       = isset($_POST['jp_profile_group_price']) ? wp_unslash($_POST['jp_profile_group_price']) : '';
+        $promo_toggle    = isset($_POST['jp_profile_group_promo_toggle']) ? wp_unslash($_POST['jp_profile_group_promo_toggle']) : '';
+        $promo_raw       = isset($_POST['jp_profile_group_price_promo']) ? wp_unslash($_POST['jp_profile_group_price_promo']) : '';
+        $total_raw       = isset($_POST['jp_profile_group_slots_total']) ? wp_unslash($_POST['jp_profile_group_slots_total']) : '';
+        $reserved_raw    = isset($_POST['jp_profile_group_slots_reserved']) ? wp_unslash($_POST['jp_profile_group_slots_reserved']) : '';
+        $member_raw      = isset($_POST['jp_profile_group_member_price']) ? wp_unslash($_POST['jp_profile_group_member_price']) : '';
+        $support_raw     = isset($_POST['jp_profile_group_support']) ? wp_unslash($_POST['jp_profile_group_support']) : '';
+        $delivery_raw    = isset($_POST['jp_profile_group_delivery']) ? wp_unslash($_POST['jp_profile_group_delivery']) : '';
+        $access_raw      = isset($_POST['jp_profile_group_access']) ? wp_unslash($_POST['jp_profile_group_access']) : '';
+        $category_raw    = isset($_POST['jp_profile_group_category']) ? wp_unslash($_POST['jp_profile_group_category']) : '';
+        $instant_raw     = isset($_POST['jp_profile_group_instant']) ? wp_unslash($_POST['jp_profile_group_instant']) : '';
+
+        $name        = sanitize_text_field(is_string($name_raw) ? $name_raw : '');
+        $service     = sanitize_text_field(is_string($service_raw) ? $service_raw : '');
+        $service_url = esc_url_raw(is_string($service_url_raw) ? $service_url_raw : '');
+        $rules       = sanitize_textarea_field(is_string($rules_raw) ? $rules_raw : '');
+        $pool_id     = absint(is_string($pool_raw) ? $pool_raw : 0);
+        $description = sanitize_textarea_field(is_string($description_raw) ? $description_raw : '');
+        $support     = sanitize_text_field(is_string($support_raw) ? $support_raw : '');
+        $delivery    = sanitize_text_field(is_string($delivery_raw) ? $delivery_raw : '');
+        $access      = sanitize_text_field(is_string($access_raw) ? $access_raw : '');
+        $cover_id       = absint(is_string($cover_raw) ? $cover_raw : 0);
+        $category_input = sanitize_key(is_string($category_raw) ? $category_raw : '');
+        $categories     = array_keys($this->get_group_categories());
+        $category       = in_array($category_input, $categories, true) ? $category_input : 'other';
+        $instant_access = is_string($instant_raw) ? sanitize_key((string) $instant_raw) === 'on' : false;
+
+        $price_value   = $this->parse_money(is_string($price_raw) ? (string) $price_raw : '');
+        $promo_enabled = is_string($promo_toggle) ? sanitize_key((string) $promo_toggle) === 'on' : false;
+        $promo_value   = $promo_enabled ? $this->parse_money(is_string($promo_raw) ? (string) $promo_raw : '') : 0.0;
+        $promo_value   = $promo_enabled && $promo_value > 0 ? $promo_value : 0.0;
+
+        $slots_total    = absint(is_string($total_raw) ? $total_raw : 0);
+        $slots_reserved = absint(is_string($reserved_raw) ? $reserved_raw : 0);
+
+        $member_input_provided = is_string($member_raw) && trim((string) $member_raw) !== '';
+        $member_value          = $member_input_provided
+            ? $this->parse_money((string) $member_raw)
+            : 0.0;
+
+        $available_slots = max(1, $slots_total - $slots_reserved);
+        $price_basis     = $promo_value > 0 ? $promo_value : $price_value;
+        if ($member_value <= 0) {
+            $member_value = $available_slots > 0 ? $price_basis / (float) $available_slots : 0.0;
+        }
+
+        $cover_preview = '';
+        if ($cover_id > 0) {
+            $cover_preview = (string) wp_get_attachment_image_url($cover_id, 'large');
+        }
+        if ($cover_preview === '' && defined('JP_URL')) {
+            $cover_preview = JP_GROUP_COVER_PLACEHOLDER;
+        }
+
+        $this->group_draft = [
+            'name'          => $name,
+            'service'       => $service,
+            'service_url'   => $service_url,
+            'rules'         => $rules,
+            'pool'          => $pool_id > 0 ? (string) $pool_id : '',
+            'description'   => $description,
+            'price'         => $this->money_to_input($price_value),
+            'promo_enabled' => $promo_enabled ? 'on' : 'off',
+            'promo'         => $promo_enabled && $promo_value > 0 ? $this->money_to_input($promo_value) : '',
+            'total'         => $slots_total > 0 ? (string) $slots_total : '',
+            'reserved'      => $slots_reserved > 0 ? (string) $slots_reserved : '',
+            'member_price'  => $member_value > 0 ? $this->money_to_input($member_value) : '',
+            'member_generated' => $member_input_provided ? 'no' : 'yes',
+            'support'        => $support,
+            'delivery'       => $delivery,
+            'access'         => $access,
+            'category'       => $category,
+            'instant_access' => $instant_access ? 'on' : 'off',
+            'cover'          => $cover_id > 0 ? (string) $cover_id : '',
+            'cover_preview'  => $cover_preview,
+        ];
+
+        if ($name === '' || strlen($name) < 3) {
+            $this->add_error('group_create', __('Informe um nome para o grupo com pelo menos 3 caracteres.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($service === '' || strlen($service) < 3) {
+            $this->add_error('group_create', __('Descreva qual serviço ou assinatura será compartilhado no grupo.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($price_value <= 0) {
+            $this->add_error('group_create', __('Informe o valor mensal do serviço para calcular as cotas.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($slots_total <= 0) {
+            $this->add_error('group_create', __('Defina a quantidade de vagas disponíveis para o grupo.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($slots_reserved >= $slots_total) {
+            $this->add_error('group_create', __('As vagas reservadas para você precisam ser menores que o total disponível.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($member_value <= 0) {
+            $this->add_error('group_create', __('Revise o valor cobrado dos membros antes de enviar para análise.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($support === '') {
+            $this->add_error('group_create', __('Informe como os membros receberão suporte (ex.: e-mail, WhatsApp).', 'juntaplay'));
+
+            return;
+        }
+
+        if ($delivery === '') {
+            $this->add_error('group_create', __('Indique em quanto tempo o acesso será liberado aos participantes.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($access === '') {
+            $this->add_error('group_create', __('Explique qual será a forma de acesso enviada aos membros.', 'juntaplay'));
+
+            return;
+        }
+
+        if ($cover_id <= 0) {
+            $this->add_error('group_create', __('Envie uma capa para o grupo (495x370 px) antes de enviar para análise.', 'juntaplay'));
+
+            return;
+        }
+
+        $pool_title = '';
+        if ($pool_id > 0) {
+            $pool = Pools::get($pool_id);
+            if (!$pool) {
+                $this->add_error('group_create', __('Selecione uma campanha válida para vincular ao grupo.', 'juntaplay'));
+
+                return;
+            }
+
+            $pool_title = isset($pool->title) ? (string) $pool->title : '';
+        }
+
+        $group_id = Groups::create([
+            'owner_id'          => $user_id,
+            'pool_id'           => $pool_id,
+            'title'             => $name,
+            'service_name'      => $service,
+            'service_url'       => $service_url,
+            'rules'             => $rules,
+            'description'       => $description,
+            'price_regular'     => $price_value,
+            'price_promotional' => $promo_value > 0 ? $promo_value : null,
+            'member_price'      => $member_value,
+            'slots_total'       => $slots_total,
+            'slots_reserved'    => $slots_reserved,
+            'support_channel'   => $support,
+            'delivery_time'     => $delivery,
+            'access_method'     => $access,
+            'category'          => $category,
+            'instant_access'    => $instant_access,
+            'cover_id'          => $cover_id,
+        ]);
+
+        if ($group_id <= 0) {
+            $this->add_error('group_create', __('Não foi possível criar o grupo agora. Tente novamente em instantes.', 'juntaplay'));
+
+            return;
+        }
+
+        $validation_code = Groups::generate_email_validation_code($group_id) ?? '';
+
+        GroupMembers::add($group_id, $user_id, 'owner', 'active');
+
+        $this->invalidate_cache();
+        $this->group_draft = [];
+        $this->add_notice(__('Seu grupo foi enviado para análise. Você receberá um e-mail quando houver uma decisão.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/groups/created', $user_id, $group_id, [
+            'title'             => $name,
+            'pool_id'           => $pool_id,
+            'description'       => $description,
+            'service_name'      => $service,
+            'service_url'       => $service_url,
+            'rules'             => $rules,
+            'price_regular'     => $price_value,
+            'price_promotional' => $promo_value > 0 ? $promo_value : null,
+            'member_price'      => $member_value,
+            'slots_total'       => $slots_total,
+            'slots_reserved'    => $slots_reserved,
+            'support_channel'   => $support,
+            'delivery_time'     => $delivery,
+            'access_method'     => $access,
+            'category'          => $category,
+            'instant_access'    => $instant_access,
+            'cover_id'          => $cover_id,
+            'validation_code'   => $validation_code,
+        ]);
+    }
+
+    private function submit_group_complaint(int $user_id): void
+    {
+        $this->active_section = 'groups';
+
+        $group_raw   = isset($_POST['jp_profile_complaint_group']) ? wp_unslash($_POST['jp_profile_complaint_group']) : '';
+        $reason_raw  = isset($_POST['jp_profile_complaint_reason']) ? wp_unslash($_POST['jp_profile_complaint_reason']) : '';
+        $message_raw = isset($_POST['jp_profile_complaint_message']) ? wp_unslash($_POST['jp_profile_complaint_message']) : '';
+        $order_raw   = isset($_POST['jp_profile_complaint_order']) ? wp_unslash($_POST['jp_profile_complaint_order']) : '';
+
+        $group_id = absint($group_raw);
+        $reason   = sanitize_key($reason_raw);
+        $message  = sanitize_textarea_field($message_raw);
+        $order_id = absint($order_raw);
+
+        $errors = [];
+        $group_title = '';
+
+        if ($group_id <= 0) {
+            $errors[] = __('Selecione um grupo válido para abrir a reclamação.', 'juntaplay');
+        }
+
+        $group = null;
+        if (!$errors) {
+            $group = Groups::get($group_id);
+            if (!$group) {
+                $errors[] = __('Não foi possível identificar o grupo informado.', 'juntaplay');
+            } else {
+                $group_title = isset($group->title) ? (string) $group->title : '';
+            }
+        }
+
+        if (!$errors && !GroupMembers::user_has_membership($group_id, $user_id)) {
+            $errors[] = __('Você não participa deste grupo.', 'juntaplay');
+        }
+
+        $reasons = GroupComplaints::get_reasons();
+        if (!isset($reasons[$reason])) {
+            $reason = 'other';
+        }
+
+        if ($message === '' || strlen($message) < 15) {
+            $errors[] = __('Descreva o que aconteceu com pelo menos 15 caracteres.', 'juntaplay');
+        }
+
+        $limits    = $this->get_complaint_limits();
+        $max_files = (int) ($limits['max_files'] ?? 3);
+        $max_size  = (int) ($limits['max_size'] ?? 5 * 1024 * 1024);
+
+        $this->group_complaint_draft[$group_id] = [
+            'reason'  => $reason,
+            'message' => $message,
+            'order'   => $order_id > 0 ? (string) $order_id : '',
+        ];
+
+        $attachment_ids = [];
+        $files          = $_FILES['jp_profile_complaint_attachments'] ?? null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+        if (!$errors && is_array($files) && isset($files['name'])) {
+            $names = array_filter((array) $files['name'], static fn($name): bool => (string) $name !== '');
+            if ($max_files > 0 && count($names) > $max_files) {
+                $errors[] = sprintf(
+                    _n('Envie no máximo %d arquivo de evidência.', 'Envie no máximo %d arquivos de evidência.', $max_files, 'juntaplay'),
+                    $max_files
+                );
+            }
+        }
+
+        if (!$errors && is_array($files) && isset($files['name'])) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/media.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+
+            foreach ((array) $files['name'] as $index => $filename) {
+                if ($filename === '') {
+                    continue;
+                }
+
+                $size       = isset($files['size'][$index]) ? (int) $files['size'][$index] : 0;
+                $error_code = isset($files['error'][$index]) ? (int) $files['error'][$index] : UPLOAD_ERR_OK;
+
+                if ($max_size > 0 && $size > $max_size) {
+                    $errors[] = sprintf(
+                        __('O arquivo %1$s ultrapassa o limite de %2$s MB.', 'juntaplay'),
+                        sanitize_text_field((string) $filename),
+                        number_format_i18n(max(1, $max_size / 1048576), 1)
+                    );
+                    continue;
+                }
+
+                if ($error_code !== UPLOAD_ERR_OK) {
+                    $errors[] = sprintf(
+                        __('Não foi possível enviar o arquivo %s. Tente novamente.', 'juntaplay'),
+                        sanitize_text_field((string) $filename)
+                    );
+                    continue;
+                }
+
+                $file_array = [
+                    'name'     => $filename,
+                    'type'     => $files['type'][$index] ?? '',
+                    'tmp_name' => $files['tmp_name'][$index] ?? '',
+                    'error'    => $error_code,
+                    'size'     => $size,
+                ];
+
+                $_FILES['jp_profile_complaint_file'] = $file_array; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+                $attachment_id = media_handle_upload('jp_profile_complaint_file', 0);
+
+                if (is_wp_error($attachment_id)) {
+                    $errors[] = sprintf(
+                        __('Não foi possível salvar o arquivo %1$s: %2$s', 'juntaplay'),
+                        sanitize_text_field((string) $filename),
+                        $attachment_id->get_error_message()
+                    );
+                } elseif ($attachment_id) {
+                    $attachment_ids[] = (int) $attachment_id;
+                }
+            }
+
+            unset($_FILES['jp_profile_complaint_file']);
+        }
+
+        if ($errors) {
+            foreach ($attachment_ids as $attachment_id) {
+                wp_delete_attachment($attachment_id, true);
+            }
+
+            foreach ($errors as $message_error) {
+                $this->add_error('group_complaint_' . $group_id, $message_error);
+            }
+
+            return;
+        }
+
+        $complaint_id = GroupComplaints::create([
+            'group_id'    => $group_id,
+            'user_id'     => $user_id,
+            'order_id'    => $order_id,
+            'reason'      => $reason,
+            'message'     => $message,
+            'attachments' => $attachment_ids,
+            'status'      => GroupComplaints::STATUS_OPEN,
+        ]);
+
+        if ($complaint_id <= 0) {
+            foreach ($attachment_ids as $attachment_id) {
+                wp_delete_attachment($attachment_id, true);
+            }
+
+            $this->add_error('group_complaint_' . $group_id, __('Não foi possível registrar sua reclamação agora. Tente novamente em instantes.', 'juntaplay'));
+
+            return;
+        }
+
+        $this->group_complaint_success[$group_id] = [
+            sprintf(__('Reclamação #%d enviada. Você receberá atualizações por e-mail.', 'juntaplay'), $complaint_id),
+        ];
+
+        unset($this->group_complaint_draft[$group_id]);
+
+        $this->invalidate_cache();
+
+        $summary = GroupComplaints::get_summary_for_user($user_id, [$group_id]);
+        $decorated = $this->decorate_group_complaint_summary($summary);
+        if (isset($decorated[$group_id])) {
+            $this->group_complaint_summary[$group_id] = $decorated[$group_id];
+        }
+
+        do_action('juntaplay/groups/complaint_created', $complaint_id, $group_id, $user_id, [
+            'reason'      => $reason,
+            'message'     => $message,
+            'order_id'    => $order_id,
+            'attachments' => $attachment_ids,
+            'group_title' => $group_title,
+        ]);
+    }
+
+    private function update_sessions(int $user_id): void
+    {
+        $token = wp_get_session_token();
+
+        if (!$token) {
+            $this->add_error('sessions', __('Não foi possível identificar a sessão atual.', 'juntaplay'));
+
+            return;
+        }
+
+        $destroyed = false;
+
+        if (function_exists('wp_destroy_other_sessions')) {
+            wp_destroy_other_sessions();
+            $destroyed = true;
+        } elseif (class_exists(WP_Session_Tokens::class)) {
+            $manager = WP_Session_Tokens::get_instance($user_id);
+            if ($manager) {
+                $manager->destroy_other_sessions($token);
+                $destroyed = true;
+            }
+        }
+
+        if (!$destroyed) {
+            $this->add_error('sessions', __('Não foi possível encerrar as outras sessões.', 'juntaplay'));
+
+            return;
+        }
+
+        $this->invalidate_cache();
+        $this->add_notice(__('Outras sessões foram desconectadas.', 'juntaplay'));
+        $this->active_section = null;
+
+        do_action('juntaplay/profile/updated', $user_id, 'sessions', []);
+    }
+
+    private function add_error(string $section, string $message): void
+    {
+        if (!isset($this->errors[$section])) {
+            $this->errors[$section] = [];
+        }
+
+        $this->errors[$section][] = $message;
+    }
+
+    private function add_notice(string $message): void
+    {
+        $this->notices[] = $message;
+    }
+
+    private function invalidate_cache(): void
+    {
+        $this->cached_profile = null;
+    }
+}

--- a/juntaplay/includes/Front/Rest.php
+++ b/juntaplay/includes/Front/Rest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Front;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use JuntaPlay\Data\Pools;
+
+defined('ABSPATH') || exit;
+
+class Rest
+{
+    public function init(): void
+    {
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    public function register_routes(): void
+    {
+        register_rest_route('juntaplay/v1', '/pools/(?P<id>\d+)/quotas', [
+            'methods'             => 'GET',
+            'callback'            => [$this, 'get_quotas'],
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'status' => [
+                    'type'    => 'string',
+                    'default' => 'available',
+                ],
+            ],
+        ]);
+    }
+
+    public function get_quotas(WP_REST_Request $request): WP_REST_Response
+    {
+        global $wpdb;
+
+        $pool_id = (int) $request['id'];
+        $status  = $request->get_param('status');
+
+        $pool = Pools::get($pool_id);
+
+        if (!$pool) {
+            return new WP_REST_Response(['message' => __('Campanha não encontrada.', 'juntaplay')], 404);
+        }
+
+        $table = "{$wpdb->prefix}jp_quotas";
+        $where = $wpdb->prepare('WHERE pool_id = %d', $pool_id);
+
+        if ($status && in_array($status, ['available', 'reserved', 'paid', 'canceled', 'expired'], true)) {
+            $where .= $wpdb->prepare(' AND status = %s', $status);
+        }
+
+        $results = $wpdb->get_results("SELECT number, status FROM $table $where ORDER BY number ASC");
+
+        return new WP_REST_Response([
+            'pool'   => ['id' => $pool->id, 'title' => $pool->title],
+            'quotas' => $results,
+        ]);
+    }
+}

--- a/juntaplay/includes/Front/Shortcodes.php
+++ b/juntaplay/includes/Front/Shortcodes.php
@@ -1,0 +1,451 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Front;
+
+defined('ABSPATH') || exit;
+
+use JuntaPlay\Admin\Settings;
+use JuntaPlay\Data\Groups;
+use function apply_filters;
+use function add_query_arg;
+use function esc_html__;
+use function esc_url;
+use function get_current_user_id;
+use function get_option;
+use function get_permalink;
+use function home_url;
+use function is_user_logged_in;
+use function sanitize_key;
+use function sanitize_text_field;
+use function shortcode_atts;
+use function wc_get_order;
+use function wp_enqueue_script;
+use function wp_safe_redirect;
+use function wp_login_url;
+use function wp_script_is;
+use function wp_unslash;
+use function wp_validate_redirect;
+use function rawurlencode;
+
+class Shortcodes
+{
+    public function __construct(private Auth $auth, private Profile $profile)
+    {
+    }
+
+    public function init(): void
+    {
+        add_shortcode('juntaplay_pools', [$this, 'pools']);
+        add_shortcode('juntaplay_pool', [$this, 'pool']);
+        add_shortcode('juntaplay_quota_selector', [$this, 'quota_selector']);
+        add_shortcode('juntaplay_my_quotas', [$this, 'my_quotas']);
+        add_shortcode('juntaplay_statement', [$this, 'statement']);
+        add_shortcode('juntaplay_terms', [$this, 'terms']);
+        add_shortcode('juntaplay_admin', [$this, 'admin_panel']);
+        add_shortcode('juntaplay_login_form', [$this, 'login_form']);
+        add_shortcode('juntaplay_dashboard', [$this, 'dashboard']);
+        add_shortcode('juntaplay_profile', [$this, 'profile']);
+        add_shortcode('juntaplay_groups', [$this, 'groups_directory']);
+        add_shortcode('juntaplay_group_search', [$this, 'group_search']);
+        add_shortcode('juntaplay_group_rotator', [$this, 'group_rotator']);
+        add_shortcode('juntaplay_two_factor', [$this, 'two_factor']);
+    }
+
+    public function pools($atts = [], $content = ''): string
+    {
+        ob_start();
+        include JP_DIR . 'templates/pool-list.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function pool($atts = []): string
+    {
+        $atts    = shortcode_atts(['id' => 0], $atts, 'juntaplay_pool');
+        $pool_id = (int) $atts['id'];
+
+        ob_start();
+        $current_pool_id = $pool_id;
+        include JP_DIR . 'templates/pool-single.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function quota_selector($atts = []): string
+    {
+        $atts = shortcode_atts([
+            'id'       => 0,
+            'per_page' => 100,
+            'search'   => 'true',
+            'filter'   => 'true',
+        ], $atts, 'juntaplay_quota_selector');
+
+        if (!wp_script_is('juntaplay', 'enqueued')) {
+            wp_enqueue_script('juntaplay');
+        }
+
+        ob_start();
+        $current_pool_id = (int) $atts['id'];
+        $per_page        = (int) $atts['per_page'];
+        $show_search     = $atts['search'] === 'true';
+        $show_filter     = $atts['filter'] === 'true';
+        include JP_DIR . 'templates/quota-grid.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function my_quotas(): string
+    {
+        if (!is_user_logged_in()) {
+            return '<p>' . esc_html__('Faça login para ver suas cotas.', 'juntaplay') . '</p>';
+        }
+
+        ob_start();
+        include JP_DIR . 'templates/my-quotas.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function group_search($atts = []): string
+    {
+        $atts = shortcode_atts([
+            'title'       => esc_html__('Assine e economize até 85% nos serviços!', 'juntaplay'),
+            'description' => esc_html__('Junte-se a grupos, compartilhe assinaturas digitais e aproveite muito mais pagando menos. Tudo sob forma simples, segura e inteligente.', 'juntaplay'),
+            'button'      => esc_html__('Buscar', 'juntaplay'),
+        ], $atts, 'juntaplay_group_search');
+
+        $groups_page_id = (int) get_option('juntaplay_page_grupos');
+        $action         = $groups_page_id ? get_permalink($groups_page_id) : home_url('/');
+
+        $categories = Groups::get_category_labels();
+        $preferred_keys = ['video', 'music', 'education', 'reading', 'office', 'games'];
+        $filtered_categories = array_filter(
+            $categories,
+            static fn ($label, $key): bool => in_array($key, $preferred_keys, true),
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        if (empty($filtered_categories)) {
+            $filtered_categories = $categories;
+        }
+
+        $search_value = '';
+        if (isset($_GET['search'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $search_value = sanitize_text_field((string) wp_unslash($_GET['search'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        }
+
+        $category_value = '';
+        if (isset($_GET['category'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $candidate = sanitize_key((string) wp_unslash($_GET['category'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            if (isset($categories[$candidate])) {
+                $category_value = $candidate;
+            }
+        }
+
+        ob_start();
+        $hero_title       = $atts['title'];
+        $hero_description = $atts['description'];
+        $hero_button      = $atts['button'];
+        $hero_action      = $action;
+        $hero_categories  = $filtered_categories;
+        $hero_search      = $search_value;
+        $hero_category    = $category_value;
+        include JP_DIR . 'templates/group-search-hero.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function group_rotator($atts = []): string
+    {
+        if (!wp_script_is('juntaplay', 'enqueued')) {
+            wp_enqueue_script('juntaplay');
+        }
+
+        $general = get_option(Settings::OPTION_GENERAL, []);
+        $default_limit = isset($general['group_rotator_limit']) ? (int) $general['group_rotator_limit'] : 12;
+        if ($default_limit <= 0) {
+            $default_limit = 12;
+        }
+
+        $atts = shortcode_atts([
+            'title'       => esc_html__('Descubra grupos com vagas agora', 'juntaplay'),
+            'description' => esc_html__('Seleção dinâmica de campanhas criadas pela comunidade com moderação do super admin.', 'juntaplay'),
+            'button'      => esc_html__('Ver todos os grupos', 'juntaplay'),
+            'limit'       => 0,
+            'category'    => '',
+        ], $atts, 'juntaplay_group_rotator');
+
+        $limit = (int) ($atts['limit'] ?: $default_limit);
+        $limit = max(4, min(40, $limit));
+
+        $categories = Groups::get_category_labels();
+        $default_category = (string) $atts['category'];
+        if ($default_category !== '' && !isset($categories[$default_category])) {
+            $default_category = '';
+        }
+
+        $groups_page_id   = (int) get_option('juntaplay_page_grupos');
+        $directory_url    = $groups_page_id ? get_permalink($groups_page_id) : home_url('/grupos');
+
+        ob_start();
+        $rotator_title            = $atts['title'];
+        $rotator_description      = $atts['description'];
+        $rotator_button           = $atts['button'];
+        $rotator_limit            = $limit;
+        $rotator_categories       = $categories;
+        $rotator_default_category = $default_category;
+        $rotator_directory_url    = $directory_url;
+        include JP_DIR . 'templates/group-rotator.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function statement($atts = []): string
+    {
+        if (!is_user_logged_in()) {
+            return '<p>' . esc_html__('Faça login para visualizar seu extrato.', 'juntaplay') . '</p>';
+        }
+
+        if (!class_exists('\\WooCommerce')) {
+            return '<p>' . esc_html__('WooCommerce é necessário para exibir o extrato.', 'juntaplay') . '</p>';
+        }
+
+        $atts = shortcode_atts([
+            'order_id' => 0,
+        ], $atts, 'juntaplay_statement');
+
+        $order_id = (int) ($atts['order_id'] ?: (isset($_GET['order_id']) ? wp_unslash($_GET['order_id']) : 0)); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $order_id = absint($order_id);
+
+        if (!$order_id) {
+            return '<p class="juntaplay-notice">' . esc_html__('Selecione um pedido para visualizar o extrato.', 'juntaplay') . '</p>';
+        }
+
+        $order = wc_get_order($order_id);
+
+        if (!$order) {
+            return '<p class="juntaplay-notice">' . esc_html__('Pedido não encontrado.', 'juntaplay') . '</p>';
+        }
+
+        if ((int) $order->get_user_id() !== get_current_user_id()) {
+            return '<p class="juntaplay-notice">' . esc_html__('Você não tem permissão para acessar este extrato.', 'juntaplay') . '</p>';
+        }
+
+        global $wpdb;
+
+        $items = [];
+        foreach ($order->get_items() as $item) {
+            $pool_id = (int) $item->get_meta('JuntaPlay Pool', true);
+            $raw_numbers = $item->get_meta('JuntaPlay Cotas', true);
+            $numbers = array_filter(array_map('absint', array_map('trim', explode(',', (string) $raw_numbers))));
+
+            if (!$pool_id || !$numbers) {
+                continue;
+            }
+
+            sort($numbers);
+
+            $placeholders = implode(',', array_fill(0, count($numbers), '%d'));
+            $prepared     = $wpdb->prepare(
+                "SELECT number, status FROM {$wpdb->prefix}jp_quotas WHERE pool_id = %d AND number IN ($placeholders)",
+                ...array_merge([$pool_id], $numbers)
+            );
+            $quota_rows   = $prepared ? $wpdb->get_results($prepared, ARRAY_A) : [];
+            $status_map   = [];
+
+            if ($quota_rows) {
+                foreach ($quota_rows as $quota_row) {
+                    $status_map[(int) $quota_row['number']] = (string) $quota_row['status'];
+                }
+            }
+
+            $pool       = \JuntaPlay\Data\Pools::get($pool_id);
+            $pool_title = $pool->title ?? $item->get_name();
+            $pool_link  = '';
+
+            if ($pool && !empty($pool->product_id)) {
+                $pool_link = get_permalink((int) $pool->product_id);
+            }
+
+            $pool_link = apply_filters('juntaplay_pool_permalink', $pool_link, $pool_id, $pool);
+            $pool_link = $pool_link ? (string) $pool_link : '';
+
+            $items[] = [
+                'pool_id'     => $pool_id,
+                'title'       => $pool_title,
+                'link'        => $pool_link,
+                'numbers'     => $numbers,
+                'statuses'    => $status_map,
+                'line_total'  => $item->get_total() + $item->get_total_tax(),
+                'quantity'    => $item->get_quantity(),
+                'line_subtotal' => $item->get_subtotal(),
+            ];
+        }
+
+        if (!$items) {
+            return '<p class="juntaplay-notice">' . esc_html__('Nenhuma cota vinculada a este pedido.', 'juntaplay') . '</p>';
+        }
+
+        $balance = (float) apply_filters('juntaplay_statement_balance', 0.0, $order);
+
+        ob_start();
+        $statement_order  = $order;
+        $statement_items  = $items;
+        $statement_balance = $balance;
+        include JP_DIR . 'templates/statement.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function terms(): string
+    {
+        ob_start();
+        include JP_DIR . 'templates/terms.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function profile(): string
+    {
+        if (!is_user_logged_in()) {
+            $profile_page_id = (int) get_option('juntaplay_page_perfil');
+            $redirect        = $profile_page_id ? get_permalink($profile_page_id) : '';
+
+            if (!$redirect) {
+                $redirect = home_url('/perfil');
+            }
+
+            $login_page_id = (int) get_option('juntaplay_page_entrar');
+            $login_url     = $login_page_id ? get_permalink($login_page_id) : wp_login_url($redirect);
+
+            if ($login_page_id && $login_url) {
+                $login_url = add_query_arg('redirect_to', rawurlencode($redirect), $login_url);
+            }
+
+            $login_url = $login_url ?: wp_login_url($redirect);
+
+            return '<p class="juntaplay-notice">' . esc_html__('Faça login para atualizar seus dados.', 'juntaplay') . ' '
+                . '<a class="juntaplay-link" href="' . esc_url($login_url) . '">' . esc_html__('Entrar agora', 'juntaplay')
+                . '</a></p>';
+        }
+
+        $profile_sections       = $this->profile->get_sections();
+        $profile_errors         = $this->profile->get_errors();
+        $profile_notices        = $this->profile->get_notices();
+        $profile_active_section = $this->profile->get_active_section();
+
+        if (function_exists('wp_enqueue_media')) {
+            wp_enqueue_media();
+        }
+
+        ob_start();
+        include JP_DIR . 'templates/profile.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function admin_panel(): string
+    {
+        if (!current_user_can('manage_options')) {
+            return '<p>' . esc_html__('Acesso restrito.', 'juntaplay') . '</p>';
+        }
+
+        ob_start();
+        include JP_DIR . 'templates/admin-panel.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function login_form(): string
+    {
+        if (is_user_logged_in()) {
+            $redirect = $this->auth->get_redirect_url();
+            if (!$redirect) {
+                $redirect = $this->auth->get_default_redirect();
+            }
+
+            wp_safe_redirect($redirect);
+            exit;
+        }
+
+        $login_errors    = $this->auth->get_login_errors();
+        $register_errors = $this->auth->get_register_errors();
+        $active_view     = $this->auth->get_active_view();
+        $redirect_to     = $this->auth->get_redirect_url();
+
+        if (!$redirect_to) {
+            $redirect_to = $this->auth->get_default_redirect();
+        }
+
+        if (!$redirect_to && isset($_GET['redirect_to'])) {
+            $raw_redirect = wp_unslash($_GET['redirect_to']);
+            $validated    = wp_validate_redirect($raw_redirect, '');
+            if (is_string($validated)) {
+                $redirect_to = $validated;
+            }
+        }
+
+        if ($active_view !== 'register' && isset($_GET['action']) && sanitize_key(wp_unslash($_GET['action'])) === 'register') { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $active_view = 'register';
+        }
+
+        ob_start();
+        include JP_DIR . 'templates/auth/login.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function dashboard(): string
+    {
+        if (!is_user_logged_in()) {
+            $login_page_id = (int) get_option('juntaplay_page_entrar');
+            $redirect      = $this->auth->get_default_redirect();
+            $login_url     = $login_page_id ? get_permalink($login_page_id) : wp_login_url($redirect);
+
+            if ($login_page_id && $login_url) {
+                $login_url = add_query_arg('redirect_to', rawurlencode($redirect), $login_url);
+            }
+
+            $login_url = $login_url ?: wp_login_url($redirect);
+
+            return '<p class="juntaplay-notice">' . esc_html__('Faça login para acessar seu painel.', 'juntaplay') . ' ' .
+                '<a class="juntaplay-link" href="' . esc_url($login_url) . '">' . esc_html__('Entrar agora', 'juntaplay') . '</a></p>';
+        }
+
+        ob_start();
+        include JP_DIR . 'templates/dashboard.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function groups_directory(): string
+    {
+        $categories = Groups::get_category_labels();
+
+        ob_start();
+        include JP_DIR . 'templates/groups-directory.php';
+
+        return (string) ob_get_clean();
+    }
+
+    public function two_factor(): string
+    {
+        if (is_user_logged_in()) {
+            $redirect = $this->auth->get_default_redirect();
+            wp_safe_redirect($redirect);
+            exit;
+        }
+
+        $context = $this->auth->get_two_factor_context();
+        $errors  = $this->auth->get_two_factor_errors();
+
+        $login_page_id = (int) get_option('juntaplay_page_entrar');
+        $login_url     = $login_page_id ? get_permalink($login_page_id) : wp_login_url();
+
+        ob_start();
+        include JP_DIR . 'templates/auth/two-factor.php';
+
+        return (string) ob_get_clean();
+    }
+}

--- a/juntaplay/includes/Installer.php
+++ b/juntaplay/includes/Installer.php
@@ -1,0 +1,281 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay;
+
+use wpdb;
+use function get_option;
+use function update_option;
+
+defined('ABSPATH') || exit;
+
+class Installer
+{
+    public function activate(): void
+    {
+        $this->create_tables();
+        self::bootstrap_cron();
+        self::schedule_cron();
+        $this->maybe_create_pages();
+
+        add_option('juntaplay_db_version', JP_DB_VERSION);
+    }
+
+    private function create_tables(): void
+    {
+        global $wpdb;
+
+        $charset_collate = $wpdb->get_charset_collate();
+        $pools_table     = "CREATE TABLE {$wpdb->prefix}jp_pools (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            title VARCHAR(255) NOT NULL,
+            slug VARCHAR(190) NOT NULL,
+            product_id BIGINT UNSIGNED NULL,
+            price DECIMAL(10,2) NOT NULL DEFAULT 0,
+            quota_start INT NOT NULL DEFAULT 1,
+            quota_end INT NOT NULL DEFAULT 1,
+            quotas_total INT NOT NULL DEFAULT 0,
+            quotas_paid INT NOT NULL DEFAULT 0,
+            category VARCHAR(100) NOT NULL DEFAULT '',
+            excerpt TEXT NULL,
+            thumbnail_id BIGINT UNSIGNED NULL,
+            is_featured TINYINT(1) NOT NULL DEFAULT 0,
+            status VARCHAR(20) NOT NULL DEFAULT 'draft',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY slug (slug),
+            KEY category_status (category, status),
+            KEY featured_status (is_featured, status)
+        ) $charset_collate;";
+
+        $quotas_table = "CREATE TABLE {$wpdb->prefix}jp_quotas (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            pool_id BIGINT UNSIGNED NOT NULL,
+            number INT NOT NULL,
+            status ENUM('available','reserved','paid','canceled','expired') NOT NULL DEFAULT 'available',
+            user_id BIGINT UNSIGNED NULL,
+            order_id BIGINT UNSIGNED NULL,
+            reserved_until DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY pool_number (pool_id, number),
+            KEY pool_status (pool_id, status),
+            KEY reserved_until (reserved_until)
+        ) $charset_collate;";
+
+        $groups_table = "CREATE TABLE {$wpdb->prefix}jp_groups (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            owner_id BIGINT UNSIGNED NOT NULL,
+            pool_id BIGINT UNSIGNED NULL,
+            title VARCHAR(255) NOT NULL,
+            service_name VARCHAR(255) NOT NULL DEFAULT '',
+            service_url VARCHAR(255) NULL,
+            rules TEXT NULL,
+            description TEXT NULL,
+            price_regular DECIMAL(10,2) NOT NULL DEFAULT 0,
+            price_promotional DECIMAL(10,2) NULL,
+            member_price DECIMAL(10,2) NULL,
+            slots_total INT NOT NULL DEFAULT 0,
+            slots_reserved INT NOT NULL DEFAULT 0,
+            support_channel VARCHAR(100) NOT NULL DEFAULT '',
+            delivery_time VARCHAR(100) NOT NULL DEFAULT '',
+            access_method VARCHAR(100) NOT NULL DEFAULT '',
+            cover_id BIGINT UNSIGNED NULL,
+            category VARCHAR(100) NOT NULL DEFAULT '',
+            instant_access TINYINT(1) NOT NULL DEFAULT 0,
+            email_validation_hash VARCHAR(255) NULL,
+            email_validation_sent_at DATETIME NULL,
+            email_validated_at DATETIME NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            visibility VARCHAR(20) NOT NULL DEFAULT 'public',
+            review_note TEXT NULL,
+            reviewed_by BIGINT UNSIGNED NULL,
+            reviewed_at DATETIME NULL,
+            slug VARCHAR(190) NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY slug (slug),
+            KEY owner_status (owner_id, status),
+            KEY pool_status_visibility (pool_id, status, visibility),
+            KEY status_created (status, created_at)
+        ) $charset_collate;";
+
+        $group_members_table = "CREATE TABLE {$wpdb->prefix}jp_group_members (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            group_id BIGINT UNSIGNED NOT NULL,
+            user_id BIGINT UNSIGNED NOT NULL,
+            role VARCHAR(20) NOT NULL DEFAULT 'member',
+            status VARCHAR(20) NOT NULL DEFAULT 'active',
+            joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY group_user (group_id, user_id),
+            KEY user_status (user_id, status)
+        ) $charset_collate;";
+
+        $group_complaints_table = "CREATE TABLE {$wpdb->prefix}jp_group_complaints (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            group_id BIGINT UNSIGNED NOT NULL,
+            user_id BIGINT UNSIGNED NOT NULL,
+            order_id BIGINT UNSIGNED NULL,
+            reason VARCHAR(50) NOT NULL DEFAULT 'other',
+            message TEXT NOT NULL,
+            attachments LONGTEXT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'open',
+            admin_note TEXT NULL,
+            resolved_by BIGINT UNSIGNED NULL,
+            resolved_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY group_status (group_id, status),
+            KEY user_group (user_id, group_id)
+        ) $charset_collate;";
+
+        $credit_transactions_table = "CREATE TABLE {$wpdb->prefix}jp_credit_transactions (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            type VARCHAR(30) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'completed',
+            amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+            balance_after DECIMAL(10,2) NULL,
+            reference VARCHAR(191) NULL,
+            context LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY user_status (user_id, status),
+            KEY user_created (user_id, created_at),
+            KEY reference (reference)
+        ) $charset_collate;";
+
+        $credit_withdrawals_table = "CREATE TABLE {$wpdb->prefix}jp_credit_withdrawals (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+            method VARCHAR(20) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            destination LONGTEXT NULL,
+            reference VARCHAR(100) NULL,
+            admin_note TEXT NULL,
+            requested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            processed_at DATETIME NULL,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY user_status (user_id, status),
+            KEY reference (reference)
+        ) $charset_collate;";
+
+        $notifications_table = "CREATE TABLE {$wpdb->prefix}jp_notifications (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            user_id BIGINT UNSIGNED NOT NULL,
+            type VARCHAR(50) NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            message TEXT NOT NULL,
+            action_url VARCHAR(255) NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'unread',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            read_at DATETIME NULL,
+            PRIMARY KEY (id),
+            KEY user_status (user_id, status),
+            KEY user_created (user_id, created_at)
+        ) $charset_collate;";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($pools_table);
+        dbDelta($quotas_table);
+        dbDelta($groups_table);
+        dbDelta($group_members_table);
+        dbDelta($group_complaints_table);
+        dbDelta($credit_transactions_table);
+        dbDelta($credit_withdrawals_table);
+        dbDelta($notifications_table);
+    }
+
+    public static function bootstrap_cron(): void
+    {
+        add_filter('cron_schedules', [self::class, 'register_custom_schedule']);
+        add_action('juntaplay_cron_release_expired', [self::class, 'release_expired']);
+    }
+
+    public static function register_custom_schedule(array $schedules): array
+    {
+        if (!isset($schedules['minute'])) {
+            $schedules['minute'] = [
+                'interval' => 60,
+                'display'  => __('A cada minuto', 'juntaplay'),
+            ];
+        }
+
+        return $schedules;
+    }
+
+    public static function schedule_cron(): void
+    {
+        if (!wp_next_scheduled('juntaplay_cron_release_expired')) {
+            wp_schedule_event(time() + 60, 'minute', 'juntaplay_cron_release_expired');
+        }
+    }
+
+    public static function release_expired(): void
+    {
+        global $wpdb;
+
+        $table = "{$wpdb->prefix}jp_quotas";
+        $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE $table
+                SET status='available', user_id=NULL, order_id=NULL, reserved_until=NULL
+                WHERE status='reserved' AND reserved_until IS NOT NULL AND reserved_until < %s",
+                current_time('mysql')
+            )
+        );
+    }
+
+    private function maybe_create_pages(): void
+    {
+        $pages = [
+            'campanhas'    => ['title' => 'Campanhas', 'shortcode' => '[juntaplay_pools]'],
+            'minhas-cotas' => ['title' => 'Minhas Cotas', 'shortcode' => '[juntaplay_my_quotas]'],
+            'extrato'      => ['title' => 'Extrato', 'shortcode' => '[juntaplay_statement]'],
+            'perfil'       => ['title' => 'Perfil', 'shortcode' => '[juntaplay_profile]'],
+            'entrar'       => ['title' => 'Entrar', 'shortcode' => '[juntaplay_login_form]'],
+            'regras'       => ['title' => 'Regras', 'shortcode' => '[juntaplay_terms]'],
+            'painel'       => ['title' => 'Painel', 'shortcode' => '[juntaplay_dashboard]'],
+            'grupos'       => ['title' => 'Grupos', 'shortcode' => '[juntaplay_groups]'],
+            'verificar-acesso' => ['title' => 'Verificar acesso', 'shortcode' => '[juntaplay_two_factor]'],
+        ];
+
+        foreach ($pages as $slug => $data) {
+            if (get_page_by_path($slug)) {
+                continue;
+            }
+
+            $page_id = wp_insert_post([
+                'post_title'   => $data['title'],
+                'post_name'    => $slug,
+                'post_status'  => 'publish',
+                'post_type'    => 'page',
+                'post_content' => $data['shortcode'],
+            ]);
+
+            if ($page_id && !is_wp_error($page_id)) {
+                add_option('juntaplay_page_' . $slug, (int) $page_id);
+            }
+        }
+    }
+
+    public static function maybe_upgrade(): void
+    {
+        $current_version = (string) get_option('juntaplay_db_version', '0');
+
+        if (version_compare($current_version, JP_DB_VERSION, '>=')) {
+            return;
+        }
+
+        $installer = new self();
+        $installer->create_tables();
+
+        update_option('juntaplay_db_version', JP_DB_VERSION);
+    }
+}

--- a/juntaplay/includes/Notifications/Credits.php
+++ b/juntaplay/includes/Notifications/Credits.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Notifications;
+
+use JuntaPlay\Data\Notifications as NotificationsData;
+
+use function add_action;
+use function admin_url;
+use function esc_url;
+use function get_bloginfo;
+use function get_option;
+use function get_permalink;
+use function get_userdata;
+use function home_url;
+use function number_format_i18n;
+use function sprintf;
+use function wp_mail;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Credits
+{
+    public function init(): void
+    {
+        add_action('juntaplay/credits/withdrawal_requested', [$this, 'on_withdrawal_requested'], 10, 3);
+        add_action('juntaplay/credits/deposit_completed', [$this, 'on_deposit_completed'], 10, 2);
+        add_action('juntaplay/credits/deposit_reversed', [$this, 'on_deposit_reversed'], 10, 2);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function on_withdrawal_requested(int $user_id, int $withdrawal_id, array $data): void
+    {
+        $user = get_userdata($user_id);
+        if (!$user) {
+            return;
+        }
+
+        $amount    = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $method    = isset($data['method']) ? (string) $data['method'] : 'pix';
+        $reference = isset($data['reference']) ? (string) $data['reference'] : '';
+        $site_name = get_bloginfo('name');
+        $currency  = number_format_i18n($amount, 2);
+
+        $dashboard_id  = (int) get_option('juntaplay_page_painel');
+        $dashboard_url = $dashboard_id ? get_permalink($dashboard_id) : home_url('/painel');
+
+        NotificationsData::add($user_id, [
+            'type'       => 'wallet',
+            'title'      => __('Solicitação de retirada recebida', 'juntaplay'),
+            'message'    => sprintf(__('Recebemos seu pedido de saque no valor de R$ %s. Assim que analisarmos você será notificado.', 'juntaplay'), $currency),
+            'action_url' => $dashboard_url,
+        ]);
+
+        $admin_email = (string) get_option('admin_email');
+        if ($admin_email !== '') {
+            $review_url = esc_url(admin_url('admin.php?page=juntaplay-groups'));
+            $message = implode("\n", [
+                sprintf(__('Nova solicitação de retirada no valor de R$ %s.', 'juntaplay'), $currency),
+                sprintf(__('Usuário: %s (%s)', 'juntaplay'), $user->display_name ?: $user->user_login, $user->user_email),
+                sprintf(__('Método: %s', 'juntaplay'), strtoupper($method)),
+                $reference !== '' ? sprintf(__('Referência: %s', 'juntaplay'), $reference) : '',
+                '',
+                sprintf(__('Gerencie as retiradas no painel do WordPress: %s', 'juntaplay'), $review_url),
+            ]);
+
+            $headers = ['Content-Type: text/plain; charset=UTF-8'];
+            wp_mail(
+                $admin_email,
+                sprintf(__('Solicitação de retirada no JuntaPlay — %s', 'juntaplay'), $site_name),
+                $message,
+                $headers
+            );
+        }
+
+        $user_message = implode("\n", [
+            sprintf(__('Olá %s, recebemos seu pedido de retirada.', 'juntaplay'), $user->display_name ?: $user->user_login),
+            sprintf(__('Valor solicitado: R$ %s', 'juntaplay'), $currency),
+            sprintf(__('Método escolhido: %s', 'juntaplay'), strtoupper($method)),
+            $reference !== '' ? sprintf(__('Protocolo: %s', 'juntaplay'), $reference) : '',
+            '',
+            __('Você receberá um novo aviso quando o pagamento for processado.', 'juntaplay'),
+            sprintf(__('Acompanhe pelo painel: %s', 'juntaplay'), $dashboard_url),
+            '',
+            sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+        ]);
+
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+        wp_mail(
+            (string) $user->user_email,
+            sprintf(__('Seu pedido de retirada foi registrado — %s', 'juntaplay'), $site_name),
+            $user_message,
+            $headers
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function on_deposit_completed(int $user_id, array $data): void
+    {
+        $user = get_userdata($user_id);
+        if (!$user) {
+            return;
+        }
+
+        $amount    = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $reference = isset($data['reference']) ? (string) $data['reference'] : '';
+        $site_name = get_bloginfo('name');
+        $currency  = number_format_i18n($amount, 2);
+
+        $dashboard_id  = (int) get_option('juntaplay_page_painel');
+        $dashboard_url = $dashboard_id ? get_permalink($dashboard_id) : home_url('/painel');
+
+        NotificationsData::add($user_id, [
+            'type'       => 'wallet',
+            'title'      => __('Créditos adicionados com sucesso', 'juntaplay'),
+            'message'    => sprintf(__('Recebemos seu pagamento de R$ %s e seu saldo foi atualizado.', 'juntaplay'), $currency),
+            'action_url' => $dashboard_url,
+        ]);
+
+        $message = implode("\n", [
+            sprintf(__('Olá %s, confirmamos a entrada de créditos na sua carteira.', 'juntaplay'), $user->display_name ?: $user->user_login),
+            sprintf(__('Valor creditado: R$ %s', 'juntaplay'), $currency),
+            $reference !== '' ? sprintf(__('Protocolo: %s', 'juntaplay'), $reference) : '',
+            '',
+            sprintf(__('Você pode consultar o extrato em: %s', 'juntaplay'), $dashboard_url),
+            '',
+            sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+        ]);
+
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+        wp_mail(
+            (string) $user->user_email,
+            sprintf(__('Créditos confirmados — %s', 'juntaplay'), $site_name),
+            $message,
+            $headers
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function on_deposit_reversed(int $user_id, array $data): void
+    {
+        $user = get_userdata($user_id);
+        if (!$user) {
+            return;
+        }
+
+        $amount    = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $reference = isset($data['reference']) ? (string) $data['reference'] : '';
+        $site_name = get_bloginfo('name');
+        $currency  = number_format_i18n($amount, 2);
+
+        $dashboard_id  = (int) get_option('juntaplay_page_painel');
+        $dashboard_url = $dashboard_id ? get_permalink($dashboard_id) : home_url('/painel');
+
+        NotificationsData::add($user_id, [
+            'type'       => 'wallet',
+            'title'      => __('Recarga cancelada', 'juntaplay'),
+            'message'    => sprintf(__('A recarga de R$ %s foi estornada e o saldo ajustado.', 'juntaplay'), $currency),
+            'action_url' => $dashboard_url,
+        ]);
+
+        $message = implode("\n", [
+            sprintf(__('Olá %s, a recarga de créditos não pôde ser concluída.', 'juntaplay'), $user->display_name ?: $user->user_login),
+            sprintf(__('Valor estornado: R$ %s', 'juntaplay'), $currency),
+            $reference !== '' ? sprintf(__('Protocolo: %s', 'juntaplay'), $reference) : '',
+            '',
+            __('Caso o pagamento tenha sido realizado, o estorno será processado pelo mesmo meio utilizado.', 'juntaplay'),
+            sprintf(__('Acompanhe o status pelo painel: %s', 'juntaplay'), $dashboard_url),
+            '',
+            sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+        ]);
+
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+        wp_mail(
+            (string) $user->user_email,
+            sprintf(__('Recarga cancelada — %s', 'juntaplay'), $site_name),
+            $message,
+            $headers
+        );
+    }
+}

--- a/juntaplay/includes/Notifications/Groups.php
+++ b/juntaplay/includes/Notifications/Groups.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JuntaPlay\Notifications;
+
+use JuntaPlay\Data\GroupComplaints as GroupComplaintsData;
+use JuntaPlay\Data\Groups as GroupsData;
+
+use function add_action;
+use function admin_url;
+use function apply_filters;
+use function esc_url;
+use function get_bloginfo;
+use function get_option;
+use function get_permalink;
+use function get_userdata;
+use function number_format_i18n;
+use function wp_get_attachment_url;
+use function sprintf;
+use function ucwords;
+use function wp_mail;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Groups
+{
+    public function init(): void
+    {
+        add_action('juntaplay/profile/groups/created', [$this, 'on_group_created'], 10, 3);
+        add_action('juntaplay/groups/status_changed', [$this, 'on_status_changed'], 10, 4);
+        add_action('juntaplay/groups/complaint_created', [$this, 'on_complaint_created'], 10, 4);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function on_group_created(int $user_id, int $group_id, array $data): void
+    {
+        $admin_email = (string) get_option('admin_email');
+        $site_name   = get_bloginfo('name');
+        $group_title  = isset($data['title']) ? (string) $data['title'] : __('Grupo', 'juntaplay');
+        $description  = isset($data['description']) ? (string) $data['description'] : '';
+        $service      = isset($data['service_name']) ? (string) $data['service_name'] : '';
+        $service_url  = isset($data['service_url']) ? (string) $data['service_url'] : '';
+        $price        = isset($data['price_regular']) ? (float) $data['price_regular'] : 0.0;
+        $promo        = isset($data['price_promotional']) ? $data['price_promotional'] : null;
+        $promo_value  = $promo !== null ? (float) $promo : null;
+        $member_price = isset($data['member_price']) ? (float) $data['member_price'] : 0.0;
+        $slots_total  = isset($data['slots_total']) ? (int) $data['slots_total'] : 0;
+        $slots_reserved = isset($data['slots_reserved']) ? (int) $data['slots_reserved'] : 0;
+        $support      = isset($data['support_channel']) ? (string) $data['support_channel'] : '';
+        $delivery     = isset($data['delivery_time']) ? (string) $data['delivery_time'] : '';
+        $access       = isset($data['access_method']) ? (string) $data['access_method'] : '';
+        $rules        = isset($data['rules']) ? (string) $data['rules'] : '';
+        $category     = isset($data['category']) ? (string) $data['category'] : '';
+        $instant      = !empty($data['instant_access']);
+        $validation_code = isset($data['validation_code']) ? (string) $data['validation_code'] : '';
+        $headers = ['Content-Type: text/plain; charset=UTF-8'];
+
+        $category_labels = GroupsData::get_category_labels();
+
+        $category_label = $category !== '' && isset($category_labels[$category])
+            ? (string) $category_labels[$category]
+            : ($category !== '' ? ucwords(str_replace(['-', '_'], ' ', $category)) : __('Outros serviços', 'juntaplay'));
+        $instant_text = $instant ? __('Ativado', 'juntaplay') : __('Desativado', 'juntaplay');
+        $promo_flag   = ($promo_value !== null && $promo_value > 0) ? __('Sim', 'juntaplay') : __('Não', 'juntaplay');
+
+        if ($admin_email !== '') {
+            $review_url = esc_url(admin_url('admin.php?page=juntaplay-groups&status=pending'));
+            $lines = [];
+            if ($service !== '') {
+                $lines[] = sprintf(__('Serviço: %s', 'juntaplay'), $service);
+            }
+            if ($service_url !== '') {
+                $lines[] = sprintf(__('Site oficial: %s', 'juntaplay'), $service_url);
+            }
+            if ($category_label !== '') {
+                $lines[] = sprintf(__('Categoria: %s', 'juntaplay'), $category_label);
+            }
+            if ($price > 0) {
+                $lines[] = sprintf(__('Valor do serviço: R$ %s', 'juntaplay'), number_format_i18n($price, 2));
+            }
+            if ($promo_value !== null) {
+                $lines[] = sprintf(__('Valor promocional: R$ %s', 'juntaplay'), number_format_i18n($promo_value, 2));
+            }
+            if ($member_price > 0) {
+                $lines[] = sprintf(__('Cota sugerida por membro: R$ %s', 'juntaplay'), number_format_i18n($member_price, 2));
+            }
+            if ($slots_total > 0) {
+                $lines[] = sprintf(__('Vagas totais/reservadas: %1$d / %2$d', 'juntaplay'), $slots_total, $slots_reserved);
+            }
+            if ($support !== '') {
+                $lines[] = sprintf(__('Suporte aos membros: %s', 'juntaplay'), $support);
+            }
+            if ($delivery !== '') {
+                $lines[] = sprintf(__('Entrega do acesso: %s', 'juntaplay'), $delivery);
+            }
+            if ($access !== '') {
+                $lines[] = sprintf(__('Forma de acesso: %s', 'juntaplay'), $access);
+            }
+            $lines[] = sprintf(__('É valor promocional?: %s', 'juntaplay'), $promo_flag);
+            $lines[] = sprintf(__('Acesso instantâneo: %s', 'juntaplay'), $instant_text);
+
+            $admin_message = sprintf(
+                "%s\n\n%s\n%s\n%s",
+                sprintf(__('Novo grupo “%s” aguarda aprovação no JuntaPlay.', 'juntaplay'), $group_title),
+                $description !== '' ? sprintf(__('Descrição: %s', 'juntaplay'), $description) : __('Descrição não informada.', 'juntaplay'),
+                $lines ? implode("\n", $lines) : __('Nenhum detalhe adicional informado.', 'juntaplay'),
+                sprintf(__('Revise agora: %s', 'juntaplay'), $review_url)
+            );
+
+            wp_mail(
+                $admin_email,
+                sprintf(__('Novo grupo aguardando aprovação — %s', 'juntaplay'), $site_name),
+                $admin_message,
+                $headers
+            );
+        }
+
+        $user = get_userdata($user_id);
+        if ($user && !empty($user->user_email)) {
+            $summary_lines = [
+                sprintf(__('Serviço: %s', 'juntaplay'), $service !== '' ? $service : __('Não informado', 'juntaplay')),
+                sprintf(__('Tipo: %s', 'juntaplay'), __('Público', 'juntaplay')),
+                sprintf(__('Categoria: %s', 'juntaplay'), $category_label),
+                sprintf(__('Acesso instantâneo: %s', 'juntaplay'), $instant_text),
+                sprintf(__('Valor do serviço: R$ %s', 'juntaplay'), number_format_i18n($price, 2)),
+                sprintf(__('É valor promocional?: %s', 'juntaplay'), $promo_flag),
+            ];
+
+            if ($promo_value !== null) {
+                $summary_lines[] = sprintf(__('Valor promocional: R$ %s', 'juntaplay'), number_format_i18n($promo_value, 2));
+            }
+
+            $summary_lines[] = sprintf(__('Vagas totais: %d', 'juntaplay'), $slots_total);
+            $summary_lines[] = sprintf(__('Reservadas para você: %d', 'juntaplay'), $slots_reserved);
+            $summary_lines[] = sprintf(__('Os membros irão pagar: R$ %s', 'juntaplay'), number_format_i18n($member_price, 2));
+
+            if ($service_url !== '') {
+                $summary_lines[] = sprintf(__('Site oficial: %s', 'juntaplay'), $service_url);
+            }
+
+            if ($support !== '') {
+                $summary_lines[] = sprintf(__('Suporte aos membros: %s', 'juntaplay'), $support);
+            }
+
+            if ($delivery !== '') {
+                $summary_lines[] = sprintf(__('Envio de acesso: %s', 'juntaplay'), $delivery);
+            }
+
+            if ($access !== '') {
+                $summary_lines[] = sprintf(__('Forma de acesso: %s', 'juntaplay'), $access);
+            }
+
+            if ($rules !== '') {
+                $summary_lines[] = sprintf(__('Regras: %s', 'juntaplay'), $rules);
+            }
+
+            if ($description !== '') {
+                $summary_lines[] = sprintf(__('Descrição: %s', 'juntaplay'), $description);
+            }
+
+            $summary_message = implode("\n", [
+                sprintf(__('Olá %s, aqui estão as informações do seu novo grupo.', 'juntaplay'), $user->display_name ?: $user->user_login),
+                sprintf(__('Seu grupo público “%s” foi criado e está aguardando análise para aprovação.', 'juntaplay'), $group_title),
+                __('Você será notificado em breve com mais informações.', 'juntaplay'),
+                '',
+                __('Resumo cadastrado:', 'juntaplay'),
+                implode("\n", $summary_lines),
+                '',
+                sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+            ]);
+
+            wp_mail(
+                (string) $user->user_email,
+                sprintf(__('Resumo do seu novo grupo — %s', 'juntaplay'), $site_name),
+                $summary_message,
+                $headers
+            );
+
+            if ($validation_code !== '') {
+                $validation_message = implode("\n", [
+                    sprintf(__('Use o código abaixo para validar o e-mail associado ao grupo “%s”.', 'juntaplay'), $group_title),
+                    '',
+                    $validation_code,
+                    '',
+                    __('Informe este código apenas dentro do painel do JuntaPlay. Caso você não tenha solicitado a criação deste grupo, ignore esta mensagem.', 'juntaplay'),
+                    '',
+                    sprintf(__('Equipe %s', 'juntaplay'), $site_name),
+                ]);
+
+                wp_mail(
+                    (string) $user->user_email,
+                    sprintf(__('Código de validação de e-mail — %s', 'juntaplay'), $site_name),
+                    $validation_message,
+                    $headers
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function on_complaint_created(int $complaint_id, int $group_id, int $user_id, array $context): void
+    {
+        $admin_email = (string) get_option('admin_email');
+        $site_name   = get_bloginfo('name');
+
+        $group       = GroupsData::get($group_id);
+        $group_title = isset($context['group_title']) && $context['group_title'] !== ''
+            ? (string) $context['group_title']
+            : ($group && isset($group->title) ? (string) $group->title : __('Grupo', 'juntaplay'));
+
+        $reason_key   = isset($context['reason']) ? (string) $context['reason'] : 'other';
+        $reason_label = GroupComplaintsData::get_reason_label($reason_key);
+        $order_id     = isset($context['order_id']) ? (int) $context['order_id'] : 0;
+        $message      = isset($context['message']) ? (string) $context['message'] : '';
+        $attachments  = isset($context['attachments']) && is_array($context['attachments'])
+            ? array_filter(array_map('intval', $context['attachments']))
+            : [];
+
+        $user      = get_userdata($user_id);
+        $user_name = $user ? ($user->display_name ?: $user->user_login) : __('Cliente', 'juntaplay');
+        $user_email = $user ? (string) $user->user_email : '';
+
+        $attachment_lines = [];
+        foreach ($attachments as $attachment_id) {
+            $url = wp_get_attachment_url($attachment_id);
+            if ($url) {
+                $attachment_lines[] = $url;
+            }
+        }
+
+        $admin_lines = [
+            sprintf(__('Grupo: %s', 'juntaplay'), $group_title),
+            sprintf(__('Motivo: %s', 'juntaplay'), $reason_label),
+            sprintf(__('Cliente: %1$s (ID %2$d)', 'juntaplay'), $user_name, $user_id),
+        ];
+
+        if ($order_id > 0) {
+            $admin_lines[] = sprintf(__('Pedido relacionado: #%d', 'juntaplay'), $order_id);
+        }
+
+        if ($attachment_lines) {
+            $admin_lines[] = __('Anexos enviados:', 'juntaplay');
+            $admin_lines   = array_merge($admin_lines, $attachment_lines);
+        }
+
+        if ($admin_email !== '') {
+            $admin_message = implode("\n", [
+                sprintf(__('Nova reclamação #%1$d registrada para o grupo “%2$s”.', 'juntaplay'), $complaint_id, $group_title),
+                '',
+                implode("\n", $admin_lines),
+                '',
+                __('Descrição enviada:', 'juntaplay'),
+                $message !== '' ? $message : __('O cliente não adicionou detalhes adicionais.', 'juntaplay'),
+                '',
+                sprintf(__('Revise no painel: %s', 'juntaplay'), esc_url(admin_url('admin.php?page=juntaplay-groups'))),
+            ]);
+
+            wp_mail(
+                $admin_email,
+                sprintf(__('Reclamação #%1$d registrada — %2$s', 'juntaplay'), $complaint_id, $site_name),
+                $admin_message,
+                ['Content-Type: text/plain; charset=UTF-8']
+            );
+        }
+
+        if ($user_email !== '') {
+            $user_lines = [
+                sprintf(__('Olá %s, recebemos sua reclamação.', 'juntaplay'), $user_name),
+                sprintf(__('Grupo: %s', 'juntaplay'), $group_title),
+                sprintf(__('Motivo selecionado: %s', 'juntaplay'), $reason_label),
+            ];
+
+            if ($order_id > 0) {
+                $user_lines[] = sprintf(__('Pedido relacionado: #%d', 'juntaplay'), $order_id);
+            }
+
+            if ($message !== '') {
+                $user_lines[] = '';
+                $user_lines[] = __('Descrição enviada:', 'juntaplay');
+                $user_lines[] = $message;
+            }
+
+            $user_lines[] = '';
+            $user_lines[] = __('Nossa equipe e o administrador foram notificados e responderão em breve.', 'juntaplay');
+            $user_lines[] = __('Você pode acompanhar o andamento acessando o seu painel em Minha Conta > Meus Grupos.', 'juntaplay');
+            $user_lines[] = '';
+            $user_lines[] = sprintf(__('Equipe %s', 'juntaplay'), $site_name);
+
+            wp_mail(
+                $user_email,
+                sprintf(__('Recebemos sua reclamação — %s', 'juntaplay'), $site_name),
+                implode("\n", $user_lines),
+                ['Content-Type: text/plain; charset=UTF-8']
+            );
+        }
+    }
+
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function on_status_changed(int $group_id, string $old_status, string $new_status, array $context = []): void
+    {
+        $group = GroupsData::get($group_id);
+        if (!$group || empty($group->owner_id)) {
+            return;
+        }
+
+        $owner = get_userdata((int) $group->owner_id);
+        if (!$owner || empty($owner->user_email)) {
+            return;
+        }
+
+        $site_name   = get_bloginfo('name');
+        $group_title = isset($group->title) ? (string) $group->title : __('Grupo', 'juntaplay');
+        $note        = isset($context['note']) ? (string) $context['note'] : '';
+        $headers     = ['Content-Type: text/plain; charset=UTF-8'];
+
+        switch ($new_status) {
+            case GroupsData::STATUS_APPROVED:
+                $subject = sprintf(__('Seu grupo “%s” foi aprovado!', 'juntaplay'), $group_title);
+                $message = sprintf(
+                    "%s\n\n%s",
+                    sprintf(__('Parabéns! O grupo “%s” foi aprovado e já está disponível para convidar participantes.', 'juntaplay'), $group_title),
+                    __('Acesse o painel do JuntaPlay para gerenciar convites e acompanhar as cotas.', 'juntaplay')
+                );
+                $profile_page_id = (int) get_option('juntaplay_page_perfil');
+                if ($profile_page_id > 0) {
+                    $profile_url = get_permalink($profile_page_id);
+                    if ($profile_url) {
+                        $message .= "\n\n" . sprintf(__('Libere o grupo acessando: %s', 'juntaplay'), esc_url($profile_url));
+                    }
+                }
+                break;
+            case GroupsData::STATUS_REJECTED:
+                $subject = sprintf(__('Seu grupo “%s” foi recusado', 'juntaplay'), $group_title);
+                $message = sprintf(
+                    "%s\n\n%s",
+                    sprintf(__('O grupo “%s” não foi aprovado neste momento.', 'juntaplay'), $group_title),
+                    $note !== '' ? sprintf(__('Motivo informado: %s', 'juntaplay'), $note) : __('Entre em contato com o suporte para mais detalhes.', 'juntaplay')
+                );
+                break;
+            case GroupsData::STATUS_ARCHIVED:
+                $subject = sprintf(__('Seu grupo “%s” foi arquivado', 'juntaplay'), $group_title);
+                $message = sprintf(
+                    "%s\n\n%s",
+                    sprintf(__('O grupo “%s” foi arquivado pelo super administrador.', 'juntaplay'), $group_title),
+                    __('Nenhuma nova cota poderá ser reservada até que ele seja reativado.', 'juntaplay')
+                );
+                if ($note !== '') {
+                    $message .= "\n\n" . sprintf(__('Observação: %s', 'juntaplay'), $note);
+                }
+                break;
+            case GroupsData::STATUS_PENDING:
+                $subject = sprintf(__('O grupo “%s” voltou para análise', 'juntaplay'), $group_title);
+                $message = __('Atualizamos o status do seu grupo para análise novamente. Em breve entraremos em contato.', 'juntaplay');
+                break;
+            default:
+                return;
+        }
+
+        wp_mail(
+            (string) $owner->user_email,
+            sprintf('%s — %s', $subject, $site_name),
+            $message,
+            $headers
+        );
+    }
+}

--- a/juntaplay/includes/Plugin.php
+++ b/juntaplay/includes/Plugin.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay;
+
+use JuntaPlay\Admin\Settings;
+use function trailingslashit;
+
+defined('ABSPATH') || exit;
+
+class Plugin
+{
+    public function init(): void
+    {
+        Installer::maybe_upgrade();
+
+        // Admin
+        (new Admin\Menu())->init();
+        (new Admin\Settings())->init();
+        (new Admin\Importer())->init();
+        (new Admin\Groups())->init();
+
+        // Frontend
+        $auth = new Front\Auth();
+        $auth->init();
+
+        $profile = new Front\Profile();
+        $profile->init();
+
+        (new Front\Shortcodes($auth, $profile))->init();
+        (new Front\Ajax($profile))->init();
+        (new Front\Rest())->init();
+
+        (new Notifications\Groups())->init();
+        (new Notifications\Credits())->init();
+
+        // WooCommerce integration
+        if (class_exists('\\WooCommerce')) {
+            (new Woo\ProductType())->init();
+            (new Woo\Hooks())->init();
+        }
+
+        // Elementor widgets
+        add_action('elementor/widgets/register', [$this, 'register_elementor_widgets']);
+
+        // Assets
+        add_action('wp_enqueue_scripts', [$this, 'enqueue_assets']);
+        Installer::bootstrap_cron();
+        Installer::schedule_cron();
+    }
+
+    public function register_elementor_widgets($widgets_manager): void
+    {
+        require_once JP_DIR . 'elementor/Widgets/WidgetPoolList.php';
+        require_once JP_DIR . 'elementor/Widgets/WidgetPoolHero.php';
+        require_once JP_DIR . 'elementor/Widgets/WidgetQuotaGrid.php';
+
+        $widgets_manager->register(new \JuntaPlayElementor\WidgetPoolList());
+        $widgets_manager->register(new \JuntaPlayElementor\WidgetPoolHero());
+        $widgets_manager->register(new \JuntaPlayElementor\WidgetQuotaGrid());
+    }
+
+    public function enqueue_assets(): void
+    {
+        wp_enqueue_style('juntaplay', JP_URL . 'assets/css/juntaplay.css', [], JP_VERSION);
+        wp_enqueue_script('juntaplay', JP_URL . 'assets/js/juntaplay.js', ['jquery'], JP_VERSION, true);
+
+        $general = get_option(Settings::OPTION_GENERAL, []);
+        $primary = isset($general['primary_color']) ? sanitize_hex_color($general['primary_color']) : null;
+        $primary = $primary ?: '#ff5a5f';
+        $primary_dark  = $this->shade_color($primary, -0.2);
+        $primary_light = $this->shade_color($primary, 0.35);
+
+        $inline_css = sprintf(
+            ':root{--jp-primary:%1$s;--jp-primary-dark:%2$s;--jp-primary-light:%3$s;} .juntaplay-button--primary{background:%1$s;border-color:%1$s;} .juntaplay-button--primary:hover,.juntaplay-button--primary:focus{background:%2$s;border-color:%2$s;} .juntaplay-badge{background:%3$s;color:%2$s;} .juntaplay-link{color:%1$s;} .juntaplay-link:hover,.juntaplay-link:focus{color:%2$s;}',
+            $primary,
+            $primary_dark,
+            $primary_light
+        );
+
+        wp_add_inline_style('juntaplay', $inline_css);
+
+        wp_localize_script('juntaplay', 'JuntaPlay', [
+            'ajax'   => admin_url('admin-ajax.php'),
+            'nonce'  => wp_create_nonce('jp_nonce'),
+            'assets' => [
+                'groupCoverPlaceholder' => JP_GROUP_COVER_PLACEHOLDER,
+            ],
+        ]);
+    }
+
+    private function shade_color(string $hex, float $percent): string
+    {
+        $hex = ltrim($hex, '#');
+        if (strlen($hex) === 3) {
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+        }
+
+        $num = hexdec($hex);
+        $r = ($num >> 16) & 0xff;
+        $g = ($num >> 8) & 0xff;
+        $b = $num & 0xff;
+
+        $percent = max(-1, min(1, $percent));
+
+        if ($percent < 0) {
+            $r = (int) max(0, round($r * (1 + $percent)));
+            $g = (int) max(0, round($g * (1 + $percent)));
+            $b = (int) max(0, round($b * (1 + $percent)));
+        } else {
+            $r = (int) min(255, round($r + (255 - $r) * $percent));
+            $g = (int) min(255, round($g + (255 - $g) * $percent));
+            $b = (int) min(255, round($b + (255 - $b) * $percent));
+        }
+
+        return sprintf('#%02x%02x%02x', $r, $g, $b);
+    }
+}

--- a/juntaplay/includes/Setup/DemoSeeder.php
+++ b/juntaplay/includes/Setup/DemoSeeder.php
@@ -1,0 +1,812 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Setup;
+
+use JuntaPlay\Data\GroupMembers;
+use JuntaPlay\Data\Groups;
+use WP_Error;
+use WP_User;
+
+use function __;
+use function current_time;
+use function file_exists;
+use function file_get_contents;
+use function esc_url_raw;
+use function get_option;
+use function get_current_user_id;
+use function get_user_by;
+use function get_post;
+use function is_wp_error;
+use function update_option;
+use function update_user_meta;
+use function wp_insert_user;
+use function wp_check_filetype;
+use function wp_insert_attachment;
+use function wp_generate_attachment_metadata;
+use function wp_update_attachment_metadata;
+use function wp_upload_bits;
+
+defined('ABSPATH') || exit;
+
+class DemoSeeder
+{
+    private const DEMO_PASSWORD = 'JuntaPlay#2024';
+
+    /**
+     * Populates demo users and groups for exploratory testing.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public function seed(): array|WP_Error
+    {
+        if (!function_exists('wp_insert_user')) {
+            return new WP_Error('missing_wp', __('Funções de usuário do WordPress indisponíveis.', 'juntaplay'));
+        }
+
+        $summary = [
+            'users'         => [],
+            'groups'        => [],
+            'created_at'    => current_time('mysql'),
+            'demo_password' => self::DEMO_PASSWORD,
+        ];
+
+        $users    = $this->get_users();
+        $user_ids = [];
+
+        foreach ($users as $user) {
+            $login    = $user['login'];
+            $existing = get_user_by('login', $login);
+
+            if ($existing instanceof WP_User) {
+                $user_ids[$login] = (int) $existing->ID;
+                $summary['users'][] = [
+                    'login'  => $login,
+                    'status' => 'existing',
+                    'id'     => (int) $existing->ID,
+                ];
+                continue;
+            }
+
+            $payload = [
+                'user_login'   => $login,
+                'user_email'   => $user['email'],
+                'user_pass'    => self::DEMO_PASSWORD,
+                'display_name' => $user['display_name'],
+                'first_name'   => $user['first_name'],
+                'last_name'    => $user['last_name'],
+                'role'         => $user['role'],
+                'description'  => $user['bio'],
+            ];
+
+            $user_id = wp_insert_user($payload);
+            if (is_wp_error($user_id)) {
+                $summary['users'][] = [
+                    'login'  => $login,
+                    'status' => 'error',
+                    'error'  => $user_id->get_error_message(),
+                ];
+                continue;
+            }
+
+            $user_id = (int) $user_id;
+            $user_ids[$login] = $user_id;
+            $summary['users'][] = [
+                'login'  => $login,
+                'status' => 'created',
+                'id'     => $user_id,
+            ];
+
+            if ($user['avatar'] !== '') {
+                update_user_meta($user_id, 'juntaplay_avatar_url', esc_url_raw($user['avatar']));
+            }
+        }
+
+        $super_admin_id = $this->resolve_super_admin_id($user_ids);
+        if ($super_admin_id <= 0) {
+            return new WP_Error('no_admin', __('Nenhum usuário administrador disponível para vincular aos grupos de exemplo.', 'juntaplay'));
+        }
+
+        $groups = $this->get_groups();
+        $default_cover_id = $this->ensure_demo_cover_attachment();
+
+        foreach ($groups as $group) {
+            $slug = $group['slug'];
+            if ($slug !== '' && Groups::slug_exists($slug)) {
+                $summary['groups'][] = [
+                    'title'  => $group['title'],
+                    'status' => 'skipped',
+                    'reason' => 'exists',
+                ];
+                continue;
+            }
+
+            $owner_id = $group['owner_login'] === 'super_admin'
+                ? $super_admin_id
+                : ($user_ids[$group['owner_login']] ?? 0);
+
+            if ($owner_id <= 0) {
+                $summary['groups'][] = [
+                    'title'  => $group['title'],
+                    'status' => 'skipped',
+                    'reason' => 'owner_missing',
+                ];
+                continue;
+            }
+
+            $group_id = Groups::create([
+                'title'             => $group['title'],
+                'owner_id'          => $owner_id,
+                'service_name'      => $group['service_name'],
+                'service_url'       => $group['service_url'],
+                'description'       => $group['description'],
+                'rules'             => $group['rules'],
+                'price_regular'     => $group['price_regular'],
+                'price_promotional' => $group['price_promotional'],
+                'member_price'      => $group['member_price'],
+                'slots_total'       => $group['slots_total'],
+                'slots_reserved'    => $group['slots_reserved'],
+                'support_channel'   => $group['support_channel'],
+                'delivery_time'     => $group['delivery_time'],
+                'access_method'     => $group['access_method'],
+                'category'          => $group['category'],
+                'instant_access'    => $group['instant_access'],
+                'slug'              => $slug,
+                'cover_id'          => isset($group['cover_id']) && (int) $group['cover_id'] > 0
+                    ? (int) $group['cover_id']
+                    : $default_cover_id,
+            ]);
+
+            if (!$group_id) {
+                $summary['groups'][] = [
+                    'title'  => $group['title'],
+                    'status' => 'error',
+                    'reason' => 'create_failed',
+                ];
+                continue;
+            }
+
+            foreach ($group['members'] as $member) {
+                $member_id = $member['login'] === 'super_admin'
+                    ? $super_admin_id
+                    : ($user_ids[$member['login']] ?? 0);
+
+                if ($member_id <= 0) {
+                    continue;
+                }
+
+                GroupMembers::add($group_id, $member_id, $member['role'], 'active');
+            }
+
+            if ($group['status'] !== Groups::STATUS_PENDING) {
+                Groups::update_status($group_id, $group['status'], [
+                    'reviewed_by' => $super_admin_id,
+                ]);
+            }
+
+            $summary['groups'][] = [
+                'title'  => $group['title'],
+                'status' => 'created',
+                'id'     => $group_id,
+            ];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function get_users(): array
+    {
+        return [
+            [
+                'login'        => 'demo.superadmin',
+                'email'        => 'demo.superadmin@example.com',
+                'display_name' => 'Equipe JuntaPlay',
+                'first_name'   => 'Equipe',
+                'last_name'    => 'JuntaPlay',
+                'role'         => 'administrator',
+                'bio'          => __('Conta administrativa de demonstração para aprovação de grupos.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=12',
+            ],
+            [
+                'login'        => 'ana.streaming',
+                'email'        => 'ana.streaming@example.com',
+                'display_name' => 'Ana Streaming',
+                'first_name'   => 'Ana',
+                'last_name'    => 'Streaming',
+                'role'         => 'subscriber',
+                'bio'          => __('Especialista em planos de streaming e vídeos on-line.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=47',
+            ],
+            [
+                'login'        => 'bruno.sound',
+                'email'        => 'bruno.sound@example.com',
+                'display_name' => 'Bruno Sound',
+                'first_name'   => 'Bruno',
+                'last_name'    => 'Sound',
+                'role'         => 'subscriber',
+                'bio'          => __('Curador de playlists e experiências de áudio em alta fidelidade.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=15',
+            ],
+            [
+                'login'        => 'carla.series',
+                'email'        => 'carla.series@example.com',
+                'display_name' => 'Carla Séries',
+                'first_name'   => 'Carla',
+                'last_name'    => 'Séries',
+                'role'         => 'subscriber',
+                'bio'          => __('Apaixonada por cinema independente e estreias semanais.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=32',
+            ],
+            [
+                'login'        => 'davi.cursos',
+                'email'        => 'davi.cursos@example.com',
+                'display_name' => 'Davi Cursos',
+                'first_name'   => 'Davi',
+                'last_name'    => 'Cursos',
+                'role'         => 'subscriber',
+                'bio'          => __('Professor que compartilha planos de estudo e ferramentas acadêmicas.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=38',
+            ],
+            [
+                'login'        => 'edu.livros',
+                'email'        => 'edu.livros@example.com',
+                'display_name' => 'Edu Livros',
+                'first_name'   => 'Edu',
+                'last_name'    => 'Livros',
+                'role'         => 'subscriber',
+                'bio'          => __('Colecionador de revistas e audiobooks digitais.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=54',
+            ],
+            [
+                'login'        => 'fernanda.office',
+                'email'        => 'fernanda.office@example.com',
+                'display_name' => 'Fernanda Office',
+                'first_name'   => 'Fernanda',
+                'last_name'    => 'Office',
+                'role'         => 'subscriber',
+                'bio'          => __('Designer que administra ferramentas de produtividade para equipes remotas.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=68',
+            ],
+            [
+                'login'        => 'gustavo.games',
+                'email'        => 'gustavo.games@example.com',
+                'display_name' => 'Gustavo Games',
+                'first_name'   => 'Gustavo',
+                'last_name'    => 'Games',
+                'role'         => 'subscriber',
+                'bio'          => __('Streamer esportivo que coordena ligas e campeonatos.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=23',
+            ],
+            [
+                'login'        => 'helena.segura',
+                'email'        => 'helena.segura@example.com',
+                'display_name' => 'Helena Segura',
+                'first_name'   => 'Helena',
+                'last_name'    => 'Segura',
+                'role'         => 'subscriber',
+                'bio'          => __('Analista de cibersegurança focada em privacidade digital.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=9',
+            ],
+            [
+                'login'        => 'igor.ai',
+                'email'        => 'igor.ai@example.com',
+                'display_name' => 'Igor AI',
+                'first_name'   => 'Igor',
+                'last_name'    => 'AI',
+                'role'         => 'subscriber',
+                'bio'          => __('Pesquisador de inteligência artificial e automações.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=5',
+            ],
+            [
+                'login'        => 'juliana.boloes',
+                'email'        => 'juliana.boloes@example.com',
+                'display_name' => 'Juliana Bolões',
+                'first_name'   => 'Juliana',
+                'last_name'    => 'Bolões',
+                'role'         => 'subscriber',
+                'bio'          => __('Organizadora de bolões semanais e rifas solidárias.', 'juntaplay'),
+                'avatar'       => 'https://i.pravatar.cc/300?img=61',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function get_groups(): array
+    {
+        return [
+            [
+                'title'            => 'YouTube Premium Família',
+                'slug'             => 'youtube-premium-familia',
+                'service_name'     => 'YouTube Premium',
+                'service_url'      => 'https://www.youtube.com/premium',
+                'description'      => __('Divida música e vídeos sem anúncios com até 6 perfis no mesmo plano.', 'juntaplay'),
+                'rules'            => __('Não alterar senha nem idioma. Perfis identificados pelo primeiro nome.', 'juntaplay'),
+                'price_regular'    => 34.9,
+                'price_promotional'=> 22.9,
+                'member_price'     => 12.9,
+                'slots_total'      => 6,
+                'slots_reserved'   => 4,
+                'support_channel'  => 'WhatsApp +55 11 90000-1000',
+                'delivery_time'    => __('Envio imediato após confirmação do pagamento.', 'juntaplay'),
+                'access_method'    => __('Convite família via e-mail cadastrado.', 'juntaplay'),
+                'category'         => 'video',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'ana.streaming',
+                'members'          => [
+                    ['login' => 'ana.streaming', 'role' => 'owner'],
+                    ['login' => 'bruno.sound', 'role' => 'manager'],
+                    ['login' => 'carla.series', 'role' => 'member'],
+                    ['login' => 'davi.cursos', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'MUBI Cinemateca',
+                'slug'             => 'mubi-cinemateca',
+                'service_name'     => 'Mubi',
+                'service_url'      => 'https://mubi.com',
+                'description'      => __('Seleção rotativa de filmes independentes para cinéfilos exigentes.', 'juntaplay'),
+                'rules'            => __('Não compartilhar fora do grupo. Acesso individual com e-mail.', 'juntaplay'),
+                'price_regular'    => 27.9,
+                'price_promotional'=> 19.9,
+                'member_price'     => 11.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 3,
+                'support_channel'  => 'Telegram @cineclubemubi',
+                'delivery_time'    => __('Confirmação em até 12 horas úteis.', 'juntaplay'),
+                'access_method'    => __('Convite por e-mail e senha compartilhada.', 'juntaplay'),
+                'category'         => 'video',
+                'instant_access'   => false,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'carla.series',
+                'members'          => [
+                    ['login' => 'carla.series', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'gustavo.games', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'NBA League Pass Squad',
+                'slug'             => 'nba-league-pass-squad',
+                'service_name'     => 'NBA League Pass',
+                'service_url'      => 'https://www.nba.com/watch/league-pass',
+                'description'      => __('Acompanhe todos os jogos da temporada regular e playoffs.', 'juntaplay'),
+                'rules'            => __('Não compartilhar streams públicos. Cada membro usa perfil dedicado.', 'juntaplay'),
+                'price_regular'    => 149.9,
+                'price_promotional'=> 119.9,
+                'member_price'     => 39.9,
+                'slots_total'      => 4,
+                'slots_reserved'   => 2,
+                'support_channel'  => 'Discord.gg/nba-coop',
+                'delivery_time'    => __('Liberação em até 6 horas.', 'juntaplay'),
+                'access_method'    => __('Perfis individuais no aplicativo oficial.', 'juntaplay'),
+                'category'         => 'games',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'gustavo.games',
+                'members'          => [
+                    ['login' => 'gustavo.games', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'juliana.boloes', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'PlayPlus Família',
+                'slug'             => 'playplus-familia',
+                'service_name'     => 'PlayPlus',
+                'service_url'      => 'https://www.playplus.com',
+                'description'      => __('Séries nacionais, jornalismo e esportes ao vivo da Record TV.', 'juntaplay'),
+                'rules'            => __('Troca de senha apenas pela administração. Sem downloads simultâneos.', 'juntaplay'),
+                'price_regular'    => 32.9,
+                'price_promotional'=> 21.9,
+                'member_price'     => 10.9,
+                'slots_total'      => 4,
+                'slots_reserved'   => 4,
+                'support_channel'  => 'E-mail suporte@juntaplay.example',
+                'delivery_time'    => __('Acesso liberado automaticamente após a aprovação.', 'juntaplay'),
+                'access_method'    => __('Perfis compartilhados e login único.', 'juntaplay'),
+                'category'         => 'video',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'super_admin',
+                'members'          => [
+                    ['login' => 'super_admin', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'manager'],
+                    ['login' => 'carla.series', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Spotify Premium Família',
+                'slug'             => 'spotify-premium-familia',
+                'service_name'     => 'Spotify Premium',
+                'service_url'      => 'https://www.spotify.com/br/family',
+                'description'      => __('Plano família com mix semanal exclusivo e podcasts originais.', 'juntaplay'),
+                'rules'            => __('Endereço cadastrado único. Perfis com nome e avatar personalizado.', 'juntaplay'),
+                'price_regular'    => 34.9,
+                'price_promotional'=> 24.9,
+                'member_price'     => 9.9,
+                'slots_total'      => 6,
+                'slots_reserved'   => 5,
+                'support_channel'  => 'WhatsApp +55 21 95555-0000',
+                'delivery_time'    => __('Convite enviado em até 2 horas.', 'juntaplay'),
+                'access_method'    => __('Convite família com endereço compartilhado.', 'juntaplay'),
+                'category'         => 'music',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'bruno.sound',
+                'members'          => [
+                    ['login' => 'bruno.sound', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'davi.cursos', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Tidal HiFi Max Collective',
+                'slug'             => 'tidal-hifi-max-collective',
+                'service_name'     => 'Tidal',
+                'service_url'      => 'https://tidal.com',
+                'description'      => __('Áudio HiFi sem perdas e catálogo Dolby Atmos compartilhado.', 'juntaplay'),
+                'rules'            => __('Sem mudanças de senha. Perfis identificados com iniciais.', 'juntaplay'),
+                'price_regular'    => 39.9,
+                'price_promotional'=> 29.9,
+                'member_price'     => 14.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 3,
+                'support_channel'  => 'Grupo Telegram @hifimax',
+                'delivery_time'    => __('Liberação em até 8 horas.', 'juntaplay'),
+                'access_method'    => __('Perfis compartilhados no app.', 'juntaplay'),
+                'category'         => 'music',
+                'instant_access'   => false,
+                'status'           => Groups::STATUS_PENDING,
+                'owner_login'      => 'bruno.sound',
+                'members'          => [
+                    ['login' => 'bruno.sound', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'igor.ai', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Brainly Premium Squad',
+                'slug'             => 'brainly-premium-squad',
+                'service_name'     => 'Brainly Premium',
+                'service_url'      => 'https://brainly.com.br',
+                'description'      => __('Respostas verificadas e monitorias em tempo real para vestibulares.', 'juntaplay'),
+                'rules'            => __('Acesso individual, não compartilhar prints públicos.', 'juntaplay'),
+                'price_regular'    => 29.9,
+                'price_promotional'=> 21.9,
+                'member_price'     => 12.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 4,
+                'support_channel'  => 'Discord.gg/brainlysquad',
+                'delivery_time'    => __('Ativação em até 4 horas.', 'juntaplay'),
+                'access_method'    => __('Convite por e-mail com usuário dedicado.', 'juntaplay'),
+                'category'         => 'education',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'davi.cursos',
+                'members'          => [
+                    ['login' => 'davi.cursos', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'igor.ai', 'role' => 'member'],
+                    ['login' => 'juliana.boloes', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Ubook Audiobooks Club',
+                'slug'             => 'ubook-audiobooks-club',
+                'service_name'     => 'Ubook',
+                'service_url'      => 'https://www.ubook.com',
+                'description'      => __('Audiobooks e podcasts originais para ouvir offline.', 'juntaplay'),
+                'rules'            => __('Download liberado para uso pessoal. Não compartilhar arquivos ripados.', 'juntaplay'),
+                'price_regular'    => 19.9,
+                'price_promotional'=> 14.9,
+                'member_price'     => 8.9,
+                'slots_total'      => 4,
+                'slots_reserved'   => 2,
+                'support_channel'  => 'E-mail clube@ubookfans.example',
+                'delivery_time'    => __('Ativação em até 24 horas.', 'juntaplay'),
+                'access_method'    => __('Usuário individual com senha única.', 'juntaplay'),
+                'category'         => 'reading',
+                'instant_access'   => false,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'edu.livros',
+                'members'          => [
+                    ['login' => 'edu.livros', 'role' => 'owner'],
+                    ['login' => 'davi.cursos', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Super Interessante Digital',
+                'slug'             => 'super-interessante-digital',
+                'service_name'     => 'Super Interessante',
+                'service_url'      => 'https://super.abril.com.br',
+                'description'      => __('Revista mensal com acervo completo e reportagens especiais.', 'juntaplay'),
+                'rules'            => __('Uso individual. Não compartilhar PDFs fora do grupo.', 'juntaplay'),
+                'price_regular'    => 16.9,
+                'price_promotional'=> 12.9,
+                'member_price'     => 6.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 5,
+                'support_channel'  => 'WhatsApp +55 31 94444-0020',
+                'delivery_time'    => __('Envio em até 3 horas.', 'juntaplay'),
+                'access_method'    => __('Login individual com senha rotativa.', 'juntaplay'),
+                'category'         => 'reading',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'edu.livros',
+                'members'          => [
+                    ['login' => 'edu.livros', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'juliana.boloes', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Veja Saúde Coletivo',
+                'slug'             => 'veja-saude-coletivo',
+                'service_name'     => 'Veja Saúde',
+                'service_url'      => 'https://saude.abril.com.br',
+                'description'      => __('Conteúdos exclusivos de saúde, bem-estar e alimentação balanceada.', 'juntaplay'),
+                'rules'            => __('Acesso somente pessoal. Não divulgar login.', 'juntaplay'),
+                'price_regular'    => 14.9,
+                'price_promotional'=> 9.9,
+                'member_price'     => 6.5,
+                'slots_total'      => 5,
+                'slots_reserved'   => 3,
+                'support_channel'  => 'Telegram @revistasaude',
+                'delivery_time'    => __('Liberação automática após pagamento.', 'juntaplay'),
+                'access_method'    => __('Login compartilhado com autenticação em duas etapas.', 'juntaplay'),
+                'category'         => 'reading',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_PENDING,
+                'owner_login'      => 'edu.livros',
+                'members'          => [
+                    ['login' => 'edu.livros', 'role' => 'owner'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                    ['login' => 'juliana.boloes', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Perplexity Pro Research Hub',
+                'slug'             => 'perplexity-pro-research-hub',
+                'service_name'     => 'Perplexity Pro',
+                'service_url'      => 'https://www.perplexity.ai',
+                'description'      => __('Pesquisa avançada com IA generativa e histórico compartilhado.', 'juntaplay'),
+                'rules'            => __('Não compartilhar histórico sensível. Limite de 5 prompts por hora por membro.', 'juntaplay'),
+                'price_regular'    => 99.9,
+                'price_promotional'=> 79.9,
+                'member_price'     => 39.9,
+                'slots_total'      => 4,
+                'slots_reserved'   => 2,
+                'support_channel'  => 'Slack #ia-coop',
+                'delivery_time'    => __('Ativação manual em até 12 horas.', 'juntaplay'),
+                'access_method'    => __('Convite por e-mail corporativo.', 'juntaplay'),
+                'category'         => 'ai',
+                'instant_access'   => false,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'igor.ai',
+                'members'          => [
+                    ['login' => 'igor.ai', 'role' => 'owner'],
+                    ['login' => 'davi.cursos', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Canva Pro Studios',
+                'slug'             => 'canva-pro-studios',
+                'service_name'     => 'Canva Pro',
+                'service_url'      => 'https://www.canva.com',
+                'description'      => __('Ferramentas premium de design com bibliotecas compartilhadas.', 'juntaplay'),
+                'rules'            => __('Não remover marcas do time. Organizar pastas por projeto.', 'juntaplay'),
+                'price_regular'    => 42.9,
+                'price_promotional'=> 31.9,
+                'member_price'     => 15.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 4,
+                'support_channel'  => 'Slack #design-freelas',
+                'delivery_time'    => __('Convite enviado automaticamente.', 'juntaplay'),
+                'access_method'    => __('Convite por e-mail com domínio verificado.', 'juntaplay'),
+                'category'         => 'office',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'fernanda.office',
+                'members'          => [
+                    ['login' => 'fernanda.office', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'igor.ai', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Google One 2TB Compartilhado',
+                'slug'             => 'google-one-2tb-compartilhado',
+                'service_name'     => 'Google One',
+                'service_url'      => 'https://one.google.com',
+                'description'      => __('2 TB de armazenamento e VPN Google para a família.', 'juntaplay'),
+                'rules'            => __('Não excluir arquivos de outros membros. Gerenciar pastas pelo Drive.', 'juntaplay'),
+                'price_regular'    => 34.9,
+                'price_promotional'=> 24.9,
+                'member_price'     => 11.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 5,
+                'support_channel'  => 'WhatsApp +55 27 93333-0990',
+                'delivery_time'    => __('Convite em até 1 hora.', 'juntaplay'),
+                'access_method'    => __('Família Google com compartilhamento imediato.', 'juntaplay'),
+                'category'         => 'office',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'fernanda.office',
+                'members'          => [
+                    ['login' => 'fernanda.office', 'role' => 'owner'],
+                    ['login' => 'bruno.sound', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                    ['login' => 'juliana.boloes', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'ExpressVPN Global Access',
+                'slug'             => 'expressvpn-global-access',
+                'service_name'     => 'ExpressVPN',
+                'service_url'      => 'https://www.expressvpn.com',
+                'description'      => __('Rede privada virtual com servidores em 94 países.', 'juntaplay'),
+                'rules'            => __('Não compartilhar credenciais fora do grupo. Respeitar limites de dispositivos.', 'juntaplay'),
+                'price_regular'    => 55.9,
+                'price_promotional'=> 42.9,
+                'member_price'     => 19.9,
+                'slots_total'      => 5,
+                'slots_reserved'   => 3,
+                'support_channel'  => 'Signal +55 41 98888-1010',
+                'delivery_time'    => __('Entrega manual em até 6 horas.', 'juntaplay'),
+                'access_method'    => __('Credenciais compartilhadas com OTP rotativo.', 'juntaplay'),
+                'category'         => 'security',
+                'instant_access'   => false,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'helena.segura',
+                'members'          => [
+                    ['login' => 'helena.segura', 'role' => 'owner'],
+                    ['login' => 'igor.ai', 'role' => 'member'],
+                    ['login' => 'bruno.sound', 'role' => 'member'],
+                ],
+            ],
+            [
+                'title'            => 'Bolão Mega da Virada 2024',
+                'slug'             => 'bolao-mega-da-virada-2024',
+                'service_name'     => 'Bolão Mega-Sena',
+                'service_url'      => 'https://loterias.caixa.gov.br',
+                'description'      => __('Cotas digitais para o maior concurso do ano com conferência automática.', 'juntaplay'),
+                'rules'            => __('Pagamento antecipado. Resultado divulgado em live exclusiva.', 'juntaplay'),
+                'price_regular'    => 25.0,
+                'price_promotional'=> 20.0,
+                'member_price'     => 20.0,
+                'slots_total'      => 50,
+                'slots_reserved'   => 28,
+                'support_channel'  => 'Grupo WhatsApp +55 62 97777-5050',
+                'delivery_time'    => __('Confirmação instantânea com recibo PDF.', 'juntaplay'),
+                'access_method'    => __('Cotas digitais com comprovante individual.', 'juntaplay'),
+                'category'         => 'boloes',
+                'instant_access'   => true,
+                'status'           => Groups::STATUS_APPROVED,
+                'owner_login'      => 'juliana.boloes',
+                'members'          => [
+                    ['login' => 'juliana.boloes', 'role' => 'owner'],
+                    ['login' => 'ana.streaming', 'role' => 'member'],
+                    ['login' => 'gustavo.games', 'role' => 'member'],
+                    ['login' => 'helena.segura', 'role' => 'member'],
+                ],
+            ],
+        ];
+    }
+
+    private function ensure_demo_cover_attachment(): int
+    {
+        $cached = (int) get_option('juntaplay_demo_cover_id', 0);
+        if ($cached > 0 && get_post($cached)) {
+            return $cached;
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $contents = $this->generate_placeholder_png();
+        if ($contents === '') {
+            return 0;
+        }
+
+        $upload = wp_upload_bits('juntaplay-group-cover-demo.png', null, $contents);
+        if (!empty($upload['error'])) {
+            return 0;
+        }
+
+        $filetype = wp_check_filetype($upload['file'], null);
+        $attachment = [
+            'post_mime_type' => $filetype['type'] ?? 'image/png',
+            'post_title'     => __('Capa demo JuntaPlay', 'juntaplay'),
+            'post_content'   => '',
+            'post_status'    => 'inherit',
+        ];
+
+        $attachment_id = wp_insert_attachment($attachment, $upload['file']);
+        if (is_wp_error($attachment_id)) {
+            return 0;
+        }
+
+        $attachment_id = (int) $attachment_id;
+        $metadata = wp_generate_attachment_metadata($attachment_id, $upload['file']);
+        if (!is_wp_error($metadata) && !empty($metadata)) {
+            wp_update_attachment_metadata($attachment_id, $metadata);
+        }
+
+        update_option('juntaplay_demo_cover_id', $attachment_id);
+
+        return $attachment_id;
+    }
+
+    private function generate_placeholder_png(): string
+    {
+        if (!function_exists('imagecreatetruecolor')) {
+            return '';
+        }
+
+        $width  = 495;
+        $height = 370;
+
+        $image = imagecreatetruecolor($width, $height);
+        if (!$image) {
+            return '';
+        }
+
+        $start = [0x5b, 0x6c, 0xff];
+        $end   = [0x8e, 0x54, 0xe9];
+
+        for ($y = 0; $y < $height; $y++) {
+            $ratio = $height > 1 ? $y / ($height - 1) : 0;
+            $r     = (int) round($start[0] + ($end[0] - $start[0]) * $ratio);
+            $g     = (int) round($start[1] + ($end[1] - $start[1]) * $ratio);
+            $b     = (int) round($start[2] + ($end[2] - $start[2]) * $ratio);
+            $color = imagecolorallocate($image, $r, $g, $b);
+            imagefilledrectangle($image, 0, $y, $width, $y, $color);
+        }
+
+        $overlay = imagecolorallocatealpha($image, 255, 255, 255, 80);
+        imagefilledrectangle($image, 28, 28, $width - 28, 120, $overlay);
+
+        $text_color = imagecolorallocate($image, 255, 255, 255);
+        imagestring($image, 5, (int) (($width / 2) - 70), (int) ($height / 2) - 10, 'JuntaPlay', $text_color);
+        imagestring($image, 3, (int) (($width / 2) - 60), (int) ($height / 2) + 20, 'Demo Cover', $text_color);
+
+        ob_start();
+        imagepng($image);
+        $png = (string) ob_get_clean();
+        imagedestroy($image);
+
+        return $png;
+    }
+
+    /**
+     * @param array<string, int> $user_ids
+     */
+    private function resolve_super_admin_id(array $user_ids): int
+    {
+        $current = get_current_user_id();
+        if ($current > 0) {
+            return $current;
+        }
+
+        if (isset($user_ids['demo.superadmin'])) {
+            return $user_ids['demo.superadmin'];
+        }
+
+        $admin = get_user_by('login', 'admin');
+        if ($admin instanceof WP_User) {
+            return (int) $admin->ID;
+        }
+
+        return 0;
+    }
+}

--- a/juntaplay/includes/Woo/Credits.php
+++ b/juntaplay/includes/Woo/Credits.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Woo;
+
+use WC_Product;
+
+use function apply_filters;
+use function class_exists;
+use function get_option;
+use function get_post_status;
+use function is_wp_error;
+use function update_option;
+use function update_post_meta;
+use function wc_get_product;
+use function wp_insert_post;
+use function wp_set_object_terms;
+use function wp_untrash_post;
+use function wp_update_post;
+
+defined('ABSPATH') || exit;
+
+class Credits
+{
+    public const OPTION_DEPOSIT_PRODUCT = 'juntaplay_credit_product_id';
+
+    public static function get_product_id(): int
+    {
+        $product_id = (int) get_option(self::OPTION_DEPOSIT_PRODUCT, 0);
+
+        if ($product_id > 0) {
+            $status = get_post_status($product_id);
+
+            if ($status === 'publish') {
+                return $product_id;
+            }
+
+            if ($status === 'trash') {
+                wp_untrash_post($product_id);
+                $status = get_post_status($product_id);
+            }
+
+            if ($status && $status !== 'publish') {
+                wp_update_post([
+                    'ID'          => $product_id,
+                    'post_status' => 'publish',
+                ]);
+
+                return $product_id;
+            }
+        }
+
+        return self::create_product();
+    }
+
+    public static function get_product(): ?WC_Product
+    {
+        if (!function_exists('wc_get_product') || !class_exists('WooCommerce')) {
+            return null;
+        }
+
+        $product_id = self::get_product_id();
+
+        return $product_id > 0 ? wc_get_product($product_id) : null;
+    }
+
+    private static function create_product(): int
+    {
+        if (!class_exists('WooCommerce')) {
+            return 0;
+        }
+
+        $title = (string) apply_filters('juntaplay/credits/deposit_product_title', __('Recarga de Créditos', 'juntaplay'));
+
+        $product_id = wp_insert_post([
+            'post_title'   => $title,
+            'post_type'    => 'product',
+            'post_status'  => 'publish',
+            'post_content' => '',
+        ], true);
+
+        if (is_wp_error($product_id) || !$product_id) {
+            return 0;
+        }
+
+        wp_set_object_terms($product_id, 'juntaplay_credit_topup', 'product_type');
+
+        update_post_meta($product_id, '_regular_price', '0');
+        update_post_meta($product_id, '_price', '0');
+        update_post_meta($product_id, '_tax_status', 'none');
+        update_post_meta($product_id, '_manage_stock', 'no');
+        update_post_meta($product_id, '_stock_status', 'instock');
+        update_post_meta($product_id, '_virtual', 'yes');
+        update_post_meta($product_id, '_sold_individually', 'yes');
+        update_post_meta($product_id, '_downloadable', 'no');
+
+        $product = wc_get_product($product_id);
+
+        if ($product instanceof WC_Product) {
+            $product->set_catalog_visibility('hidden');
+            $product->set_status('publish');
+            $product->save();
+        }
+
+        update_option(self::OPTION_DEPOSIT_PRODUCT, (int) $product_id);
+
+        return (int) $product_id;
+    }
+}

--- a/juntaplay/includes/Woo/Hooks.php
+++ b/juntaplay/includes/Woo/Hooks.php
@@ -1,0 +1,292 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Woo;
+
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Product;
+use JuntaPlay\Admin\Settings;
+use JuntaPlay\Data\CreditTransactions;
+use JuntaPlay\Data\Quotas;
+
+use function absint;
+use function add_action;
+use function add_filter;
+use function array_map;
+use function current_time;
+use function get_option;
+use function get_current_user_id;
+use function get_user_meta;
+use function implode;
+use function in_array;
+use function is_admin;
+use function is_array;
+use function is_numeric;
+use function sanitize_text_field;
+use function sprintf;
+use function str_replace;
+use function update_user_meta;
+use function wc_add_notice;
+use function wc_get_order;
+use function wc_get_product;
+use function wc_price;
+use function wp_unslash;
+use function __;
+
+defined('ABSPATH') || exit;
+
+class Hooks
+{
+    public function init(): void
+    {
+        add_filter('woocommerce_add_to_cart_validation', [$this, 'validate_add_to_cart'], 10, 6);
+        add_filter('woocommerce_add_cart_item_data', [$this, 'store_cart_data'], 10, 3);
+        add_action('woocommerce_checkout_create_order_line_item', [$this, 'add_meta_to_item'], 10, 4);
+        add_action('woocommerce_order_status_changed', [$this, 'on_order_status_changed'], 10, 4);
+        add_action('woocommerce_before_calculate_totals', [$this, 'enforce_price']);
+    }
+
+    private array $pending_item = [];
+
+    public function validate_add_to_cart($passed, $product_id, $quantity, $variation_id = 0, $variations = [], $cart_item_data = [])
+    {
+        $product = wc_get_product($product_id);
+
+        if ($product instanceof WC_Product && $product->is_type('juntaplay_credit_topup')) {
+            $amount = 0.0;
+
+            if (isset($cart_item_data['juntaplay_deposit']) && is_array($cart_item_data['juntaplay_deposit'])) {
+                $amount = isset($cart_item_data['juntaplay_deposit']['amount']) && is_numeric($cart_item_data['juntaplay_deposit']['amount'])
+                    ? (float) $cart_item_data['juntaplay_deposit']['amount']
+                    : 0.0;
+            } elseif (isset($_POST['jp_deposit_amount'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+                $amount = (float) sanitize_text_field(wp_unslash($_POST['jp_deposit_amount'])); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+            }
+
+            if ($amount <= 0) {
+                wc_add_notice(__('Informe um valor válido para a recarga de créditos.', 'juntaplay'), 'error');
+
+                return false;
+            }
+
+            return $passed;
+        }
+
+        $pool_id = absint($_POST['jp_pool_id'] ?? 0);
+        $numbers = array_map('intval', $_POST['jp_numbers'] ?? []);
+        $user_id = get_current_user_id() ?: 0;
+
+        if (!$pool_id || empty($numbers)) {
+            wc_add_notice(__('Selecione pelo menos uma cota.', 'juntaplay'), 'error');
+
+            return false;
+        }
+
+        $settings = get_option(Settings::OPTION_RESERVE, ['minutes' => 15]);
+        $minutes  = (int) ($settings['minutes'] ?? 15);
+
+        $reserved = Quotas::reserve($pool_id, $numbers, $user_id, $minutes);
+
+        if (count($reserved) !== count($numbers)) {
+            wc_add_notice(__('Algumas cotas escolhidas não estão mais disponíveis.', 'juntaplay'), 'error');
+
+            return false;
+        }
+
+        $this->pending_item = ['pool_id' => $pool_id, 'numbers' => $numbers];
+
+        return $passed;
+    }
+
+    public function store_cart_data($cart_item_data, $product_id, $variation_id)
+    {
+        if (!empty($cart_item_data['juntaplay_deposit'])) {
+            return $cart_item_data;
+        }
+
+        if (!empty($this->pending_item)) {
+            $cart_item_data['juntaplay'] = $this->pending_item;
+            $this->pending_item          = [];
+        }
+
+        return $cart_item_data;
+    }
+
+    public function add_meta_to_item($item, $cart_item_key, $values, $order): void
+    {
+        if (!empty($values['juntaplay'])) {
+            $data = $values['juntaplay'];
+            $item->add_meta_data('JuntaPlay Pool', (int) $data['pool_id']);
+            $item->add_meta_data('JuntaPlay Cotas', implode(', ', array_map('intval', $data['numbers'])));
+
+            return;
+        }
+
+        if (empty($values['juntaplay_deposit'])) {
+            return;
+        }
+
+        $deposit   = $values['juntaplay_deposit'];
+        $amount    = isset($deposit['amount']) ? (float) $deposit['amount'] : 0.0;
+        $display   = $amount > 0 ? wc_price($amount) : '';
+        $reference = isset($deposit['reference']) ? (string) $deposit['reference'] : '';
+
+        $item->add_meta_data('JuntaPlay Depósito', $display !== '' ? $display : $amount);
+        $item->add_meta_data('_juntaplay_deposit_amount', $amount, true);
+
+        if ($reference !== '') {
+            $item->add_meta_data('_juntaplay_deposit_reference', $reference, true);
+        }
+    }
+
+    public function on_order_status_changed($order_id, $from, $to, $order): void
+    {
+        if (!($order instanceof WC_Order)) {
+            $order = wc_get_order($order_id);
+        }
+
+        if (!$order) {
+            return;
+        }
+
+        foreach ($order->get_items() as $item) {
+            if (!$item instanceof WC_Order_Item_Product) {
+                continue;
+            }
+
+            $deposit_amount = $item->get_meta('_juntaplay_deposit_amount', true);
+
+            if ($deposit_amount !== '') {
+                $this->handle_deposit_item($order, $item, $to);
+
+                continue;
+            }
+
+            $pool_id = (int) $item->get_meta('JuntaPlay Pool');
+            $numbers = $item->get_meta('JuntaPlay Cotas');
+
+            if (!$pool_id || !$numbers) {
+                continue;
+            }
+
+            $numbers = array_map('intval', explode(',', str_replace(' ', '', (string) $numbers)));
+
+            if (in_array($to, ['processing', 'completed'], true)) {
+                Quotas::pay($pool_id, $numbers, $order_id, (int) $order->get_user_id());
+            }
+
+            if (in_array($to, ['failed', 'cancelled', 'refunded'], true)) {
+                Quotas::release_by_order($order_id);
+            }
+        }
+    }
+
+    public function enforce_price($cart): void
+    {
+        if (is_admin() && !defined('DOING_AJAX')) {
+            return;
+        }
+
+        foreach ($cart->get_cart() as $cart_item_key => $cart_item) {
+            if (!empty($cart_item['juntaplay_deposit'])) {
+                $amount = isset($cart_item['juntaplay_deposit']['amount']) ? (float) $cart_item['juntaplay_deposit']['amount'] : 0.0;
+                $cart_item['data']->set_price($amount);
+
+                continue;
+            }
+
+            if (empty($cart_item['juntaplay']['pool_id'])) {
+                continue;
+            }
+
+            $pool = \JuntaPlay\Data\Pools::get((int) $cart_item['juntaplay']['pool_id']);
+
+            if ($pool) {
+                $cart_item['data']->set_price($pool->price);
+            }
+        }
+    }
+
+    private function handle_deposit_item(WC_Order $order, WC_Order_Item_Product $item, string $new_status): void
+    {
+        $order_id  = $order->get_id();
+        $user_id   = (int) $order->get_user_id();
+        $amount    = (float) $item->get_meta('_juntaplay_deposit_amount', true);
+        $processed = (string) $item->get_meta('_juntaplay_deposit_processed', true);
+        $reference = (string) $item->get_meta('_juntaplay_deposit_reference', true);
+
+        if ($user_id <= 0 || $amount <= 0) {
+            return;
+        }
+
+        if (in_array($new_status, ['processing', 'completed'], true)) {
+            if ($processed === 'completed') {
+                return;
+            }
+
+            $balance       = (float) get_user_meta($user_id, 'juntaplay_credit_balance', true);
+            $balance       = max(0.0, $balance);
+            $balance_after = $balance + $amount;
+
+            update_user_meta($user_id, 'juntaplay_credit_balance', number_format($balance_after, 2, '.', ''));
+            update_user_meta($user_id, 'juntaplay_credit_updated_at', current_time('mysql'));
+            update_user_meta($user_id, 'juntaplay_credit_last_recharge', current_time('mysql'));
+
+            CreditTransactions::create([
+                'user_id'       => $user_id,
+                'type'          => CreditTransactions::TYPE_DEPOSIT,
+                'status'        => CreditTransactions::STATUS_COMPLETED,
+                'amount'        => $amount,
+                'balance_after' => $balance_after,
+                'reference'     => $reference !== '' ? $reference : sprintf('JPD-%d', $order_id),
+                'context'       => [
+                    'order_id' => $order_id,
+                    'item_id'  => $item->get_id(),
+                ],
+            ]);
+
+            $item->update_meta_data('_juntaplay_deposit_processed', 'completed');
+            $item->save();
+
+            do_action('juntaplay/credits/deposit_completed', $user_id, [
+                'amount'    => $amount,
+                'reference' => $reference,
+                'order_id'  => $order_id,
+            ]);
+
+            return;
+        }
+
+        if (in_array($new_status, ['failed', 'cancelled', 'refunded'], true) && $processed === 'completed') {
+            $balance       = (float) get_user_meta($user_id, 'juntaplay_credit_balance', true);
+            $balance_after = max(0.0, $balance - $amount);
+
+            update_user_meta($user_id, 'juntaplay_credit_balance', number_format($balance_after, 2, '.', ''));
+            update_user_meta($user_id, 'juntaplay_credit_updated_at', current_time('mysql'));
+
+            CreditTransactions::create([
+                'user_id'       => $user_id,
+                'type'          => CreditTransactions::TYPE_ADJUSTMENT,
+                'status'        => CreditTransactions::STATUS_FAILED,
+                'amount'        => -$amount,
+                'balance_after' => $balance_after,
+                'reference'     => $reference !== '' ? $reference : sprintf('JPD-%d', $order_id),
+                'context'       => [
+                    'order_id' => $order_id,
+                    'item_id'  => $item->get_id(),
+                    'reason'   => 'deposit_reversed',
+                ],
+            ]);
+
+            $item->update_meta_data('_juntaplay_deposit_processed', 'reversed');
+            $item->save();
+
+            do_action('juntaplay/credits/deposit_reversed', $user_id, [
+                'amount'    => $amount,
+                'reference' => $reference,
+                'order_id'  => $order_id,
+            ]);
+        }
+    }
+}

--- a/juntaplay/includes/Woo/ProductType.php
+++ b/juntaplay/includes/Woo/ProductType.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Woo;
+
+defined('ABSPATH') || exit;
+
+class ProductType
+{
+    public function init(): void
+    {
+        add_filter('product_type_selector', [$this, 'add_product_type']);
+        add_filter('woocommerce_product_class', [$this, 'map_product_class'], 10, 2);
+    }
+
+    public function add_product_type(array $types): array
+    {
+        $types['juntaplay_pool_product']   = __('Campanha JuntaPlay', 'juntaplay');
+        $types['juntaplay_credit_topup']   = __('Recarga de Créditos', 'juntaplay');
+
+        return $types;
+    }
+
+    public function map_product_class(string $classname, string $product_type): string
+    {
+        if ('juntaplay_pool_product' === $product_type) {
+            return '\\JuntaPlay\\Woo\\Products\\PoolProduct';
+        }
+
+        if ('juntaplay_credit_topup' === $product_type) {
+            return '\\JuntaPlay\\Woo\\Products\\CreditTopUpProduct';
+        }
+
+        return $classname;
+    }
+}

--- a/juntaplay/includes/Woo/Products/CreditTopUpProduct.php
+++ b/juntaplay/includes/Woo/Products/CreditTopUpProduct.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Woo\Products;
+
+use WC_Product_Simple;
+
+defined('ABSPATH') || exit;
+
+class CreditTopUpProduct extends WC_Product_Simple
+{
+    protected $product_type = 'juntaplay_credit_topup';
+}

--- a/juntaplay/includes/Woo/Products/PoolProduct.php
+++ b/juntaplay/includes/Woo/Products/PoolProduct.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace JuntaPlay\Woo\Products;
+
+use WC_Product_Simple;
+
+defined('ABSPATH') || exit;
+
+class PoolProduct extends WC_Product_Simple
+{
+    protected $product_type = 'juntaplay_pool_product';
+}

--- a/juntaplay/juntaplay.php
+++ b/juntaplay/juntaplay.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Plugin Name: JuntaPlay — Gestão de Cotas
+ * Description: Campanhas com cotas integradas ao WooCommerce e Elementor.
+ * Version: 0.1.1
+ * Requires at least: 6.2
+ * Requires PHP: 8.1
+ * Author: Sua Empresa
+ * Text Domain: juntaplay
+ */
+
+declare(strict_types=1);
+
+defined('ABSPATH') || exit;
+
+const JP_VERSION    = '0.1.1';
+const JP_MIN_WP     = '6.2';
+const JP_MIN_PHP    = '8.1';
+const JP_DB_VERSION = '1.9.0';
+const JP_SLUG       = 'juntaplay';
+const JP_GROUP_COVER_PLACEHOLDER = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc0OTUnIGhlaWdodD0nMzcwJyB2aWV3Qm94PScwIDA0OTUgMzcwJz4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0nZycgeDE9JzAnIHkxPScwJyB4Mj0nMScgeTI9JzEnPgogICAgICA8c3RvcCBvZmZzZXQ9JzAlJyBzdG9wLWNvbG9yPScjNUI2Q0ZGJy8+CiAgICAgIDxzdG9wIG9mZnNldD0nMTAwJScgc3RvcC1jb2xvcj0nIzhFNTRFOScvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9JzQ5NScgaGVpZ2h0PSczNzAnIGZpbGw9J3VybCgjZyknIHJ4PSczMicvPgogIDxnIGZpbGw9JyNGRkZGRkYnIGZvbnQtZmFtaWx5PSdGcmVkb2thLCBGaWd0cmVlLCBzYW5zLXNlcmlmJyBmb250LXdlaWdodD0nNjAwJz4KICAgIDx0ZXh0IHg9JzUwJScgeT0nNDglJyBkb21pbmFudC1iYXNlbGluZT0nbWlkZGxlJyB0ZXh0LWFuY2hvcj0nbWlkZGxlJyBmb250LXNpemU9JzQwJz5KdW50YVBsYXk8L3RleHQ+CiAgICA8dGV4dCB4PSc1MCUnIHk9JzYwJScgZG9taW5hbnQtYmFzZWxpbmU9J21pZGRsZScgdGV4dC1hbmNob3I9J21pZGRsZScgZm9udC1zaXplPScyNCcgZm9udC13ZWlnaHQ9JzQwMCc+Q2FwYSBEZW1vbnN0cmF0aXZhPC90ZXh0PgogIDwvZz4KPC9zdmc+';
+
+define('JP_FILE', __FILE__);
+define('JP_DIR', plugin_dir_path(__FILE__));
+define('JP_URL', plugin_dir_url(__FILE__));
+
+spl_autoload_register(static function (string $class): void {
+    $prefix   = 'JuntaPlay\\';
+    $base_dir = JP_DIR . 'includes/';
+    $len      = strlen($prefix);
+
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative_class = substr($class, $len);
+    $file           = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+register_activation_hook(__FILE__, static function (): void {
+    (new \JuntaPlay\Installer())->activate();
+});
+
+register_uninstall_hook(__FILE__, 'juntaplay_uninstall');
+
+function juntaplay_uninstall(): void
+{
+    // Opcional: remover opções, eventos agendados etc. Não apagar dados por padrão.
+}
+
+add_action('plugins_loaded', static function (): void {
+    if (version_compare(PHP_VERSION, JP_MIN_PHP, '<')) {
+        return;
+    }
+
+    if (version_compare(get_bloginfo('version'), JP_MIN_WP, '<')) {
+        return;
+    }
+
+    (new \JuntaPlay\Plugin())->init();
+});

--- a/juntaplay/readme.txt
+++ b/juntaplay/readme.txt
@@ -1,0 +1,11 @@
+=== JuntaPlay — Gestão de Cotas ===
+Contributors: sua-empresa
+Tags: woocommerce, elementor, raffle, quotas
+Requires at least: 6.2
+Tested up to: 6.4
+Requires PHP: 8.1
+Stable tag: 0.1.1
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Plugin completo para gestão de campanhas com cotas integrado ao WooCommerce e Elementor.

--- a/juntaplay/templates/admin-groups.php
+++ b/juntaplay/templates/admin-groups.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Admin listing for JuntaPlay groups.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$context = isset($groups_page_context) && is_array($groups_page_context) ? $groups_page_context : [];
+
+$groups        = isset($context['groups']) && is_array($context['groups']) ? $context['groups'] : [];
+$current_status = isset($context['status']) ? (string) $context['status'] : 'all';
+$search_term    = isset($context['search']) ? (string) $context['search'] : '';
+$status_counts  = isset($context['status_counts']) && is_array($context['status_counts']) ? $context['status_counts'] : [];
+$notice         = isset($context['notice']) && is_array($context['notice']) ? $context['notice'] : null;
+
+$pending_count  = isset($status_counts[\JuntaPlay\Data\Groups::STATUS_PENDING]) ? (int) $status_counts[\JuntaPlay\Data\Groups::STATUS_PENDING] : 0;
+$approved_count = isset($status_counts[\JuntaPlay\Data\Groups::STATUS_APPROVED]) ? (int) $status_counts[\JuntaPlay\Data\Groups::STATUS_APPROVED] : 0;
+$rejected_count = isset($status_counts[\JuntaPlay\Data\Groups::STATUS_REJECTED]) ? (int) $status_counts[\JuntaPlay\Data\Groups::STATUS_REJECTED] : 0;
+$archived_count = isset($status_counts[\JuntaPlay\Data\Groups::STATUS_ARCHIVED]) ? (int) $status_counts[\JuntaPlay\Data\Groups::STATUS_ARCHIVED] : 0;
+
+$status_options = [
+    'all'                                   => esc_html__('Todos os status', 'juntaplay'),
+    \JuntaPlay\Data\Groups::STATUS_PENDING  => sprintf(esc_html__('Em análise (%d)', 'juntaplay'), $pending_count),
+    \JuntaPlay\Data\Groups::STATUS_APPROVED => sprintf(esc_html__('Aprovados (%d)', 'juntaplay'), $approved_count),
+    \JuntaPlay\Data\Groups::STATUS_REJECTED => sprintf(esc_html__('Recusados (%d)', 'juntaplay'), $rejected_count),
+    \JuntaPlay\Data\Groups::STATUS_ARCHIVED => sprintf(esc_html__('Arquivados (%d)', 'juntaplay'), $archived_count),
+];
+
+$current_url = add_query_arg([
+    'page'   => 'juntaplay-groups',
+    'status' => $current_status,
+    's'      => $search_term,
+], admin_url('admin.php'));
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('Grupos do JuntaPlay', 'juntaplay'); ?></h1>
+
+    <?php if ($notice) : ?>
+        <div class="notice notice-<?php echo esc_attr($notice['type'] === 'error' ? 'error' : 'success'); ?> is-dismissible">
+            <p><?php echo esc_html($notice['message']); ?></p>
+        </div>
+    <?php endif; ?>
+
+    <form method="get" class="juntaplay-groups-admin__filters">
+        <input type="hidden" name="page" value="juntaplay-groups" />
+
+        <label for="jp-groups-status" class="screen-reader-text"><?php esc_html_e('Filtrar por status', 'juntaplay'); ?></label>
+        <select id="jp-groups-status" name="status">
+            <?php foreach ($status_options as $value => $label) : ?>
+                <option value="<?php echo esc_attr((string) $value); ?>" <?php selected((string) $value, $current_status); ?>><?php echo esc_html($label); ?></option>
+            <?php endforeach; ?>
+        </select>
+
+        <label for="jp-groups-search" class="screen-reader-text"><?php esc_html_e('Buscar grupo', 'juntaplay'); ?></label>
+        <input type="search" id="jp-groups-search" name="s" value="<?php echo esc_attr($search_term); ?>" placeholder="<?php esc_attr_e('Buscar por nome ou criador', 'juntaplay'); ?>" />
+
+        <button type="submit" class="button button-primary"><?php esc_html_e('Filtrar', 'juntaplay'); ?></button>
+
+        <?php if ($current_status !== 'all' || $search_term !== '') : ?>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=juntaplay-groups')); ?>" class="button button-link"><?php esc_html_e('Limpar filtros', 'juntaplay'); ?></a>
+        <?php endif; ?>
+    </form>
+
+    <table class="wp-list-table widefat striped">
+        <thead>
+            <tr>
+                <th scope="col"><?php esc_html_e('Grupo', 'juntaplay'); ?></th>
+                <th scope="col"><?php esc_html_e('Criador', 'juntaplay'); ?></th>
+                <th scope="col"><?php esc_html_e('Status', 'juntaplay'); ?></th>
+                <th scope="col"><?php esc_html_e('Campanha', 'juntaplay'); ?></th>
+                <th scope="col" style="width:90px; text-align:center; "><?php esc_html_e('Membros', 'juntaplay'); ?></th>
+                <th scope="col"><?php esc_html_e('Criado em', 'juntaplay'); ?></th>
+                <th scope="col" style="width:220px; "><?php esc_html_e('Ações', 'juntaplay'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (!$groups) : ?>
+                <tr>
+                    <td colspan="7"><?php esc_html_e('Nenhum grupo encontrado.', 'juntaplay'); ?></td>
+                </tr>
+            <?php else : ?>
+                <?php $category_labels = \JuntaPlay\Data\Groups::get_category_labels(); ?>
+                <?php foreach ($groups as $group) :
+                    if (!is_array($group)) {
+                        continue;
+                    }
+
+                    $group_id      = isset($group['id']) ? (int) $group['id'] : 0;
+                    $group_title   = isset($group['title']) ? (string) $group['title'] : '';
+                    $status        = isset($group['status']) ? (string) $group['status'] : '';
+                    $status_label  = \JuntaPlay\Data\Groups::get_status_label($status);
+                    $owner_name    = isset($group['owner_name']) ? (string) $group['owner_name'] : '';
+                    $owner_email   = isset($group['owner_email']) ? (string) $group['owner_email'] : '';
+                    $pool_title    = isset($group['pool_title']) ? (string) $group['pool_title'] : '';
+                    $members_count = isset($group['members_count']) ? (int) $group['members_count'] : 0;
+                    $created_at    = isset($group['created_at']) ? (string) $group['created_at'] : '';
+                    $review_note   = isset($group['review_note']) ? (string) $group['review_note'] : '';
+                    $service_name  = isset($group['service_name']) ? (string) $group['service_name'] : '';
+                    $service_url   = isset($group['service_url']) ? (string) $group['service_url'] : '';
+                    $price_regular = isset($group['price_regular']) ? (float) $group['price_regular'] : 0.0;
+                    $price_promo   = isset($group['price_promotional']) ? (float) $group['price_promotional'] : 0.0;
+                    $member_price  = isset($group['member_price']) ? (float) $group['member_price'] : 0.0;
+                    $slots_total   = isset($group['slots_total']) ? (int) $group['slots_total'] : 0;
+                    $slots_reserved = isset($group['slots_reserved']) ? (int) $group['slots_reserved'] : 0;
+                    $support_channel = isset($group['support_channel']) ? (string) $group['support_channel'] : '';
+                    $delivery_time = isset($group['delivery_time']) ? (string) $group['delivery_time'] : '';
+                    $access_method = isset($group['access_method']) ? (string) $group['access_method'] : '';
+                    $category      = isset($group['category']) ? (string) $group['category'] : '';
+                    $instant_access = !empty($group['instant_access']);
+                    $category_label = $category !== '' && isset($category_labels[$category])
+                        ? (string) $category_labels[$category]
+                        : ($category !== '' ? ucwords(str_replace(['-', '_'], ' ', $category)) : '');
+
+                    $created_at_display = $created_at !== '' ? date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($created_at)) : '—';
+
+                    $available_actions = [];
+                    if ($status === \JuntaPlay\Data\Groups::STATUS_PENDING) {
+                        $available_actions = [
+                            'approve' => esc_html__('Aprovar', 'juntaplay'),
+                            'reject'  => esc_html__('Recusar', 'juntaplay'),
+                        ];
+                    } elseif ($status === \JuntaPlay\Data\Groups::STATUS_APPROVED) {
+                        $available_actions = [
+                            'archive' => esc_html__('Arquivar', 'juntaplay'),
+                            'reject'  => esc_html__('Recusar', 'juntaplay'),
+                        ];
+                    } elseif ($status === \JuntaPlay\Data\Groups::STATUS_REJECTED) {
+                        $available_actions = [
+                            'approve' => esc_html__('Aprovar novamente', 'juntaplay'),
+                            'archive' => esc_html__('Arquivar', 'juntaplay'),
+                            'reset'   => esc_html__('Voltar para análise', 'juntaplay'),
+                        ];
+                    } else {
+                        $available_actions = [
+                            'approve' => esc_html__('Reativar', 'juntaplay'),
+                            'reset'   => esc_html__('Voltar para análise', 'juntaplay'),
+                        ];
+                    }
+                    ?>
+                    <tr>
+                        <td>
+                            <strong><?php echo esc_html($group_title ?: __('(Sem título)', 'juntaplay')); ?></strong>
+                            <?php if ($service_name !== '' || $price_regular > 0 || $member_price > 0 || $slots_total > 0) : ?>
+                                <div class="description juntaplay-admin-group__meta">
+                                    <?php if ($service_name !== '') : ?>
+                                        <span>
+                                            <?php esc_html_e('Serviço:', 'juntaplay'); ?>
+                                            <?php if ($service_url !== '') : ?>
+                                                <a href="<?php echo esc_url($service_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($service_name); ?></a>
+                                            <?php else : ?>
+                                                <?php echo esc_html($service_name); ?>
+                                            <?php endif; ?>
+                                        </span>
+                                    <?php endif; ?>
+                                    <?php if ($price_regular > 0) : ?>
+                                        <span><?php echo esc_html(sprintf(__('Valor do serviço: R$ %s', 'juntaplay'), number_format_i18n($price_regular, 2))); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($price_promo > 0) : ?>
+                                        <span><?php echo esc_html(sprintf(__('Promo: R$ %s', 'juntaplay'), number_format_i18n($price_promo, 2))); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($member_price > 0) : ?>
+                                        <span><?php echo esc_html(sprintf(__('Cota por membro: R$ %s', 'juntaplay'), number_format_i18n($member_price, 2))); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($slots_total > 0) : ?>
+                                        <span><?php echo esc_html(sprintf(__('Vagas: %1$d (reservadas: %2$d)', 'juntaplay'), $slots_total, $slots_reserved)); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($category_label !== '') : ?>
+                                        <span><?php echo esc_html(sprintf(__('Categoria: %s', 'juntaplay'), $category_label)); ?></span>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
+                            <?php if ($support_channel !== '' || $delivery_time !== '' || $access_method !== '' || $instant_access) : ?>
+                                <div class="description juntaplay-admin-group__meta">
+                                    <?php if ($support_channel !== '') : ?>
+                                        <span><?php echo esc_html(sprintf(__('Suporte: %s', 'juntaplay'), $support_channel)); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($delivery_time !== '') : ?>
+                                        <span><?php echo esc_html(sprintf(__('Entrega: %s', 'juntaplay'), $delivery_time)); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($access_method !== '') : ?>
+                                        <span><?php echo esc_html(sprintf(__('Acesso: %s', 'juntaplay'), $access_method)); ?></span>
+                                    <?php endif; ?>
+                                    <span><?php echo esc_html(sprintf(__('Instantâneo: %s', 'juntaplay'), $instant_access ? __('Ativado', 'juntaplay') : __('Desativado', 'juntaplay'))); ?></span>
+                                </div>
+                            <?php endif; ?>
+                            <?php if ($review_note !== '') : ?>
+                                <div class="description"><?php echo esc_html($review_note); ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php echo esc_html($owner_name ?: __('Usuário', 'juntaplay')); ?>
+                            <?php if ($owner_email !== '') : ?>
+                                <div class="description"><a href="mailto:<?php echo esc_attr($owner_email); ?>"><?php echo esc_html($owner_email); ?></a></div>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo esc_html($status_label); ?></td>
+                        <td><?php echo $pool_title !== '' ? esc_html($pool_title) : '—'; ?></td>
+                        <td style="text-align:center; "><?php echo esc_html(number_format_i18n($members_count)); ?></td>
+                        <td><?php echo esc_html($created_at_display); ?></td>
+                        <td>
+                            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="juntaplay-group-action">
+                                <?php wp_nonce_field('juntaplay_group_action'); ?>
+                                <input type="hidden" name="action" value="juntaplay_group_action" />
+                                <input type="hidden" name="group_id" value="<?php echo esc_attr((string) $group_id); ?>" />
+                                <input type="hidden" name="redirect_to" value="<?php echo esc_attr($current_url); ?>" />
+                                <select name="group_action" required>
+                                    <option value=""><?php esc_html_e('Selecione…', 'juntaplay'); ?></option>
+                                    <?php foreach ($available_actions as $value => $label) : ?>
+                                        <option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <input type="text" name="group_note" class="regular-text" placeholder="<?php esc_attr_e('Mensagem ao criador (opcional)', 'juntaplay'); ?>" />
+                                <button type="submit" class="button button-secondary"><?php esc_html_e('Aplicar', 'juntaplay'); ?></button>
+                            </form>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/juntaplay/templates/admin-panel.php
+++ b/juntaplay/templates/admin-panel.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+?>
+<section class="juntaplay-admin-panel">
+    <h2><?php esc_html_e('Painel Operacional', 'juntaplay'); ?></h2>
+    <ul>
+        <li><a href="<?php echo esc_url(admin_url('admin.php?page=juntaplay')); ?>"><?php esc_html_e('Dashboard', 'juntaplay'); ?></a></li>
+        <li><a href="<?php echo esc_url(admin_url('admin.php?page=juntaplay-import')); ?>"><?php esc_html_e('Importar Campanhas', 'juntaplay'); ?></a></li>
+        <li><a href="<?php echo esc_url(admin_url('admin.php?page=juntaplay-settings')); ?>"><?php esc_html_e('Configurações', 'juntaplay'); ?></a></li>
+    </ul>
+</section>

--- a/juntaplay/templates/auth/login.php
+++ b/juntaplay/templates/auth/login.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * JuntaPlay authentication template (login + register).
+ *
+ * @var string[] $login_errors
+ * @var string[] $register_errors
+ * @var string   $redirect_to
+ * @var string   $active_view
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$providers = apply_filters(
+    'juntaplay/login/providers',
+    [
+        [
+            'key'   => 'facebook',
+            'label' => __('Entrar com Facebook', 'juntaplay'),
+            'href'  => '#',
+        ],
+        [
+            'key'   => 'google',
+            'label' => __('Entrar com Google', 'juntaplay'),
+            'href'  => '#',
+        ],
+    ]
+);
+
+$current_url   = isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : '';
+$redirect_to   = $redirect_to ? esc_url_raw($redirect_to) : '';
+$username      = isset($_POST['jp_login_username']) ? sanitize_text_field(wp_unslash($_POST['jp_login_username'])) : '';
+$remember      = !empty($_POST['jp_login_remember']);
+$register_name = isset($_POST['jp_register_name']) ? sanitize_text_field(wp_unslash($_POST['jp_register_name'])) : '';
+$register_mail = isset($_POST['jp_register_email']) ? sanitize_email(wp_unslash($_POST['jp_register_email'])) : '';
+$register_accept = !empty($_POST['jp_register_accept']);
+
+$can_register  = (bool) get_option('users_can_register');
+$social_hooks  = has_action('wordpress_social_login') || has_action('nextend_social_login_buttons');
+$show_register = $can_register || has_action('juntaplay/login/register_alternate');
+
+if (!$show_register) {
+    $active_view = 'login';
+}
+
+$active_view = $active_view === 'register' && $show_register ? 'register' : 'login';
+
+$terms_id      = (int) get_option('juntaplay_page_regras');
+$privacy_url   = function_exists('get_privacy_policy_url') ? get_privacy_policy_url() : '';
+$terms_url     = $terms_id ? get_permalink($terms_id) : $privacy_url;
+$terms_url     = $terms_url ?: home_url('/regras');
+?>
+<div class="juntaplay-auth" data-active-view="<?php echo esc_attr($active_view); ?>">
+    <div class="juntaplay-auth__container">
+        <div class="juntaplay-auth__intro">
+            <span class="juntaplay-auth__brand">JuntaPlay</span>
+            <h1><?php esc_html_e('Entre, crie. Compartilhe e curta.', 'juntaplay'); ?></h1>
+            <p><?php esc_html_e('Acesse sua conta para acompanhar campanhas, reservar cotas e gerenciar seus pedidos com facilidade.', 'juntaplay'); ?></p>
+        </div>
+        <div class="juntaplay-auth__card" data-has-register="<?php echo $show_register ? '1' : '0'; ?>">
+            <div class="juntaplay-auth__header">
+                <h2 class="juntaplay-auth__title">
+                    <?php esc_html_e('Bem-vindo(a)!', 'juntaplay'); ?>
+                </h2>
+                <?php if ($show_register) : ?>
+                    <div class="juntaplay-auth__switch" role="tablist">
+                        <button type="button" class="juntaplay-auth__switch-btn<?php echo $active_view === 'login' ? ' is-active' : ''; ?>" data-target="login" role="tab" aria-selected="<?php echo $active_view === 'login' ? 'true' : 'false'; ?>">
+                            <?php esc_html_e('Entrar', 'juntaplay'); ?>
+                        </button>
+                        <button type="button" class="juntaplay-auth__switch-btn<?php echo $active_view === 'register' ? ' is-active' : ''; ?>" data-target="register" role="tab" aria-selected="<?php echo $active_view === 'register' ? 'true' : 'false'; ?>" <?php disabled(!$can_register); ?>>
+                            <?php echo $can_register ? esc_html__('Criar conta', 'juntaplay') : esc_html__('Solicitar acesso', 'juntaplay'); ?>
+                        </button>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <div class="juntaplay-auth__panes">
+                <div class="juntaplay-auth__pane juntaplay-auth__pane--login<?php echo $active_view === 'login' ? ' is-active' : ''; ?>" data-pane="login" role="tabpanel" aria-hidden="<?php echo $active_view === 'login' ? 'false' : 'true'; ?>">
+                    <?php if (!empty($providers) || $social_hooks) : ?>
+                        <div class="juntaplay-auth__social">
+                            <?php if ($social_hooks) : ?>
+                                <div class="juntaplay-auth__social-integrations">
+                                    <?php if (has_action('wordpress_social_login')) : ?>
+                                        <?php do_action('wordpress_social_login'); ?>
+                                    <?php endif; ?>
+                                    <?php if (has_action('nextend_social_login_buttons')) : ?>
+                                        <?php do_action('nextend_social_login_buttons', 'login'); ?>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endif; ?>
+
+                            <?php if (!empty($providers)) : ?>
+                                <div class="juntaplay-auth__social-list">
+                                    <?php foreach ($providers as $provider) :
+                                        $href    = isset($provider['href']) ? esc_url($provider['href']) : '#';
+                                        $label   = isset($provider['label']) ? esc_html($provider['label']) : '';
+                                        $key     = isset($provider['key']) ? sanitize_html_class((string) $provider['key']) : 'provider';
+                                        $classes = 'juntaplay-auth__social-btn juntaplay-auth__social-btn--' . $key;
+                                        ?>
+                                        <a class="<?php echo esc_attr($classes); ?>" href="<?php echo $href; ?>"<?php echo $href === '#' ? ' role="button" aria-disabled="true"' : ''; ?>>
+                                            <span class="juntaplay-auth__social-label"><?php echo $label; ?></span>
+                                        </a>
+                                    <?php endforeach; ?>
+                                </div>
+                            <?php endif; ?>
+                        </div>
+                        <div class="juntaplay-auth__divider" role="presentation">
+                            <span><?php esc_html_e('ou acesse com seu e-mail', 'juntaplay'); ?></span>
+                        </div>
+                    <?php endif; ?>
+
+                    <form class="juntaplay-auth__form" method="post" action="<?php echo esc_url($current_url); ?>">
+                        <input type="hidden" name="jp_auth_view" value="login">
+                        <?php if (!empty($login_errors)) : ?>
+                            <div class="juntaplay-auth__alert" role="alert">
+                                <ul>
+                                    <?php foreach ($login_errors as $message) : ?>
+                                        <li><?php echo esc_html($message); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+
+                        <div class="juntaplay-auth__field">
+                            <label for="jp_login_username"><?php esc_html_e('E-mail ou usuário', 'juntaplay'); ?></label>
+                            <input type="text" name="jp_login_username" id="jp_login_username" autocomplete="username" placeholder="nome@email.com" value="<?php echo esc_attr($username); ?>" required>
+                        </div>
+
+                        <div class="juntaplay-auth__field">
+                            <label for="jp_login_password"><?php esc_html_e('Senha', 'juntaplay'); ?></label>
+                            <input type="password" name="jp_login_password" id="jp_login_password" autocomplete="current-password" placeholder="••••••••" required>
+                        </div>
+
+                        <div class="juntaplay-auth__meta">
+                            <label class="juntaplay-auth__remember">
+                                <input type="checkbox" name="jp_login_remember" value="1" <?php checked($remember); ?>>
+                                <span><?php esc_html_e('Lembrar-me', 'juntaplay'); ?></span>
+                            </label>
+                            <a class="juntaplay-auth__forgot" href="<?php echo esc_url(wp_lostpassword_url()); ?>"><?php esc_html_e('Esqueci minha senha', 'juntaplay'); ?></a>
+                        </div>
+
+                        <input type="hidden" name="jp_login_action" value="1">
+                        <?php wp_nonce_field('juntaplay_login', 'jp_login_nonce'); ?>
+
+                        <?php if ($redirect_to) : ?>
+                            <input type="hidden" name="redirect_to" value="<?php echo esc_attr($redirect_to); ?>">
+                        <?php endif; ?>
+
+                        <button type="submit" class="juntaplay-button juntaplay-button--primary juntaplay-auth__submit"><?php esc_html_e('Entrar', 'juntaplay'); ?></button>
+                    </form>
+                </div>
+
+                <?php if ($show_register) : ?>
+                    <div class="juntaplay-auth__pane juntaplay-auth__pane--register<?php echo $active_view === 'register' ? ' is-active' : ''; ?>" data-pane="register" role="tabpanel" aria-hidden="<?php echo $active_view === 'register' ? 'false' : 'true'; ?>">
+                        <form class="juntaplay-auth__form" method="post" action="<?php echo esc_url($current_url); ?>">
+                            <input type="hidden" name="jp_auth_view" value="register">
+                            <?php if (!$can_register) : ?>
+                                <div class="juntaplay-auth__alert" role="alert">
+                                    <p><?php esc_html_e('Estamos com novas contas fechadas no momento. Entre em contato com nossa equipe para solicitar acesso.', 'juntaplay'); ?></p>
+                                </div>
+                            <?php endif; ?>
+
+                            <?php if (!empty($register_errors)) : ?>
+                                <div class="juntaplay-auth__alert" role="alert">
+                                    <ul>
+                                        <?php foreach ($register_errors as $message) : ?>
+                                            <li><?php echo esc_html($message); ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+
+                            <div class="juntaplay-auth__field">
+                                <label for="jp_register_name"><?php esc_html_e('Nome completo', 'juntaplay'); ?></label>
+                                <input type="text" name="jp_register_name" id="jp_register_name" autocomplete="name" placeholder="Maria Silva" value="<?php echo esc_attr($register_name); ?>" <?php disabled(!$can_register); ?> required>
+                            </div>
+
+                            <div class="juntaplay-auth__field">
+                                <label for="jp_register_email"><?php esc_html_e('E-mail', 'juntaplay'); ?></label>
+                                <input type="email" name="jp_register_email" id="jp_register_email" autocomplete="email" placeholder="nome@email.com" value="<?php echo esc_attr($register_mail); ?>" <?php disabled(!$can_register); ?> required>
+                            </div>
+
+                            <div class="juntaplay-auth__field">
+                                <label for="jp_register_password"><?php esc_html_e('Senha', 'juntaplay'); ?></label>
+                                <input type="password" name="jp_register_password" id="jp_register_password" autocomplete="new-password" placeholder="••••••••" <?php disabled(!$can_register); ?> required>
+                            </div>
+
+                            <div class="juntaplay-auth__field">
+                                <label for="jp_register_password_confirm"><?php esc_html_e('Confirmar senha', 'juntaplay'); ?></label>
+                                <input type="password" name="jp_register_password_confirm" id="jp_register_password_confirm" autocomplete="new-password" placeholder="••••••••" <?php disabled(!$can_register); ?> required>
+                            </div>
+
+                            <div class="juntaplay-auth__meta juntaplay-auth__meta--terms">
+                                <label class="juntaplay-auth__remember">
+                                    <input type="checkbox" name="jp_register_accept" value="1" <?php checked($register_accept); ?> <?php disabled(!$can_register); ?>>
+                                    <span>
+                                        <?php
+                                        $terms_template = wp_kses(
+                                            /* translators: %s: terms link */
+                                            __('Li e concordo com os <a href="%s" target="_blank" rel="noopener noreferrer">Termos de uso</a>.', 'juntaplay'),
+                                            [
+                                                'a' => [
+                                                    'href'   => [],
+                                                    'target' => [],
+                                                    'rel'    => [],
+                                                ],
+                                            ]
+                                        );
+
+                                        echo sprintf($terms_template, esc_url($terms_url)); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                        ?>
+                                    </span>
+                                </label>
+                            </div>
+
+                            <input type="hidden" name="jp_register_action" value="1">
+                            <?php wp_nonce_field('juntaplay_register', 'jp_register_nonce'); ?>
+
+                            <?php if ($redirect_to) : ?>
+                                <input type="hidden" name="redirect_to" value="<?php echo esc_attr($redirect_to); ?>">
+                            <?php endif; ?>
+
+                            <?php do_action('register_form'); ?>
+
+                            <button type="submit" class="juntaplay-button juntaplay-button--primary juntaplay-auth__submit" <?php disabled(!$can_register); ?>>
+                                <?php echo $can_register ? esc_html__('Criar conta', 'juntaplay') : esc_html__('Solicitar acesso', 'juntaplay'); ?>
+                            </button>
+                        </form>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <?php if (!$show_register) : ?>
+                <p class="juntaplay-auth__footer">
+                    <?php esc_html_e('Ainda não possui conta?', 'juntaplay'); ?>
+                    <a class="juntaplay-link" href="<?php echo esc_url(wp_login_url()); ?>?action=register"><?php esc_html_e('Solicite acesso', 'juntaplay'); ?></a>
+                </p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>

--- a/juntaplay/templates/auth/two-factor.php
+++ b/juntaplay/templates/auth/two-factor.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * JuntaPlay two-factor verification template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$errors   = isset($errors) && is_array($errors) ? $errors : [];
+$context  = isset($context) && is_array($context) ? $context : [];
+$login_url = isset($login_url) ? (string) $login_url : wp_login_url();
+
+$challenge    = isset($context['challenge']) ? (string) $context['challenge'] : '';
+$destination  = isset($context['destination']) ? (string) $context['destination'] : '';
+$method       = isset($context['method']) ? (string) $context['method'] : 'email';
+$resent       = !empty($context['resent']);
+$attempts     = isset($context['attempts']) ? (int) $context['attempts'] : 0;
+$remaining    = isset($context['expires']) ? max(0, (int) $context['expires'] - time()) : 0;
+$method_label = match ($method) {
+    'whatsapp' => __('WhatsApp cadastrado', 'juntaplay'),
+    default    => __('E-mail cadastrado', 'juntaplay'),
+};
+$destination_display = $destination !== '' ? $destination : __('seu contato cadastrado', 'juntaplay');
+?>
+<div class="juntaplay-two-factor" data-jp-two-factor data-remaining="<?php echo esc_attr((string) $remaining); ?>" data-cooldown="45">
+    <div class="juntaplay-two-factor__card">
+        <h1><?php esc_html_e('Confirme seu acesso', 'juntaplay'); ?></h1>
+        <p><?php printf(esc_html__('Enviamos um código de verificação para %1$s (%2$s). Digite abaixo para finalizar o login.', 'juntaplay'), esc_html($destination_display), esc_html($method_label)); ?></p>
+
+        <?php if (!empty($errors)) : ?>
+            <div class="juntaplay-two-factor__alert" role="alert">
+                <ul>
+                    <?php foreach ($errors as $message) : ?>
+                        <li><?php echo esc_html($message); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($resent) : ?>
+            <p class="juntaplay-two-factor__notice"><?php esc_html_e('Enviamos um novo código. Verifique seu contato.', 'juntaplay'); ?></p>
+        <?php endif; ?>
+
+        <?php if ($challenge === '') : ?>
+            <p class="juntaplay-two-factor__empty"><?php esc_html_e('Sua sessão de verificação expirou. Faça login novamente para receber um novo código.', 'juntaplay'); ?></p>
+            <p><a class="juntaplay-link" href="<?php echo esc_url($login_url); ?>"><?php esc_html_e('Voltar para o login', 'juntaplay'); ?></a></p>
+        <?php else : ?>
+            <form method="post" class="juntaplay-two-factor__form" novalidate>
+                <label for="jp-two-factor-code" class="juntaplay-two-factor__label"><?php esc_html_e('Código de verificação', 'juntaplay'); ?></label>
+                <input
+                    id="jp-two-factor-code"
+                    name="jp_two_factor_code"
+                    type="text"
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                    maxlength="6"
+                    autocomplete="one-time-code"
+                    class="juntaplay-two-factor__input"
+                    placeholder="000000"
+                    data-jp-two-factor-input
+                    required
+                />
+                <input type="hidden" name="jp_two_factor_challenge" value="<?php echo esc_attr($challenge); ?>" />
+                <input type="hidden" name="jp_two_factor_action" value="verify" />
+                <?php wp_nonce_field('juntaplay_two_factor', 'jp_two_factor_nonce'); ?>
+
+                <button type="submit" class="juntaplay-button juntaplay-button--primary juntaplay-two-factor__submit"><?php esc_html_e('Confirmar acesso', 'juntaplay'); ?></button>
+            </form>
+
+            <div class="juntaplay-two-factor__meta">
+                <?php if ($attempts > 0) : ?>
+                    <p class="juntaplay-two-factor__attempts"><?php printf(esc_html__('Tentativas restantes: %d', 'juntaplay'), max(0, 5 - $attempts)); ?></p>
+                <?php endif; ?>
+                <p class="juntaplay-two-factor__timer" data-jp-two-factor-timer<?php echo $remaining > 0 ? '' : ' hidden'; ?>><?php esc_html_e('O código expira em instantes.', 'juntaplay'); ?></p>
+                <form method="post" class="juntaplay-two-factor__resend" data-jp-two-factor-resend>
+                    <input type="hidden" name="jp_two_factor_challenge" value="<?php echo esc_attr($challenge); ?>" />
+                    <input type="hidden" name="jp_two_factor_action" value="resend" />
+                    <?php wp_nonce_field('juntaplay_two_factor', 'jp_two_factor_nonce'); ?>
+                    <button type="submit" class="juntaplay-button juntaplay-button--ghost" data-jp-two-factor-resend-button><?php esc_html_e('Enviar novo código', 'juntaplay'); ?></button>
+                </form>
+            </div>
+
+            <p class="juntaplay-two-factor__back"><a class="juntaplay-link" href="<?php echo esc_url($login_url); ?>"><?php esc_html_e('Voltar para o login', 'juntaplay'); ?></a></p>
+        <?php endif; ?>
+    </div>
+</div>

--- a/juntaplay/templates/dashboard.php
+++ b/juntaplay/templates/dashboard.php
@@ -1,0 +1,473 @@
+<?php
+/**
+ * JuntaPlay user dashboard template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+global $wpdb;
+
+$user_id = get_current_user_id();
+$user    = wp_get_current_user();
+$name    = $user && $user->exists() ? $user->display_name : '';
+if ($name === '') {
+    $name = $user && $user->exists() ? $user->user_login : '';
+}
+
+$hero_defaults = [
+    'badge'        => __('10.10', 'juntaplay'),
+    'title'        => sprintf(__('Bem-vindo, %s!', 'juntaplay'), $name ? wp_strip_all_tags($name) : __('ao JuntaPlay', 'juntaplay')),
+    'description'  => __('Consiga as melhores cotas do mercado e fique por dentro das novidades.', 'juntaplay'),
+    'cta_label'    => __('Entrar no grupo', 'juntaplay'),
+    'cta_url'      => '',
+    'secondary'    => __('Descubra oportunidades exclusivas e participe das campanhas mais quentes.', 'juntaplay'),
+];
+
+$campaigns_page_id = (int) get_option('juntaplay_page_campanhas');
+if ($campaigns_page_id) {
+    $hero_defaults['cta_url'] = get_permalink($campaigns_page_id);
+}
+
+if (!$hero_defaults['cta_url']) {
+    $hero_defaults['cta_url'] = home_url('/campanhas');
+}
+
+$hero = apply_filters('juntaplay/dashboard/hero', $hero_defaults, $user);
+
+$status_rows = $wpdb->get_results(
+    $wpdb->prepare(
+        "SELECT status, COUNT(*) AS total
+         FROM {$wpdb->prefix}jp_quotas
+         WHERE user_id = %d
+         GROUP BY status",
+        $user_id
+    ),
+    ARRAY_A
+);
+
+$quota_totals = [
+    'paid'     => 0,
+    'reserved' => 0,
+    'canceled' => 0,
+    'expired'  => 0,
+];
+
+if ($status_rows) {
+    foreach ($status_rows as $row) {
+        $status = $row['status'] ?? '';
+        if (isset($quota_totals[$status])) {
+            $quota_totals[$status] = (int) ($row['total'] ?? 0);
+        }
+    }
+}
+
+$orders_count = (int) $wpdb->get_var(
+    $wpdb->prepare(
+        "SELECT COUNT(DISTINCT order_id)
+         FROM {$wpdb->prefix}jp_quotas
+         WHERE user_id = %d AND order_id IS NOT NULL",
+        $user_id
+    )
+);
+
+$total_spent = (float) $wpdb->get_var(
+    $wpdb->prepare(
+        "SELECT COALESCE(SUM(p.price), 0)
+         FROM {$wpdb->prefix}jp_quotas q
+         INNER JOIN {$wpdb->prefix}jp_pools p ON p.id = q.pool_id
+         WHERE q.user_id = %d AND q.status = 'paid'",
+        $user_id
+    )
+);
+
+$recommended_pools = $wpdb->get_results(
+    "SELECT *
+     FROM {$wpdb->prefix}jp_pools
+     WHERE status='publish'
+     ORDER BY created_at DESC
+     LIMIT 4"
+);
+
+$user_pools = $wpdb->get_results(
+    $wpdb->prepare(
+        "SELECT p.id, p.title, p.product_id, p.price,
+                SUM(CASE WHEN q.status='paid' THEN 1 ELSE 0 END) AS paid_count,
+                SUM(CASE WHEN q.status='reserved' THEN 1 ELSE 0 END) AS reserved_count,
+                COUNT(*) AS total_count,
+                MAX(q.created_at) AS last_activity
+         FROM {$wpdb->prefix}jp_quotas q
+         INNER JOIN {$wpdb->prefix}jp_pools p ON p.id = q.pool_id
+         WHERE q.user_id = %d
+         GROUP BY p.id, p.title, p.product_id, p.price
+         ORDER BY last_activity DESC
+         LIMIT 3",
+        $user_id
+    )
+);
+
+$my_quotas_id = (int) get_option('juntaplay_page_minhas-cotas');
+$my_quotas_url = $my_quotas_id ? get_permalink($my_quotas_id) : '';
+if (!$my_quotas_url) {
+    $my_quotas_url = home_url('/minhas-cotas');
+}
+
+$extrato_id = (int) get_option('juntaplay_page_extrato');
+$extrato_url = $extrato_id ? get_permalink($extrato_id) : '';
+$myaccount_url = function_exists('wc_get_page_permalink') ? wc_get_page_permalink('myaccount') : home_url('/minha-conta');
+
+$quick_actions = apply_filters(
+    'juntaplay/dashboard/actions',
+    [
+        [
+            'label' => __('Explorar campanhas', 'juntaplay'),
+            'href'  => $hero['cta_url'] ?? $hero_defaults['cta_url'],
+        ],
+        [
+            'label' => __('Minhas cotas', 'juntaplay'),
+            'href'  => $my_quotas_url,
+        ],
+        [
+            'label' => __('Pedidos e extratos', 'juntaplay'),
+            'href'  => $extrato_url ?: $myaccount_url,
+        ],
+    ],
+    $user
+);
+
+$account_base = $myaccount_url ?: home_url('/minha-conta');
+$profile_id   = (int) get_option('juntaplay_page_perfil');
+$profile_url  = $profile_id ? get_permalink($profile_id) : '';
+if (!$profile_url) {
+    $profile_url = $account_base;
+}
+
+$account_sections = apply_filters(
+    'juntaplay/dashboard/sections',
+    [
+        [
+            'title'       => __('Configurações', 'juntaplay'),
+            'description' => __('Atualize informações da conta e preferências.', 'juntaplay'),
+            'items'       => [
+                [
+                    'label'       => __('Meu perfil', 'juntaplay'),
+                    'description' => __('Nome, CPF e dados básicos.', 'juntaplay'),
+                    'href'        => $profile_url,
+                    'icon'        => 'user-circle',
+                ],
+                [
+                    'label'       => __('Endereços', 'juntaplay'),
+                    'description' => __('Entrega e cobrança.', 'juntaplay'),
+                    'href'        => function_exists('wc_get_account_endpoint_url') ? wc_get_account_endpoint_url('edit-address') : $account_base,
+                    'icon'        => 'map',
+                ],
+                [
+                    'label'       => __('Segurança', 'juntaplay'),
+                    'description' => __('Senha e login social.', 'juntaplay'),
+                    'href'        => $account_base,
+                    'icon'        => 'shield',
+                ],
+                [
+                    'label'       => __('Comunicações', 'juntaplay'),
+                    'description' => __('Controle notificações e e-mails.', 'juntaplay'),
+                    'href'        => $account_base,
+                    'icon'        => 'bell',
+                ],
+            ],
+        ],
+        [
+            'title'       => __('Financeiro', 'juntaplay'),
+            'description' => __('Acompanhe pagamentos, extratos e saldos.', 'juntaplay'),
+            'items'       => [
+                [
+                    'label'       => __('Pedidos', 'juntaplay'),
+                    'description' => __('Histórico de compras e notas.', 'juntaplay'),
+                    'href'        => function_exists('wc_get_account_endpoint_url') ? wc_get_account_endpoint_url('orders') : $account_base,
+                    'icon'        => 'receipt',
+                ],
+                [
+                    'label'       => __('Extrato de cotas', 'juntaplay'),
+                    'description' => __('Detalhe dos pagamentos aprovados.', 'juntaplay'),
+                    'href'        => $extrato_url ?: $account_base,
+                    'icon'        => 'document',
+                ],
+                [
+                    'label'       => __('Meios de pagamento', 'juntaplay'),
+                    'description' => __('Gerencie cartões e PIX.', 'juntaplay'),
+                    'href'        => function_exists('wc_get_account_endpoint_url') ? wc_get_account_endpoint_url('payment-methods') : $account_base,
+                    'icon'        => 'card',
+                ],
+                [
+                    'label'       => __('Cupons e créditos', 'juntaplay'),
+                    'description' => __('Aproveite recompensas disponíveis.', 'juntaplay'),
+                    'href'        => function_exists('wc_get_account_endpoint_url') ? wc_get_account_endpoint_url('downloads') : $account_base,
+                    'icon'        => 'ticket',
+                ],
+            ],
+        ],
+    ],
+    $user
+);
+
+$format_money = static function (float $value): string {
+    if (function_exists('wc_price')) {
+        return wp_kses_post(wc_price($value));
+    }
+
+    $formatted = number_format_i18n($value, 2);
+
+    return '<span class="juntaplay-money">R$ ' . esc_html($formatted) . '</span>';
+};
+
+$notifications_unread = \JuntaPlay\Data\Notifications::count_unread($user_id);
+?>
+<div class="juntaplay-dashboard juntaplay-section">
+    <div class="juntaplay-dashboard__toolbar">
+        <button type="button" class="juntaplay-notification-bell" data-jp-notifications aria-haspopup="true" aria-expanded="false"<?php if ($notifications_unread > 0) : ?> data-count="<?php echo esc_attr($notifications_unread); ?>"<?php endif; ?>>
+            <span class="screen-reader-text"><?php esc_html_e('Abrir notificações', 'juntaplay'); ?></span>
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M12 22a2 2 0 0 0 1.995-1.85L14 20h-4a2 2 0 0 0 1.85 1.995L12 22Zm7-6v-5a7 7 0 0 0-5-6.708V4a2 2 0 1 0-4 0v.292A7.002 7.002 0 0 0 6 11v5l-1.447 2.894A1 1 0 0 0 5.447 20h13.106a1 1 0 0 0 .894-1.447Z" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </button>
+        <div class="juntaplay-notifications" data-jp-notifications-panel aria-hidden="true">
+            <div class="juntaplay-notifications__header">
+                <h4><?php esc_html_e('Notificações', 'juntaplay'); ?></h4>
+            </div>
+            <ul class="juntaplay-notifications__list" data-jp-notifications-list>
+                <li class="juntaplay-notifications__empty"><?php esc_html_e('Carregando notificações...', 'juntaplay'); ?></li>
+            </ul>
+            <div class="juntaplay-notifications__footer">
+                <button type="button" data-jp-notifications-close><?php esc_html_e('Fechar', 'juntaplay'); ?></button>
+            </div>
+        </div>
+    </div>
+    <section class="juntaplay-dashboard__hero">
+        <div class="juntaplay-dashboard__hero-copy">
+            <?php if (!empty($hero['badge'])) : ?>
+                <span class="juntaplay-dashboard__badge"><?php echo esc_html((string) $hero['badge']); ?></span>
+            <?php endif; ?>
+            <h1><?php echo esc_html(wp_strip_all_tags((string) ($hero['title'] ?? $hero_defaults['title']))); ?></h1>
+            <p class="juntaplay-dashboard__lead"><?php echo esc_html((string) ($hero['description'] ?? $hero_defaults['description'])); ?></p>
+            <?php if (!empty($hero['secondary'])) : ?>
+                <p class="juntaplay-dashboard__sub"><?php echo esc_html((string) $hero['secondary']); ?></p>
+            <?php endif; ?>
+            <div class="juntaplay-dashboard__cta">
+                <?php if (!empty($hero['cta_url'])) : ?>
+                    <a class="juntaplay-button juntaplay-button--primary" href="<?php echo esc_url((string) $hero['cta_url']); ?>">
+                        <?php echo esc_html((string) ($hero['cta_label'] ?? $hero_defaults['cta_label'])); ?>
+                    </a>
+                <?php endif; ?>
+                <a class="juntaplay-link" href="<?php echo esc_url($my_quotas_url); ?>"><?php esc_html_e('Ver minhas cotas', 'juntaplay'); ?></a>
+            </div>
+        </div>
+        <div class="juntaplay-dashboard__hero-card" aria-hidden="true">
+            <div class="juntaplay-dashboard__hero-value"><?php echo esc_html((string) ($hero['badge'] ?? '')); ?></div>
+            <p><?php esc_html_e('Consiga os melhores cupons do Mercado e fique por dentro das novidades.', 'juntaplay'); ?></p>
+        </div>
+    </section>
+
+    <section class="juntaplay-dashboard__stats" aria-label="<?php esc_attr_e('Resumo da sua conta', 'juntaplay'); ?>">
+        <article class="juntaplay-dashboard__stat">
+            <span class="juntaplay-dashboard__stat-label"><?php esc_html_e('Cotas pagas', 'juntaplay'); ?></span>
+            <strong class="juntaplay-dashboard__stat-value"><?php echo esc_html(number_format_i18n($quota_totals['paid'])); ?></strong>
+            <span class="juntaplay-dashboard__stat-caption"><?php echo esc_html__('Participações confirmadas', 'juntaplay'); ?></span>
+        </article>
+        <article class="juntaplay-dashboard__stat">
+            <span class="juntaplay-dashboard__stat-label"><?php esc_html_e('Reservas ativas', 'juntaplay'); ?></span>
+            <strong class="juntaplay-dashboard__stat-value"><?php echo esc_html(number_format_i18n($quota_totals['reserved'])); ?></strong>
+            <span class="juntaplay-dashboard__stat-caption"><?php echo esc_html__('Garanta a compra antes do prazo expirar.', 'juntaplay'); ?></span>
+        </article>
+        <article class="juntaplay-dashboard__stat">
+            <span class="juntaplay-dashboard__stat-label"><?php esc_html_e('Pedidos realizados', 'juntaplay'); ?></span>
+            <strong class="juntaplay-dashboard__stat-value"><?php echo esc_html(number_format_i18n($orders_count)); ?></strong>
+            <span class="juntaplay-dashboard__stat-caption"><?php echo esc_html__('Acompanhe pagamentos e extratos.', 'juntaplay'); ?></span>
+        </article>
+        <article class="juntaplay-dashboard__stat juntaplay-dashboard__stat--highlight">
+            <span class="juntaplay-dashboard__stat-label"><?php esc_html_e('Total investido', 'juntaplay'); ?></span>
+            <strong class="juntaplay-dashboard__stat-value juntaplay-dashboard__stat-value--currency">
+                <?php echo $format_money($total_spent); ?>
+            </strong>
+            <span class="juntaplay-dashboard__stat-caption"><?php esc_html_e('Somente cotas pagas contam aqui.', 'juntaplay'); ?></span>
+        </article>
+    </section>
+
+    <?php if (!empty($account_sections)) : ?>
+        <section class="juntaplay-dashboard__nav" aria-label="<?php esc_attr_e('Configurações da conta', 'juntaplay'); ?>">
+            <?php foreach ($account_sections as $section) :
+                $section_title = isset($section['title']) ? (string) $section['title'] : '';
+                $section_desc  = isset($section['description']) ? (string) $section['description'] : '';
+                $items         = isset($section['items']) && is_array($section['items']) ? $section['items'] : [];
+                if (!$items) {
+                    continue;
+                }
+                ?>
+                <article class="juntaplay-dashboard__nav-card">
+                    <header>
+                        <?php if ($section_title) : ?>
+                            <h2><?php echo esc_html($section_title); ?></h2>
+                        <?php endif; ?>
+                        <?php if ($section_desc) : ?>
+                            <p><?php echo esc_html($section_desc); ?></p>
+                        <?php endif; ?>
+                    </header>
+                    <ul>
+                        <?php foreach ($items as $item) :
+                            $label = isset($item['label']) ? (string) $item['label'] : '';
+                            if (!$label) {
+                                continue;
+                            }
+
+                            $href        = isset($item['href']) ? (string) $item['href'] : '#';
+                            $description = isset($item['description']) ? (string) $item['description'] : '';
+                            $icon        = isset($item['icon']) ? (string) $item['icon'] : '';
+                            ?>
+                            <li>
+                                <a href="<?php echo esc_url($href); ?>" class="juntaplay-dashboard__nav-link">
+                                    <?php if ($icon) : ?>
+                                        <span class="juntaplay-dashboard__nav-icon juntaplay-dashboard__nav-icon--<?php echo esc_attr($icon); ?>" aria-hidden="true"></span>
+                                    <?php endif; ?>
+                                    <span class="juntaplay-dashboard__nav-copy">
+                                        <strong><?php echo esc_html($label); ?></strong>
+                                        <?php if ($description) : ?>
+                                            <small><?php echo esc_html($description); ?></small>
+                                        <?php endif; ?>
+                                    </span>
+                                    <span class="juntaplay-dashboard__nav-arrow" aria-hidden="true">
+                                        <svg width="16" height="16" viewBox="0 0 16 16" focusable="false">
+                                            <path d="M5.5 3.5L10.5 8L5.5 12.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                                        </svg>
+                                    </span>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </article>
+            <?php endforeach; ?>
+        </section>
+    <?php endif; ?>
+
+    <?php if (!empty($quick_actions)) : ?>
+        <section class="juntaplay-dashboard__actions" aria-label="<?php esc_attr_e('Ações rápidas', 'juntaplay'); ?>">
+            <?php foreach ($quick_actions as $action) :
+                $href  = isset($action['href']) ? (string) $action['href'] : '#';
+                $label = isset($action['label']) ? (string) $action['label'] : '';
+                if (!$label) {
+                    continue;
+                }
+                ?>
+                <a class="juntaplay-dashboard__action" href="<?php echo esc_url($href); ?>">
+                    <span><?php echo esc_html($label); ?></span>
+                    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                        <path d="M5.75 3.25L10.25 7.75L5.75 12.25" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </a>
+            <?php endforeach; ?>
+        </section>
+    <?php endif; ?>
+
+    <section class="juntaplay-dashboard__panel">
+        <header class="juntaplay-dashboard__panel-header">
+            <div>
+                <h2><?php esc_html_e('Selecionados para você', 'juntaplay'); ?></h2>
+                <p><?php esc_html_e('Confira campanhas em destaque e garanta as melhores cotas antes que acabem.', 'juntaplay'); ?></p>
+            </div>
+            <a class="juntaplay-link" href="<?php echo esc_url($hero['cta_url'] ?? $hero_defaults['cta_url']); ?>"><?php esc_html_e('Ver todas', 'juntaplay'); ?></a>
+        </header>
+        <div class="juntaplay-dashboard__grid">
+            <?php if ($recommended_pools) : ?>
+                <?php foreach ($recommended_pools as $pool) :
+                    $permalink = $pool->product_id ? get_permalink((int) $pool->product_id) : '';
+                    $price     = isset($pool->price) ? (float) $pool->price : 0.0;
+                    $price_str = function_exists('wc_price') ? wc_price($price) : sprintf('R$ %s', esc_html(number_format_i18n($price, 2)));
+                    $total     = (int) ($pool->quotas_total ?? 0);
+                    $paid      = (int) ($pool->quotas_paid ?? 0);
+                    $available = max(0, $total - $paid);
+                    $progress  = $total > 0 ? min(100, (int) round(($paid / $total) * 100)) : 0;
+                    ?>
+                    <article class="juntaplay-dashboard__card">
+                        <header>
+                            <h3><?php echo esc_html($pool->title); ?></h3>
+                            <span class="juntaplay-badge"><?php esc_html_e('Campanha ativa', 'juntaplay'); ?></span>
+                        </header>
+                        <p class="juntaplay-dashboard__card-price"><?php echo wp_kses_post(sprintf(__('Cota a partir de %s', 'juntaplay'), $price_str)); ?></p>
+                        <div class="juntaplay-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr((string) $progress); ?>">
+                            <span class="juntaplay-progress__bar" style="width: <?php echo esc_attr((string) $progress); ?>%;"></span>
+                        </div>
+                        <ul class="juntaplay-dashboard__metrics">
+                            <li>
+                                <span><?php esc_html_e('Disponíveis', 'juntaplay'); ?></span>
+                                <strong><?php echo esc_html(number_format_i18n($available)); ?></strong>
+                            </li>
+                            <li>
+                                <span><?php esc_html_e('Vendidas', 'juntaplay'); ?></span>
+                                <strong><?php echo esc_html(number_format_i18n($paid)); ?></strong>
+                            </li>
+                        </ul>
+                        <?php if ($permalink) : ?>
+                            <a class="juntaplay-dashboard__card-link" href="<?php echo esc_url($permalink); ?>"><?php esc_html_e('Ver campanha', 'juntaplay'); ?></a>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            <?php else : ?>
+                <p class="juntaplay-notice"><?php esc_html_e('Nenhuma campanha disponível no momento.', 'juntaplay'); ?></p>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section class="juntaplay-dashboard__panel">
+        <header class="juntaplay-dashboard__panel-header">
+            <div>
+                <h2><?php esc_html_e('Suas campanhas', 'juntaplay'); ?></h2>
+                <p><?php esc_html_e('Resumo das últimas campanhas onde você possui cotas.', 'juntaplay'); ?></p>
+            </div>
+            <a class="juntaplay-link" href="<?php echo esc_url($my_quotas_url); ?>"><?php esc_html_e('Ver todas as cotas', 'juntaplay'); ?></a>
+        </header>
+        <?php if ($user_pools) : ?>
+            <div class="juntaplay-dashboard__list">
+                <?php foreach ($user_pools as $pool) :
+                    $permalink = $pool->product_id ? get_permalink((int) $pool->product_id) : '';
+                    $numbers   = (int) $pool->total_count;
+                    $paid      = (int) $pool->paid_count;
+                    $reserved  = (int) $pool->reserved_count;
+                    $progress  = $numbers > 0 ? min(100, (int) round(($paid / $numbers) * 100)) : 0;
+                    ?>
+                    <article class="juntaplay-dashboard__item">
+                        <div class="juntaplay-dashboard__item-head">
+                            <h3><?php echo esc_html($pool->title); ?></h3>
+                            <?php if ($permalink) : ?>
+                                <a class="juntaplay-chip" href="<?php echo esc_url($permalink); ?>"><?php esc_html_e('Ver campanha', 'juntaplay'); ?></a>
+                            <?php endif; ?>
+                        </div>
+                        <div class="juntaplay-dashboard__item-body">
+                            <div class="juntaplay-dashboard__item-progress">
+                                <div class="juntaplay-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr((string) $progress); ?>">
+                                    <span class="juntaplay-progress__bar" style="width: <?php echo esc_attr((string) $progress); ?>%;"></span>
+                                </div>
+                                <span><?php echo esc_html(sprintf(_n('%s cota ativa', '%s cotas ativas', $paid, 'juntaplay'), number_format_i18n($paid))); ?></span>
+                            </div>
+                            <ul class="juntaplay-dashboard__item-stats">
+                                <li>
+                                    <span><?php esc_html_e('Reservadas', 'juntaplay'); ?></span>
+                                    <strong><?php echo esc_html(number_format_i18n($reserved)); ?></strong>
+                                </li>
+                                <li>
+                                    <span><?php esc_html_e('Pagas', 'juntaplay'); ?></span>
+                                    <strong><?php echo esc_html(number_format_i18n($paid)); ?></strong>
+                                </li>
+                                <li>
+                                    <span><?php esc_html_e('Total', 'juntaplay'); ?></span>
+                                    <strong><?php echo esc_html(number_format_i18n($numbers)); ?></strong>
+                                </li>
+                            </ul>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        <?php else : ?>
+            <p class="juntaplay-notice"><?php esc_html_e('Você ainda não possui cotas. Que tal começar agora mesmo?', 'juntaplay'); ?></p>
+        <?php endif; ?>
+    </section>
+</div>

--- a/juntaplay/templates/email/order-paid.php
+++ b/juntaplay/templates/email/order-paid.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+?>
+<html>
+<body style="font-family: Arial, sans-serif; color: #111;">
+    <h1><?php esc_html_e('Pagamento confirmado!', 'juntaplay'); ?></h1>
+    <p><?php esc_html_e('Obrigado pela sua compra. As cotas abaixo foram confirmadas:', 'juntaplay'); ?></p>
+    <ul>
+        <?php foreach ($quotas as $quota) : ?>
+            <li><?php echo esc_html($quota); ?></li>
+        <?php endforeach; ?>
+    </ul>
+</body>
+</html>

--- a/juntaplay/templates/email/reservation-expired.php
+++ b/juntaplay/templates/email/reservation-expired.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+?>
+<html>
+<body style="font-family: Arial, sans-serif; color: #111;">
+    <h1><?php esc_html_e('Reserva expirada', 'juntaplay'); ?></h1>
+    <p><?php esc_html_e('As seguintes cotas voltaram para o estoque por falta de pagamento:', 'juntaplay'); ?></p>
+    <ul>
+        <?php foreach ($quotas as $quota) : ?>
+            <li><?php echo esc_html($quota); ?></li>
+        <?php endforeach; ?>
+    </ul>
+</body>
+</html>

--- a/juntaplay/templates/group-rotator.php
+++ b/juntaplay/templates/group-rotator.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * JuntaPlay group rotator template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$rotator_title            = isset($rotator_title) ? (string) $rotator_title : '';
+$rotator_description      = isset($rotator_description) ? (string) $rotator_description : '';
+$rotator_button           = isset($rotator_button) ? (string) $rotator_button : '';
+$rotator_limit            = isset($rotator_limit) ? (int) $rotator_limit : 12;
+$rotator_categories       = isset($rotator_categories) && is_array($rotator_categories) ? $rotator_categories : [];
+$rotator_default_category = isset($rotator_default_category) ? (string) $rotator_default_category : '';
+$rotator_directory_url    = isset($rotator_directory_url) ? (string) $rotator_directory_url : home_url('/grupos');
+
+if ($rotator_default_category !== '' && !isset($rotator_categories[$rotator_default_category])) {
+    $rotator_default_category = '';
+}
+?>
+<section class="juntaplay-group-rotator" data-group-rotator data-limit="<?php echo esc_attr((string) max(4, $rotator_limit)); ?>" data-default-category="<?php echo esc_attr($rotator_default_category); ?>" data-autoplay="6500">
+    <header class="juntaplay-group-rotator__header">
+        <div>
+            <?php if ($rotator_title !== '') : ?>
+                <h2><?php echo esc_html($rotator_title); ?></h2>
+            <?php endif; ?>
+            <?php if ($rotator_description !== '') : ?>
+                <p><?php echo esc_html($rotator_description); ?></p>
+            <?php endif; ?>
+        </div>
+        <?php if ($rotator_button !== '') : ?>
+            <a class="juntaplay-button juntaplay-button--ghost" href="<?php echo esc_url($rotator_directory_url); ?>"><?php echo esc_html($rotator_button); ?></a>
+        <?php endif; ?>
+    </header>
+
+    <?php if ($rotator_categories) : ?>
+        <nav class="juntaplay-group-rotator__filters" aria-label="<?php esc_attr_e('Filtrar categorias de grupos', 'juntaplay'); ?>">
+            <button type="button" class="<?php echo $rotator_default_category === '' ? 'is-active' : ''; ?>" data-rotator-filter="" aria-selected="<?php echo $rotator_default_category === '' ? 'true' : 'false'; ?>"><?php esc_html_e('Todos', 'juntaplay'); ?></button>
+            <?php foreach ($rotator_categories as $category_key => $category_label) :
+                $category_key   = (string) $category_key;
+                $is_active      = $rotator_default_category !== '' && $rotator_default_category === $category_key;
+                ?>
+                <button type="button" class="<?php echo $is_active ? 'is-active' : ''; ?>" data-rotator-filter="<?php echo esc_attr($category_key); ?>" aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>"><?php echo esc_html((string) $category_label); ?></button>
+            <?php endforeach; ?>
+        </nav>
+    <?php endif; ?>
+
+    <div class="juntaplay-group-rotator__viewport" data-rotator-viewport>
+        <div class="juntaplay-group-rotator__track" data-rotator-track></div>
+        <p class="juntaplay-group-rotator__empty" data-rotator-empty hidden><?php esc_html_e('Nenhum grupo disponível para esta categoria no momento.', 'juntaplay'); ?></p>
+    </div>
+
+    <div class="juntaplay-group-rotator__nav">
+        <button type="button" data-rotator-prev aria-label="<?php esc_attr_e('Ver grupo anterior', 'juntaplay'); ?>">&#10094;</button>
+        <button type="button" data-rotator-next aria-label="<?php esc_attr_e('Ver próximo grupo', 'juntaplay'); ?>">&#10095;</button>
+    </div>
+</section>

--- a/juntaplay/templates/group-search-hero.php
+++ b/juntaplay/templates/group-search-hero.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * JuntaPlay hero search template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$categories = isset($hero_categories) ? (array) $hero_categories : \JuntaPlay\Data\Groups::get_category_labels();
+$search     = isset($hero_search) ? (string) $hero_search : '';
+$current_category = isset($hero_category) ? (string) $hero_category : '';
+$action     = isset($hero_action) ? (string) $hero_action : home_url('/');
+$title      = isset($hero_title) ? (string) $hero_title : esc_html__('Assine e economize até 85% nos serviços!', 'juntaplay');
+$description = isset($hero_description) ? (string) $hero_description : '';
+$button_label = isset($hero_button) ? (string) $hero_button : esc_html__('Buscar', 'juntaplay');
+?>
+<section class="juntaplay-search-hero">
+    <div class="juntaplay-search-hero__content">
+        <div class="juntaplay-search-hero__copy">
+            <span class="juntaplay-search-hero__tagline"><?php esc_html_e('JuntaPlay', 'juntaplay'); ?></span>
+            <h1 class="juntaplay-search-hero__title"><?php echo esc_html($title); ?></h1>
+            <?php if ($description !== '') : ?>
+                <p class="juntaplay-search-hero__description"><?php echo esc_html($description); ?></p>
+            <?php endif; ?>
+            <form class="juntaplay-search-hero__form" action="<?php echo esc_url($action); ?>" method="get" role="search" data-jp-group-search>
+                <div class="juntaplay-search-hero__field">
+                    <label for="juntaplay-search-query" class="screen-reader-text"><?php esc_html_e('O que você está procurando?', 'juntaplay'); ?></label>
+                    <input type="search" id="juntaplay-search-query" name="search" value="<?php echo esc_attr($search); ?>" placeholder="<?php esc_attr_e('O que você está procurando?', 'juntaplay'); ?>" autocomplete="off" />
+                </div>
+                <div class="juntaplay-search-hero__field juntaplay-search-hero__field--select">
+                    <label for="juntaplay-search-category" class="screen-reader-text"><?php esc_html_e('Categoria', 'juntaplay'); ?></label>
+                    <select id="juntaplay-search-category" name="category">
+                        <option value=""><?php esc_html_e('Categoria', 'juntaplay'); ?></option>
+                        <?php foreach ($categories as $category_key => $category_label) : ?>
+                            <option value="<?php echo esc_attr((string) $category_key); ?>" <?php selected($current_category, (string) $category_key); ?>><?php echo esc_html((string) $category_label); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="juntaplay-search-hero__actions">
+                    <button type="submit" class="juntaplay-button juntaplay-button--primary juntaplay-search-hero__submit"><?php echo esc_html($button_label); ?></button>
+                </div>
+            </form>
+            <dl class="juntaplay-search-hero__stats">
+                <div>
+                    <dt><?php esc_html_e('960M+', 'juntaplay'); ?></dt>
+                    <dd><?php esc_html_e('Serviços compartilhados', 'juntaplay'); ?></dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e('850M', 'juntaplay'); ?></dt>
+                    <dd><?php esc_html_e('Cotas aprovadas', 'juntaplay'); ?></dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e('98M', 'juntaplay'); ?></dt>
+                    <dd><?php esc_html_e('Usuários satisfeitos', 'juntaplay'); ?></dd>
+                </div>
+                <div>
+                    <dt><?php esc_html_e('250M', 'juntaplay'); ?></dt>
+                    <dd><?php esc_html_e('Projetos acompanhados', 'juntaplay'); ?></dd>
+                </div>
+            </dl>
+        </div>
+        <div class="juntaplay-search-hero__media" aria-hidden="true">
+            <div class="juntaplay-search-hero__card">
+                <span class="juntaplay-search-hero__badge"><?php esc_html_e('Qualidade comprovada', 'juntaplay'); ?></span>
+                <p><?php esc_html_e('Campanhas verificadas diariamente pela equipe JuntaPlay.', 'juntaplay'); ?></p>
+            </div>
+            <div class="juntaplay-search-hero__illustration"></div>
+        </div>
+    </div>
+</section>

--- a/juntaplay/templates/groups-directory.php
+++ b/juntaplay/templates/groups-directory.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Public groups directory template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$group_categories = isset($categories) && is_array($categories) ? $categories : \JuntaPlay\Data\Groups::get_category_labels();
+$current_search = '';
+if (isset($_GET['search'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $current_search = sanitize_text_field((string) wp_unslash($_GET['search'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+}
+
+$current_category = '';
+if (isset($_GET['category'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $candidate = sanitize_key((string) wp_unslash($_GET['category'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    if (isset($group_categories[$candidate])) {
+        $current_category = $candidate;
+    }
+}
+
+$allowed_orderby = ['created', 'price', 'members'];
+$current_orderby = 'created';
+if (isset($_GET['orderby'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $candidate = sanitize_key((string) wp_unslash($_GET['orderby'])); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    if (in_array($candidate, $allowed_orderby, true)) {
+        $current_orderby = $candidate;
+    }
+}
+
+$current_order = 'desc';
+if (isset($_GET['order'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $candidate = strtolower(sanitize_text_field((string) wp_unslash($_GET['order']))); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    if (in_array($candidate, ['asc', 'desc'], true)) {
+        $current_order = $candidate;
+    }
+}
+
+$instant_access = '';
+if (isset($_GET['instant'])) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $instant_access = (string) wp_unslash($_GET['instant']) === '1' ? '1' : '';
+}
+?>
+<section class="juntaplay-groups" data-jp-groups data-page="1" data-pages="1" data-per-page="9" data-default-search="<?php echo esc_attr($current_search); ?>" data-default-category="<?php echo esc_attr($current_category); ?>" data-default-orderby="<?php echo esc_attr($current_orderby); ?>" data-default-order="<?php echo esc_attr($current_order); ?>" data-default-instant="<?php echo esc_attr($instant_access); ?>">
+    <header class="juntaplay-groups__header">
+        <div>
+            <h1><?php esc_html_e('Explore grupos e campanhas compartilhadas', 'juntaplay'); ?></h1>
+            <p><?php esc_html_e('Encontre grupos ativos criados pela comunidade, compare valores e solicite participação com poucos cliques.', 'juntaplay'); ?></p>
+        </div>
+    </header>
+
+    <form class="juntaplay-filters" data-jp-groups-filters>
+        <div class="juntaplay-filters__group juntaplay-filters__group--search">
+            <label class="juntaplay-filters__label" for="jp-groups-search"><?php esc_html_e('Buscar grupos', 'juntaplay'); ?></label>
+            <input type="search" id="jp-groups-search" name="search" class="juntaplay-filters__input" value="<?php echo esc_attr($current_search); ?>" placeholder="<?php esc_attr_e('Procure por nome, serviço ou organizador', 'juntaplay'); ?>" />
+        </div>
+
+        <div class="juntaplay-filters__group">
+            <label class="juntaplay-filters__label" for="jp-groups-category"><?php esc_html_e('Categoria', 'juntaplay'); ?></label>
+            <select id="jp-groups-category" name="category" class="juntaplay-filters__input">
+                <option value=""><?php esc_html_e('Todas as categorias', 'juntaplay'); ?></option>
+                <?php foreach ($group_categories as $category_key => $category_label) : ?>
+                    <option value="<?php echo esc_attr((string) $category_key); ?>" <?php selected($current_category, (string) $category_key); ?>><?php echo esc_html((string) $category_label); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+
+        <div class="juntaplay-filters__group">
+            <label class="juntaplay-filters__label" for="jp-groups-sort"><?php esc_html_e('Ordenar por', 'juntaplay'); ?></label>
+            <select id="jp-groups-sort" name="orderby" class="juntaplay-filters__input">
+                <option value="created" data-order="desc" <?php selected($current_orderby === 'created' && $current_order === 'desc'); ?>><?php esc_html_e('Mais recentes', 'juntaplay'); ?></option>
+                <option value="price" data-order="asc" <?php selected($current_orderby === 'price' && $current_order === 'asc'); ?>><?php esc_html_e('Menor preço', 'juntaplay'); ?></option>
+                <option value="price" data-order="desc" <?php selected($current_orderby === 'price' && $current_order === 'desc'); ?>><?php esc_html_e('Maior preço', 'juntaplay'); ?></option>
+                <option value="members" data-order="desc" <?php selected($current_orderby === 'members'); ?>><?php esc_html_e('Mais participantes', 'juntaplay'); ?></option>
+            </select>
+        </div>
+
+        <div class="juntaplay-filters__group juntaplay-filters__group--inline">
+            <label class="juntaplay-checkbox">
+                <input type="checkbox" name="instant" value="1" <?php checked($instant_access, '1'); ?> />
+                <span><?php esc_html_e('Acesso imediato', 'juntaplay'); ?></span>
+            </label>
+        </div>
+
+        <div class="juntaplay-filters__actions">
+            <button type="submit" class="juntaplay-button juntaplay-button--primary"><?php esc_html_e('Filtrar grupos', 'juntaplay'); ?></button>
+            <button type="button" class="juntaplay-button juntaplay-button--ghost" data-jp-groups-clear><?php esc_html_e('Limpar filtros', 'juntaplay'); ?></button>
+        </div>
+    </form>
+
+    <div class="juntaplay-groups__body" data-jp-groups-body>
+        <div class="juntaplay-groups__list" data-jp-groups-list></div>
+        <p class="juntaplay-groups__empty" data-jp-groups-empty hidden><?php esc_html_e('Nenhum grupo corresponde aos filtros selecionados.', 'juntaplay'); ?></p>
+    </div>
+
+    <footer class="juntaplay-groups__footer">
+        <span class="juntaplay-groups__total" data-jp-groups-total><?php esc_html_e('Carregando grupos...', 'juntaplay'); ?></span>
+        <button type="button" class="juntaplay-button juntaplay-button--ghost" data-jp-groups-more hidden><?php esc_html_e('Carregar mais grupos', 'juntaplay'); ?></button>
+    </footer>
+
+    <noscript>
+        <p class="juntaplay-groups__noscript"><?php esc_html_e('Ative o JavaScript para explorar e filtrar os grupos disponíveis.', 'juntaplay'); ?></p>
+    </noscript>
+</section>

--- a/juntaplay/templates/my-quotas.php
+++ b/juntaplay/templates/my-quotas.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+global $wpdb;
+
+$user_id = get_current_user_id();
+$table   = "{$wpdb->prefix}jp_quotas";
+$results = $wpdb->get_results($wpdb->prepare(
+    "SELECT q.number, q.status, p.title, q.order_id
+     FROM $table q
+     INNER JOIN {$wpdb->prefix}jp_pools p ON p.id = q.pool_id
+     WHERE q.user_id = %d
+     ORDER BY q.created_at DESC",
+    $user_id
+));
+
+$statement_page_id   = (int) get_option('juntaplay_page_extrato');
+$statement_page_link = $statement_page_id ? get_permalink($statement_page_id) : '';
+
+$status_labels = [
+    'available' => __('Disponível', 'juntaplay'),
+    'reserved'  => __('Reservada', 'juntaplay'),
+    'paid'      => __('Paga', 'juntaplay'),
+    'canceled'  => __('Cancelada', 'juntaplay'),
+    'expired'   => __('Expirada', 'juntaplay'),
+];
+?>
+<div class="juntaplay-my-quotas juntaplay-section">
+    <?php if ($results) : ?>
+        <table class="juntaplay-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e('Campanha', 'juntaplay'); ?></th>
+                    <th><?php esc_html_e('Cota', 'juntaplay'); ?></th>
+                    <th><?php esc_html_e('Status', 'juntaplay'); ?></th>
+                    <th><?php esc_html_e('Pedido', 'juntaplay'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($results as $row) :
+                    $status_key   = (string) $row->status;
+                    $status_label = $status_labels[$status_key] ?? ucfirst($status_key);
+                    $status_class = 'juntaplay-status juntaplay-status--' . sanitize_html_class($status_key);
+                    ?>
+                    <tr>
+                        <td data-label="<?php echo esc_attr__('Campanha', 'juntaplay'); ?>"><?php echo esc_html($row->title); ?></td>
+                        <td data-label="<?php echo esc_attr__('Cota', 'juntaplay'); ?>"><?php echo esc_html($row->number); ?></td>
+                        <td data-label="<?php echo esc_attr__('Status', 'juntaplay'); ?>">
+                            <span class="<?php echo esc_attr($status_class); ?>"><?php echo esc_html($status_label); ?></span>
+                        </td>
+                        <td data-label="<?php echo esc_attr__('Pedido', 'juntaplay'); ?>">
+                            <?php if ($row->order_id) : ?>
+                                <div class="juntaplay-table-actions">
+                                    <a class="juntaplay-link" href="<?php echo esc_url(wc_get_endpoint_url('view-order', (string) $row->order_id, wc_get_page_permalink('myaccount'))); ?>">
+                                        #<?php echo esc_html($row->order_id); ?>
+                                    </a>
+                                    <?php if ($statement_page_link) :
+                                        $statement_url = add_query_arg('order_id', (int) $row->order_id, $statement_page_link);
+                                        ?>
+                                        <a class="juntaplay-chip" href="<?php echo esc_url($statement_url); ?>"><?php esc_html_e('Ver extrato', 'juntaplay'); ?></a>
+                                    <?php endif; ?>
+                                </div>
+                            <?php else : ?>
+                                <span class="juntaplay-summary__label"><?php esc_html_e('Em aberto', 'juntaplay'); ?></span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php else : ?>
+        <p class="juntaplay-notice"><?php esc_html_e('Nenhuma cota encontrada.', 'juntaplay'); ?></p>
+    <?php endif; ?>
+</div>

--- a/juntaplay/templates/pool-list.php
+++ b/juntaplay/templates/pool-list.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+use JuntaPlay\Data\Pools;
+
+$categories = Pools::get_category_labels();
+$per_page   = 12;
+?>
+<div
+    class="juntaplay-pool-catalog juntaplay-section"
+    data-per-page="<?php echo esc_attr($per_page); ?>"
+    data-order="desc"
+    data-orderby="created_at"
+>
+    <header class="juntaplay-catalog__header">
+        <div>
+            <h2 class="juntaplay-catalog__title"><?php esc_html_e('Campanhas disponíveis', 'juntaplay'); ?></h2>
+            <p class="juntaplay-catalog__subtitle"><?php esc_html_e('Explore grupos ativos, organize por categoria e encontre a melhor oportunidade para entrar agora.', 'juntaplay'); ?></p>
+        </div>
+        <div class="juntaplay-catalog__meta" data-pool-meta></div>
+    </header>
+
+    <form class="juntaplay-pool-filters" novalidate>
+        <div class="juntaplay-filters juntaplay-filters--catalog">
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-search"><?php esc_html_e('Buscar campanha', 'juntaplay'); ?></label>
+                <input id="juntaplay-pool-search" name="search" type="search" placeholder="<?php esc_attr_e('Nome, serviço ou palavra-chave', 'juntaplay'); ?>" />
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-category"><?php esc_html_e('Categoria', 'juntaplay'); ?></label>
+                <select id="juntaplay-pool-category" name="category">
+                    <option value=""><?php esc_html_e('Todas as categorias', 'juntaplay'); ?></option>
+                    <?php foreach ($categories as $key => $label) : ?>
+                        <option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-orderby"><?php esc_html_e('Ordenar por', 'juntaplay'); ?></label>
+                <select id="juntaplay-pool-orderby" name="orderby">
+                    <option value="created_at"><?php esc_html_e('Mais recentes', 'juntaplay'); ?></option>
+                    <option value="price"><?php esc_html_e('Menor preço', 'juntaplay'); ?></option>
+                    <option value="quotas_paid"><?php esc_html_e('Maior adesão', 'juntaplay'); ?></option>
+                </select>
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-order"><?php esc_html_e('Direção', 'juntaplay'); ?></label>
+                <select id="juntaplay-pool-order" name="order">
+                    <option value="desc"><?php esc_html_e('Decrescente', 'juntaplay'); ?></option>
+                    <option value="asc"><?php esc_html_e('Crescente', 'juntaplay'); ?></option>
+                </select>
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-min-price"><?php esc_html_e('Preço mínimo', 'juntaplay'); ?></label>
+                <input id="juntaplay-pool-min-price" name="min_price" type="number" step="0.01" min="0" placeholder="0,00" />
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-pool-max-price"><?php esc_html_e('Preço máximo', 'juntaplay'); ?></label>
+                <input id="juntaplay-pool-max-price" name="max_price" type="number" step="0.01" min="0" placeholder="<?php esc_attr_e('Sem limite', 'juntaplay'); ?>" />
+            </div>
+            <div class="juntaplay-filters__actions">
+                <button type="submit" class="juntaplay-button juntaplay-button--secondary"><?php esc_html_e('Aplicar filtros', 'juntaplay'); ?></button>
+            </div>
+        </div>
+    </form>
+
+    <div class="juntaplay-catalog__results" data-pool-results></div>
+    <p class="juntaplay-feedback" data-pool-empty></p>
+
+    <div class="juntaplay-catalog__actions">
+        <button type="button" class="juntaplay-button juntaplay-button--ghost" data-pools-load><?php esc_html_e('Carregar mais campanhas', 'juntaplay'); ?></button>
+    </div>
+</div>

--- a/juntaplay/templates/pool-single.php
+++ b/juntaplay/templates/pool-single.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+use JuntaPlay\Data\Pools;
+
+global $product, $wpdb;
+
+$pool = isset($current_pool_id) && $current_pool_id ? Pools::get((int) $current_pool_id) : null;
+
+if (!$pool && isset($product)) {
+    $pool = Pools::get((int) get_post_meta($product->get_id(), '_juntaplay_pool_id', true));
+}
+
+if ($pool) {
+    $stats = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT 
+                SUM(CASE WHEN status = 'available' THEN 1 ELSE 0 END) AS available,
+                SUM(CASE WHEN status = 'reserved' THEN 1 ELSE 0 END) AS reserved,
+                SUM(CASE WHEN status = 'paid' THEN 1 ELSE 0 END) AS paid,
+                COUNT(*) AS total
+             FROM {$wpdb->prefix}jp_quotas
+             WHERE pool_id = %d",
+            (int) $pool->id
+        ),
+        ARRAY_A
+    ) ?: [];
+
+    $total     = (int) ($stats['total'] ?? ($pool->quotas_total ?? 0));
+    $available = (int) ($stats['available'] ?? max(0, $total - ($pool->quotas_paid ?? 0)));
+    $reserved  = (int) ($stats['reserved'] ?? 0);
+    $paid      = (int) ($stats['paid'] ?? ($pool->quotas_paid ?? 0));
+    $progress  = $total > 0 ? min(100, (int) round(($paid / $total) * 100)) : 0;
+    $price_display = function_exists('wc_price') ? wc_price($pool->price) : number_format_i18n((float) $pool->price, 2);
+}
+?>
+<?php if ($pool) : ?>
+    <section class="juntaplay-pool-single juntaplay-card juntaplay-card--single juntaplay-section" aria-labelledby="juntaplay-pool-title">
+        <header class="juntaplay-pool-single__header">
+            <span class="juntaplay-badge"><?php esc_html_e('Campanha ativa', 'juntaplay'); ?></span>
+            <h1 id="juntaplay-pool-title"><?php echo esc_html($pool->title); ?></h1>
+            <p class="juntaplay-card__price"><?php echo wp_kses_post(sprintf(__('Cada cota custa %s', 'juntaplay'), $price_display)); ?></p>
+        </header>
+
+        <div class="juntaplay-summary" aria-label="<?php echo esc_attr__('Painel da campanha', 'juntaplay'); ?>">
+            <div class="juntaplay-summary__item">
+                <span class="juntaplay-summary__label"><?php esc_html_e('Disponíveis', 'juntaplay'); ?></span>
+                <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($available)); ?></span>
+            </div>
+            <div class="juntaplay-summary__item">
+                <span class="juntaplay-summary__label"><?php esc_html_e('Reservadas', 'juntaplay'); ?></span>
+                <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($reserved)); ?></span>
+            </div>
+            <div class="juntaplay-summary__item">
+                <span class="juntaplay-summary__label"><?php esc_html_e('Pagas', 'juntaplay'); ?></span>
+                <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($paid)); ?></span>
+            </div>
+            <div class="juntaplay-summary__item">
+                <span class="juntaplay-summary__label"><?php esc_html_e('Total de cotas', 'juntaplay'); ?></span>
+                <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($total)); ?></span>
+            </div>
+        </div>
+
+        <div class="juntaplay-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr((string) $progress); ?>">
+            <span class="juntaplay-progress__bar" style="width: <?php echo esc_attr((string) $progress); ?>%;"></span>
+        </div>
+
+        <div class="juntaplay-summary__legend" aria-hidden="true">
+            <?php
+            printf(
+                /* translators: %s: percentage of paid quotas */
+                esc_html__('Progresso das cotas pagas: %s%% concluído', 'juntaplay'),
+                esc_html(number_format_i18n($progress))
+            );
+            ?>
+        </div>
+
+        <div class="juntaplay-pool-single__content">
+            <?php echo apply_filters('the_content', get_post_field('post_content', (int) $pool->product_id)); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        </div>
+    </section>
+<?php else : ?>
+    <p class="juntaplay-notice"><?php esc_html_e('Campanha não encontrada.', 'juntaplay'); ?></p>
+<?php endif; ?>

--- a/juntaplay/templates/profile-credit-history.php
+++ b/juntaplay/templates/profile-credit-history.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * JuntaPlay profile credit history template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$wallet_transactions = isset($context['transactions']) && is_array($context['transactions']) ? $context['transactions'] : [];
+$wallet_pagination  = isset($context['pagination']) && is_array($context['pagination']) ? $context['pagination'] : ['page' => 1, 'pages' => 1, 'total' => 0];
+$wallet_withdrawals = isset($context['withdrawals']) && is_array($context['withdrawals']) ? $context['withdrawals'] : [];
+$wallet_two_factor  = isset($context['two_factor']) && is_array($context['two_factor']) ? $context['two_factor'] : [];
+$wallet_deposit     = isset($context['deposit']) && is_array($context['deposit']) ? $context['deposit'] : [];
+$wallet_has_pix     = !empty($context['has_pix']);
+$wallet_has_bank    = !empty($context['has_bank']);
+$wallet_balance     = isset($context['balance_label']) ? (string) $context['balance_label'] : '';
+$wallet_reserved    = isset($context['reserved_label']) ? (string) $context['reserved_label'] : '';
+$wallet_bonus       = isset($context['bonus_label']) ? (string) $context['bonus_label'] : '';
+$wallet_pending     = isset($context['withdraw_pending']) ? (string) $context['withdraw_pending'] : '';
+$wallet_page        = isset($wallet_pagination['page']) ? (int) $wallet_pagination['page'] : 1;
+$wallet_pages       = isset($wallet_pagination['pages']) ? (int) $wallet_pagination['pages'] : 1;
+$wallet_total       = isset($wallet_pagination['total']) ? (int) $wallet_pagination['total'] : 0;
+$two_factor_method  = isset($wallet_two_factor['method']) ? (string) $wallet_two_factor['method'] : 'email';
+$two_factor_label   = isset($wallet_two_factor['label']) ? (string) $wallet_two_factor['label'] : '';
+$two_factor_destination = isset($wallet_two_factor['destination']) ? (string) $wallet_two_factor['destination'] : '';
+$two_factor_expires = isset($wallet_two_factor['code_expires']) ? (string) $wallet_two_factor['code_expires'] : '';
+$two_factor_remaining = isset($wallet_two_factor['code_remaining']) ? (int) $wallet_two_factor['code_remaining'] : 0;
+$requires_destination = (!$wallet_has_pix && !$wallet_has_bank);
+$deposit_enabled   = !empty($wallet_deposit['enabled']);
+$deposit_min_label = isset($wallet_deposit['min']) ? (string) $wallet_deposit['min'] : '';
+$deposit_min_value = isset($wallet_deposit['min_raw']) ? (float) $wallet_deposit['min_raw'] : 0.0;
+$deposit_max_label = isset($wallet_deposit['max']) ? (string) $wallet_deposit['max'] : '';
+$deposit_max_value = isset($wallet_deposit['max_raw']) ? (float) $wallet_deposit['max_raw'] : 0.0;
+$deposit_suggestions = [];
+
+if (!empty($wallet_deposit['suggestions']) && is_array($wallet_deposit['suggestions'])) {
+    foreach ($wallet_deposit['suggestions'] as $suggestion) {
+        if (!is_array($suggestion)) {
+            continue;
+        }
+
+        $value = isset($suggestion['value']) ? (float) $suggestion['value'] : 0.0;
+        $label = isset($suggestion['label']) ? (string) $suggestion['label'] : '';
+
+        if ($value > 0 && $label !== '') {
+            $deposit_suggestions[] = ['value' => $value, 'label' => $label];
+        }
+    }
+}
+?>
+<div
+    class="juntaplay-wallet"
+    data-jp-wallet
+    data-page="<?php echo esc_attr($wallet_page); ?>"
+    data-pages="<?php echo esc_attr($wallet_pages); ?>"
+    data-total="<?php echo esc_attr($wallet_total); ?>"
+    data-deposit-enabled="<?php echo esc_attr($deposit_enabled ? '1' : '0'); ?>"
+    data-deposit-min="<?php echo esc_attr($deposit_min_value); ?>"
+    data-deposit-max="<?php echo esc_attr($deposit_max_value); ?>"
+>
+    <header class="juntaplay-wallet__header">
+        <div class="juntaplay-wallet__summary">
+            <article class="juntaplay-wallet__card">
+                <span class="juntaplay-wallet__card-label"><?php esc_html_e('Saldo disponível', 'juntaplay'); ?></span>
+                <strong class="juntaplay-wallet__card-value"><?php echo esc_html($wallet_balance); ?></strong>
+            </article>
+            <article class="juntaplay-wallet__card">
+                <span class="juntaplay-wallet__card-label"><?php esc_html_e('Reservado em pedidos', 'juntaplay'); ?></span>
+                <span class="juntaplay-wallet__card-value juntaplay-wallet__card-value--muted"><?php echo esc_html($wallet_reserved); ?></span>
+            </article>
+            <article class="juntaplay-wallet__card">
+                <span class="juntaplay-wallet__card-label"><?php esc_html_e('Bônus disponível', 'juntaplay'); ?></span>
+                <span class="juntaplay-wallet__card-value juntaplay-wallet__card-value--accent"><?php echo esc_html($wallet_bonus); ?></span>
+            </article>
+            <article class="juntaplay-wallet__card">
+                <span class="juntaplay-wallet__card-label"><?php esc_html_e('Saques em análise', 'juntaplay'); ?></span>
+                <span class="juntaplay-wallet__card-value juntaplay-wallet__card-value--warning"><?php echo esc_html($wallet_pending); ?></span>
+            </article>
+        </div>
+        <div class="juntaplay-wallet__actions">
+            <button type="button" class="juntaplay-button juntaplay-button--primary" data-jp-credit-topup <?php disabled(!$deposit_enabled); ?>>
+                <?php esc_html_e('Adicionar créditos', 'juntaplay'); ?>
+            </button>
+            <button type="button" class="juntaplay-button juntaplay-button--ghost" data-jp-credit-send-code>
+                <?php esc_html_e('Enviar código de confirmação', 'juntaplay'); ?>
+            </button>
+            <span class="juntaplay-wallet__hint" data-jp-credit-destination>
+                <?php
+                if ($two_factor_label !== '') {
+                    echo esc_html(sprintf('%1$s · %2$s', $two_factor_label, $two_factor_destination !== '' ? $two_factor_destination : __('verifique seu e-mail cadastrado', 'juntaplay')));
+                }
+                ?>
+            </span>
+            <?php if ($deposit_min_label !== '') : ?>
+                <span class="juntaplay-wallet__hint juntaplay-wallet__hint--cta" data-jp-credit-deposit-hint>
+                    <?php
+                    if ($deposit_max_label !== '') {
+                        echo esc_html(sprintf(__('Valores entre %1$s e %2$s', 'juntaplay'), $deposit_min_label, $deposit_max_label));
+                    } else {
+                        echo esc_html(sprintf(__('Valor mínimo: %s', 'juntaplay'), $deposit_min_label));
+                    }
+                    ?>
+                </span>
+            <?php endif; ?>
+        </div>
+    </header>
+
+    <div class="juntaplay-wallet__content">
+        <section class="juntaplay-wallet__withdraw">
+            <h3><?php esc_html_e('Solicitar retirada', 'juntaplay'); ?></h3>
+            <?php if ($requires_destination) : ?>
+                <div class="juntaplay-wallet__alert juntaplay-wallet__alert--warning">
+                    <?php esc_html_e('Cadastre uma chave Pix ou uma conta bancária para habilitar os saques.', 'juntaplay'); ?>
+                </div>
+            <?php endif; ?>
+            <form method="post" class="juntaplay-wallet__form">
+                <?php wp_nonce_field('juntaplay_profile', 'jp_profile_nonce'); ?>
+                <input type="hidden" name="jp_profile_section" value="credit_withdrawal" />
+                <div class="juntaplay-field">
+                    <label class="juntaplay-field__label" for="jp-profile-withdraw-amount"><?php esc_html_e('Valor do saque', 'juntaplay'); ?></label>
+                    <input id="jp-profile-withdraw-amount" type="number" step="0.01" min="0" name="jp_profile_withdraw_amount" class="juntaplay-field__input" placeholder="0,00" <?php disabled($requires_destination); ?> />
+                </div>
+                <div class="juntaplay-field">
+                    <label class="juntaplay-field__label" for="jp-profile-withdraw-method"><?php esc_html_e('Forma de recebimento', 'juntaplay'); ?></label>
+                    <select id="jp-profile-withdraw-method" class="juntaplay-field__input" name="jp_profile_withdraw_method" <?php disabled($requires_destination); ?>>
+                        <option value="pix" <?php selected(!$wallet_has_bank); ?> <?php disabled(!$wallet_has_pix); ?>><?php esc_html_e('Pix cadastrado', 'juntaplay'); ?></option>
+                        <option value="bank" <?php selected($wallet_has_bank && !$wallet_has_pix); ?> <?php disabled(!$wallet_has_bank); ?>><?php esc_html_e('Conta bancária', 'juntaplay'); ?></option>
+                    </select>
+                </div>
+                <div class="juntaplay-field">
+                    <label class="juntaplay-field__label" for="jp-profile-withdraw-code"><?php esc_html_e('Código de confirmação', 'juntaplay'); ?></label>
+                    <input id="jp-profile-withdraw-code" type="text" name="jp_profile_withdraw_code" class="juntaplay-field__input" placeholder="000000" autocomplete="one-time-code" <?php disabled($requires_destination); ?> />
+                    <p class="juntaplay-field__hint" data-jp-credit-countdown>
+                        <?php
+                        if ($two_factor_destination !== '') {
+                            echo esc_html(sprintf(__('Código enviado para %s', 'juntaplay'), $two_factor_destination));
+                        } else {
+                            esc_html_e('Solicite um novo código antes de confirmar a retirada.', 'juntaplay');
+                        }
+                        ?>
+                    </p>
+                </div>
+                <button type="submit" class="juntaplay-button juntaplay-button--primary" <?php disabled($requires_destination); ?>>
+                    <?php esc_html_e('Confirmar retirada', 'juntaplay'); ?>
+                </button>
+            </form>
+        </section>
+
+        <aside class="juntaplay-wallet__deposit" data-jp-credit-deposit hidden>
+            <div class="juntaplay-wallet__deposit-card">
+                <header class="juntaplay-wallet__deposit-header">
+                    <h3><?php esc_html_e('Adicionar créditos', 'juntaplay'); ?></h3>
+                    <button type="button" class="juntaplay-wallet__deposit-close" data-jp-credit-deposit-close aria-label="<?php esc_attr_e('Fechar', 'juntaplay'); ?>">&times;</button>
+                </header>
+                <form class="juntaplay-wallet__deposit-form" data-jp-credit-deposit-form>
+                    <div class="juntaplay-field">
+                        <label class="juntaplay-field__label" for="jp-profile-deposit-amount"><?php esc_html_e('Quanto você deseja adicionar?', 'juntaplay'); ?></label>
+                        <div class="juntaplay-field__input-wrapper">
+                            <span class="juntaplay-field__prefix">R$</span>
+                            <input id="jp-profile-deposit-amount" type="number" step="0.01" min="0" name="jp_profile_deposit_amount" class="juntaplay-field__input" placeholder="0,00" />
+                        </div>
+                        <p class="juntaplay-field__hint">
+                            <?php
+                            if ($deposit_max_label !== '') {
+                                echo esc_html(sprintf(__('Valores entre %1$s e %2$s serão direcionados ao checkout seguro do WooCommerce.', 'juntaplay'), $deposit_min_label, $deposit_max_label));
+                            } else {
+                                echo esc_html(sprintf(__('Valor mínimo de recarga: %s', 'juntaplay'), $deposit_min_label));
+                            }
+                            ?>
+                        </p>
+                    </div>
+                    <?php if ($deposit_suggestions) : ?>
+                        <div class="juntaplay-wallet__deposit-suggestions" role="group" aria-label="<?php esc_attr_e('Sugestões rápidas', 'juntaplay'); ?>">
+                            <?php foreach ($deposit_suggestions as $suggestion) :
+                                $suggest_value = isset($suggestion['value']) ? (float) $suggestion['value'] : 0.0;
+                                $suggest_label = isset($suggestion['label']) ? (string) $suggestion['label'] : '';
+                                ?>
+                                <button type="button" class="juntaplay-chip" data-jp-credit-suggestion="<?php echo esc_attr($suggest_value); ?>">
+                                    <?php echo esc_html($suggest_label); ?>
+                                </button>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                    <div class="juntaplay-wallet__deposit-actions">
+                        <button type="submit" class="juntaplay-button juntaplay-button--primary" data-jp-credit-deposit-submit>
+                            <?php esc_html_e('Ir para o pagamento', 'juntaplay'); ?>
+                        </button>
+                        <button type="button" class="juntaplay-button juntaplay-button--ghost" data-jp-credit-deposit-close>
+                            <?php esc_html_e('Cancelar', 'juntaplay'); ?>
+                        </button>
+                    </div>
+                    <p class="juntaplay-wallet__alert juntaplay-wallet__alert--warning" data-jp-credit-deposit-error hidden></p>
+                </form>
+            </div>
+        </aside>
+
+        <section class="juntaplay-wallet__transactions" data-jp-credit-list>
+            <header class="juntaplay-wallet__section-header">
+                <div>
+                    <h3><?php esc_html_e('Movimentações recentes', 'juntaplay'); ?></h3>
+                    <p><?php esc_html_e('Acompanhe entradas, saídas e ajustes da sua carteira.', 'juntaplay'); ?></p>
+                </div>
+                <span class="juntaplay-wallet__total" data-jp-credit-total><?php echo esc_html(sprintf(_n('%d movimento', '%d movimentos', $wallet_total, 'juntaplay'), $wallet_total)); ?></span>
+            </header>
+            <?php if ($wallet_transactions) : ?>
+                <ul class="juntaplay-wallet__list" role="list">
+                    <?php foreach ($wallet_transactions as $transaction) :
+                        $transaction_id    = isset($transaction['id']) ? (int) $transaction['id'] : 0;
+                        $transaction_title = isset($transaction['type_label']) ? (string) $transaction['type_label'] : '';
+                        $transaction_status = isset($transaction['status_label']) ? (string) $transaction['status_label'] : '';
+                        $transaction_amount = isset($transaction['amount']) ? (string) $transaction['amount'] : '';
+                        $transaction_time  = isset($transaction['time']) ? (string) $transaction['time'] : '';
+                        $transaction_reference = isset($transaction['reference']) ? (string) $transaction['reference'] : '';
+                        ?>
+                        <li class="juntaplay-wallet__item" data-transaction="<?php echo esc_attr($transaction_id); ?>">
+                            <div class="juntaplay-wallet__item-main">
+                                <strong class="juntaplay-wallet__item-title"><?php echo esc_html($transaction_title); ?></strong>
+                                <span class="juntaplay-wallet__item-meta">
+                                    <?php echo esc_html($transaction_time); ?>
+                                    <?php if ($transaction_reference !== '') : ?>
+                                        · <?php echo esc_html($transaction_reference); ?>
+                                    <?php endif; ?>
+                                </span>
+                            </div>
+                            <div class="juntaplay-wallet__item-side">
+                                <span class="juntaplay-wallet__item-status"><?php echo esc_html($transaction_status); ?></span>
+                                <span class="juntaplay-wallet__item-amount"><?php echo esc_html($transaction_amount); ?></span>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <?php if ($wallet_page < $wallet_pages) : ?>
+                    <button type="button" class="juntaplay-button juntaplay-button--ghost juntaplay-wallet__more" data-jp-credit-load-more>
+                        <?php esc_html_e('Carregar mais movimentações', 'juntaplay'); ?>
+                    </button>
+                <?php endif; ?>
+            <?php else : ?>
+                <p class="juntaplay-wallet__empty" data-jp-credit-empty><?php esc_html_e('Nenhuma movimentação registrada ainda.', 'juntaplay'); ?></p>
+            <?php endif; ?>
+        </section>
+
+        <aside class="juntaplay-wallet__history">
+            <header class="juntaplay-wallet__section-header">
+                <h3><?php esc_html_e('Solicitações recentes', 'juntaplay'); ?></h3>
+                <p><?php esc_html_e('Acompanhe o status das suas retiradas.', 'juntaplay'); ?></p>
+            </header>
+            <?php if ($wallet_withdrawals) : ?>
+                <ul class="juntaplay-wallet__history-list" role="list">
+                    <?php foreach ($wallet_withdrawals as $withdrawal) :
+                        $withdraw_id = isset($withdrawal['id']) ? (int) $withdrawal['id'] : 0;
+                        $withdraw_status = isset($withdrawal['status_label']) ? (string) $withdrawal['status_label'] : '';
+                        $withdraw_amount = isset($withdrawal['amount']) ? (string) $withdrawal['amount'] : '';
+                        $withdraw_time   = isset($withdrawal['time']) ? (string) $withdrawal['time'] : '';
+                        $withdraw_dest   = isset($withdrawal['destination']) ? (string) $withdrawal['destination'] : '';
+                        $withdraw_ref    = isset($withdrawal['reference']) ? (string) $withdrawal['reference'] : '';
+                        ?>
+                        <li class="juntaplay-wallet__history-item">
+                            <div>
+                                <strong><?php echo esc_html($withdraw_amount); ?></strong>
+                                <span class="juntaplay-wallet__history-meta"><?php echo esc_html($withdraw_time); ?></span>
+                                <?php if ($withdraw_dest !== '') : ?>
+                                    <span class="juntaplay-wallet__history-destination"><?php echo esc_html($withdraw_dest); ?></span>
+                                <?php endif; ?>
+                                <?php if ($withdraw_ref !== '') : ?>
+                                    <span class="juntaplay-wallet__history-ref"><?php echo esc_html($withdraw_ref); ?></span>
+                                <?php endif; ?>
+                            </div>
+                            <span class="juntaplay-wallet__history-status"><?php echo esc_html($withdraw_status); ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else : ?>
+                <p class="juntaplay-wallet__empty"><?php esc_html_e('Nenhuma solicitação de saque foi realizada.', 'juntaplay'); ?></p>
+            <?php endif; ?>
+        </aside>
+    </div>
+
+    <div class="juntaplay-wallet__details" data-jp-credit-details hidden>
+        <div class="juntaplay-wallet__details-card">
+            <header class="juntaplay-wallet__details-header">
+                <h4 data-jp-credit-details-title><?php esc_html_e('Detalhes da movimentação', 'juntaplay'); ?></h4>
+                <button type="button" class="juntaplay-wallet__details-close" data-jp-credit-details-close>&times;</button>
+            </header>
+            <div class="juntaplay-wallet__details-body" data-jp-credit-details-body>
+                <p class="juntaplay-wallet__empty"><?php esc_html_e('Selecione uma movimentação para visualizar os detalhes.', 'juntaplay'); ?></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/juntaplay/templates/profile-groups.php
+++ b/juntaplay/templates/profile-groups.php
@@ -1,0 +1,931 @@
+<?php
+/**
+ * JuntaPlay profile groups hub template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$group_context = isset($group_context) && is_array($group_context) ? $group_context : [];
+
+$groups_owned   = isset($group_context['groups_owned']) && is_array($group_context['groups_owned']) ? $group_context['groups_owned'] : [];
+$groups_member  = isset($group_context['groups_member']) && is_array($group_context['groups_member']) ? $group_context['groups_member'] : [];
+$group_counts   = isset($group_context['group_counts']) && is_array($group_context['group_counts']) ? $group_context['group_counts'] : [];
+$pool_choices   = isset($group_context['pool_choices']) && is_array($group_context['pool_choices']) ? $group_context['pool_choices'] : [];
+$group_categories = isset($group_context['group_categories']) && is_array($group_context['group_categories']) ? $group_context['group_categories'] : [];
+$group_suggestions = isset($group_context['group_suggestions']) && is_array($group_context['group_suggestions']) ? $group_context['group_suggestions'] : [];
+$form_errors    = isset($group_context['form_errors']) && is_array($group_context['form_errors']) ? $group_context['form_errors'] : [];
+$form_values    = isset($group_context['form_values']) && is_array($group_context['form_values']) ? $group_context['form_values'] : [];
+$complaint_errors  = isset($group_context['complaint_errors']) && is_array($group_context['complaint_errors']) ? $group_context['complaint_errors'] : [];
+$complaint_drafts  = isset($group_context['complaint_drafts']) && is_array($group_context['complaint_drafts']) ? $group_context['complaint_drafts'] : [];
+$complaint_success = isset($group_context['complaint_success']) && is_array($group_context['complaint_success']) ? $group_context['complaint_success'] : [];
+$complaint_reasons = isset($group_context['complaint_reasons']) && is_array($group_context['complaint_reasons']) ? $group_context['complaint_reasons'] : [];
+$complaint_limits  = isset($group_context['complaint_limits']) && is_array($group_context['complaint_limits']) ? $group_context['complaint_limits'] : [];
+$complaint_summary = isset($group_context['complaint_summary']) && is_array($group_context['complaint_summary']) ? $group_context['complaint_summary'] : [];
+
+$complaint_max_files = isset($complaint_limits['max_files']) ? (int) $complaint_limits['max_files'] : 3;
+$complaint_max_size  = isset($complaint_limits['max_size']) ? (int) $complaint_limits['max_size'] : 5 * 1024 * 1024;
+$complaint_max_size_mb = max(1, round($complaint_max_size / 1048576, 1));
+
+$total_groups   = isset($group_counts['total']) ? (int) $group_counts['total'] : count($groups_owned) + count($groups_member);
+$owned_count    = isset($group_counts['owned']) ? (int) $group_counts['owned'] : count($groups_owned);
+$member_count   = isset($group_counts['member']) ? (int) $group_counts['member'] : count($groups_member);
+$pending_count  = isset($group_counts['pending']) ? (int) $group_counts['pending'] : 0;
+$approved_count = isset($group_counts['approved']) ? (int) $group_counts['approved'] : 0;
+$rejected_count = isset($group_counts['rejected']) ? (int) $group_counts['rejected'] : 0;
+$archived_count = isset($group_counts['archived']) ? (int) $group_counts['archived'] : 0;
+
+$current_name        = isset($form_values['name']) ? (string) $form_values['name'] : '';
+$current_pool        = isset($form_values['pool']) ? (string) $form_values['pool'] : '';
+$current_description = isset($form_values['description']) ? (string) $form_values['description'] : '';
+$current_service     = isset($form_values['service']) ? (string) $form_values['service'] : '';
+$current_service_url = isset($form_values['service_url']) ? (string) $form_values['service_url'] : '';
+$current_rules       = isset($form_values['rules']) ? (string) $form_values['rules'] : '';
+$current_price       = isset($form_values['price']) ? (string) $form_values['price'] : '';
+$promo_enabled       = isset($form_values['promo_enabled']) ? (string) $form_values['promo_enabled'] === 'on' : false;
+$current_promo       = isset($form_values['promo']) ? (string) $form_values['promo'] : '';
+$current_total       = isset($form_values['total']) ? (string) $form_values['total'] : '';
+$current_reserved    = isset($form_values['reserved']) ? (string) $form_values['reserved'] : '';
+$current_member      = isset($form_values['member_price']) ? (string) $form_values['member_price'] : '';
+$member_was_generated = isset($form_values['member_generated']) ? (string) $form_values['member_generated'] === 'yes' : false;
+$current_support     = isset($form_values['support']) ? (string) $form_values['support'] : '';
+$current_delivery    = isset($form_values['delivery']) ? (string) $form_values['delivery'] : '';
+$current_access      = isset($form_values['access']) ? (string) $form_values['access'] : '';
+$cover_placeholder   = defined('JP_GROUP_COVER_PLACEHOLDER') ? JP_GROUP_COVER_PLACEHOLDER : '';
+$current_cover_id    = isset($form_values['cover']) ? (int) $form_values['cover'] : 0;
+$current_cover_preview = isset($form_values['cover_preview']) ? (string) $form_values['cover_preview'] : '';
+if ($current_cover_preview === '' && $current_cover_id > 0) {
+    $attachment_preview = wp_get_attachment_image_url($current_cover_id, 'large');
+    if ($attachment_preview) {
+        $current_cover_preview = $attachment_preview;
+    }
+}
+if ($current_cover_preview === '') {
+    $current_cover_preview = $cover_placeholder;
+}
+$current_category    = isset($form_values['category']) ? (string) $form_values['category'] : 'other';
+if ($current_category === '' || !isset($group_categories[$current_category])) {
+    $current_category = 'other';
+}
+$category_label = isset($group_categories[$current_category]) ? (string) $group_categories[$current_category] : ucwords(str_replace(['-', '_'], ' ', $current_category));
+$current_instant     = isset($form_values['instant_access']) ? (string) $form_values['instant_access'] === 'on' : false;
+
+$site_host = wp_parse_url(home_url(), PHP_URL_HOST);
+if (!$site_host) {
+    $site_host = preg_replace('~^https?://~', '', home_url());
+}
+$site_host = is_string($site_host) ? trim($site_host, '/') : '';
+
+$group_type_label = esc_html__('Público', 'juntaplay');
+$category_display = esc_html($category_label);
+$instant_display  = $current_instant ? esc_html__('Ativado', 'juntaplay') : esc_html__('Desativado', 'juntaplay');
+
+$price_display = '';
+if ($current_price !== '') {
+    $price_display = sprintf(__('R$ %s', 'juntaplay'), esc_html($current_price));
+    $price_display = esc_html($price_display);
+}
+
+$promo_display = esc_html__('Não', 'juntaplay');
+$promo_flag    = esc_html__('Não', 'juntaplay');
+if ($promo_enabled && $current_promo !== '') {
+    $promo_display = sprintf(__('R$ %s', 'juntaplay'), esc_html($current_promo));
+    $promo_display = esc_html($promo_display);
+    $promo_flag    = esc_html__('Sim', 'juntaplay');
+}
+
+$member_display = '';
+if ($current_member !== '') {
+    $member_display = sprintf(__('R$ %s', 'juntaplay'), esc_html($current_member));
+    $member_display = esc_html($member_display);
+}
+
+$share_lines = [];
+if ($current_service !== '') {
+    $share_lines[] = sprintf(esc_html__('Serviço: %s', 'juntaplay'), esc_html($current_service));
+}
+if ($current_name !== '') {
+    $share_lines[] = sprintf(esc_html__('Nome do grupo: %s', 'juntaplay'), esc_html($current_name));
+}
+$share_lines[] = sprintf(esc_html__('Tipo: %s', 'juntaplay'), $group_type_label);
+$share_lines[] = sprintf(esc_html__('Categoria: %s', 'juntaplay'), $category_display);
+if ($current_service_url !== '') {
+    $share_lines[] = sprintf(esc_html__('Site: %s', 'juntaplay'), esc_html($current_service_url));
+}
+if ($current_rules !== '') {
+    $share_lines[] = sprintf(esc_html__('Regras: %s', 'juntaplay'), esc_html($current_rules));
+}
+if ($current_description !== '') {
+    $share_lines[] = sprintf(esc_html__('Descrição: %s', 'juntaplay'), esc_html($current_description));
+}
+if ($price_display !== '') {
+    $share_lines[] = sprintf(esc_html__('Valor do serviço: %s', 'juntaplay'), $price_display);
+}
+$share_lines[] = sprintf(esc_html__('É valor promocional?: %s', 'juntaplay'), $promo_flag);
+$share_lines[] = sprintf(esc_html__('Valor promocional: %s', 'juntaplay'), $promo_display);
+if ($current_total !== '') {
+    $share_lines[] = sprintf(esc_html__('Vagas totais: %s', 'juntaplay'), esc_html($current_total));
+}
+if ($current_reserved !== '') {
+    $share_lines[] = sprintf(esc_html__('Reservadas para você: %s', 'juntaplay'), esc_html($current_reserved));
+}
+if ($member_display !== '') {
+    $share_lines[] = sprintf(esc_html__('Os membros vão pagar: %s', 'juntaplay'), $member_display);
+}
+if ($current_support !== '') {
+    $share_lines[] = sprintf(esc_html__('Suporte aos membros: %s', 'juntaplay'), esc_html($current_support));
+}
+if ($current_delivery !== '') {
+    $share_lines[] = sprintf(esc_html__('Envio de acesso: %s', 'juntaplay'), esc_html($current_delivery));
+}
+if ($current_access !== '') {
+    $share_lines[] = sprintf(esc_html__('Forma de acesso: %s', 'juntaplay'), esc_html($current_access));
+}
+$share_lines[] = sprintf(esc_html__('Acesso instantâneo: %s', 'juntaplay'), $instant_display);
+
+$share_text = implode("\n", $share_lines);
+
+$member_preview_text = '';
+if ($current_member !== '') {
+    $member_preview_text = sprintf(
+        /* translators: %s: formatted price */
+        __('Cobrando dos membros: R$ %s por vaga disponível.', 'juntaplay'),
+        $current_member
+    );
+}
+
+$all_groups = array_merge($groups_owned, $groups_member);
+$campanhas_page_id = (int) get_option('juntaplay_page_campanhas');
+$campaigns_url = $campanhas_page_id ? get_permalink($campanhas_page_id) : home_url('/campanhas');
+?>
+<div class="juntaplay-groups" data-groups data-role-filter="all" data-status-filter="all">
+    <div class="juntaplay-groups__filters" role="tablist">
+        <button type="button" class="juntaplay-chip is-active" data-group-filter="all" aria-selected="true">
+            <?php echo esc_html(sprintf(__('Todos (%d)', 'juntaplay'), $total_groups)); ?>
+        </button>
+        <button type="button" class="juntaplay-chip" data-group-filter="owned" aria-selected="false">
+            <?php echo esc_html(sprintf(__('Meus grupos (%d)', 'juntaplay'), $owned_count)); ?>
+        </button>
+        <button type="button" class="juntaplay-chip" data-group-filter="member" aria-selected="false">
+            <?php echo esc_html(sprintf(__('Participando (%d)', 'juntaplay'), $member_count)); ?>
+        </button>
+    </div>
+
+    <div class="juntaplay-groups__status-filter">
+        <label for="jp-group-status-filter"><?php echo esc_html__('Status', 'juntaplay'); ?></label>
+        <select id="jp-group-status-filter" class="juntaplay-form__input" data-group-status-filter>
+            <option value="all"><?php echo esc_html__('Todos os status', 'juntaplay'); ?></option>
+            <option value="pending"><?php echo esc_html(sprintf(__('Em análise (%d)', 'juntaplay'), $pending_count)); ?></option>
+            <option value="approved"><?php echo esc_html(sprintf(__('Aprovados (%d)', 'juntaplay'), $approved_count)); ?></option>
+            <option value="rejected"><?php echo esc_html(sprintf(__('Recusados (%d)', 'juntaplay'), $rejected_count)); ?></option>
+            <option value="archived"><?php echo esc_html(sprintf(__('Arquivados (%d)', 'juntaplay'), $archived_count)); ?></option>
+        </select>
+    </div>
+
+    <div class="juntaplay-groups__list" data-group-list>
+        <?php if ($all_groups) : ?>
+            <?php foreach ($all_groups as $group) :
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $group_id        = isset($group['id']) ? (int) $group['id'] : 0;
+                $group_title     = isset($group['title']) ? (string) $group['title'] : '';
+                $group_role      = isset($group['membership_role']) ? (string) $group['membership_role'] : 'member';
+                $role_label      = isset($group['role_label']) ? (string) $group['role_label'] : '';
+                $role_tone       = isset($group['role_tone']) ? (string) $group['role_tone'] : '';
+                $status          = isset($group['status']) ? (string) $group['status'] : '';
+                $status_label    = isset($group['status_label']) ? (string) $group['status_label'] : '';
+                $status_tone     = isset($group['status_tone']) ? (string) $group['status_tone'] : '';
+                $status_message  = isset($group['status_message']) ? (string) $group['status_message'] : '';
+                $members_count   = isset($group['members_count']) ? (int) $group['members_count'] : 0;
+                $created_human   = isset($group['created_human']) ? (string) $group['created_human'] : '';
+                $pool_title      = isset($group['pool_title']) ? (string) $group['pool_title'] : '';
+                $pool_link       = isset($group['pool_link']) ? (string) $group['pool_link'] : '';
+                $review_note     = isset($group['review_note']) ? (string) $group['review_note'] : '';
+                $reviewed_human  = isset($group['reviewed_human']) ? (string) $group['reviewed_human'] : '';
+                $service_name    = isset($group['service_name']) ? (string) $group['service_name'] : '';
+                $service_url     = isset($group['service_url']) ? (string) $group['service_url'] : '';
+                $group_rules     = isset($group['rules']) ? (string) $group['rules'] : '';
+                $price_display   = isset($group['price_regular_display']) ? (string) $group['price_regular_display'] : '';
+                $promo_display   = isset($group['price_promotional_display']) ? (string) $group['price_promotional_display'] : '';
+                $member_display  = isset($group['member_price_display']) ? (string) $group['member_price_display'] : '';
+                $enrollment_total = isset($group['enrollment_total_display']) ? (string) $group['enrollment_total_display'] : '';
+                $slots_summary   = isset($group['slots_summary']) ? (string) $group['slots_summary'] : '';
+                $support_channel = isset($group['support_channel']) ? (string) $group['support_channel'] : '';
+                $delivery_time   = isset($group['delivery_time']) ? (string) $group['delivery_time'] : '';
+                $access_method   = isset($group['access_method']) ? (string) $group['access_method'] : '';
+                $category_label  = isset($group['category_label']) ? (string) $group['category_label'] : '';
+                $instant_label   = isset($group['instant_access_label']) ? (string) $group['instant_access_label'] : '';
+                $blocked_notice  = isset($group['blocked_notice']) ? (string) $group['blocked_notice'] : '';
+                $members_preview = isset($group['members_preview']) && is_array($group['members_preview']) ? $group['members_preview'] : [];
+                $member_names    = isset($members_preview['names']) && is_array($members_preview['names']) ? array_filter($members_preview['names'], 'is_string') : [];
+                $members_remaining = isset($members_preview['remaining']) ? (int) $members_preview['remaining'] : 0;
+                $faq_items       = isset($group['faq_items']) && is_array($group['faq_items']) ? array_filter($group['faq_items'], 'is_array') : [];
+                $share_domain    = isset($group['share_domain']) ? (string) $group['share_domain'] : '';
+                $share_snippet   = isset($group['share_snippet']) ? (string) $group['share_snippet'] : '';
+                $complaints_meta = isset($group['complaints']) && is_array($group['complaints']) ? $group['complaints'] : [];
+                $complaints_open = isset($complaints_meta['open']) ? (int) $complaints_meta['open'] : 0;
+                $complaints_total = isset($complaints_meta['total']) ? (int) $complaints_meta['total'] : 0;
+                $complaint_latest = isset($complaints_meta['latest']) && is_array($complaints_meta['latest']) ? $complaints_meta['latest'] : [];
+                $complaint_status_label = isset($complaint_latest['status_label']) ? (string) $complaint_latest['status_label'] : '';
+                $complaint_status_tone  = isset($complaint_latest['status_tone']) ? (string) $complaint_latest['status_tone'] : 'info';
+                $complaint_status_message = isset($complaint_latest['status_message']) ? (string) $complaint_latest['status_message'] : '';
+                $complaint_summary_text = isset($complaint_latest['summary']) ? (string) $complaint_latest['summary'] : '';
+                $complaint_key    = 'group_complaint_' . $group_id;
+                $complaint_messages = isset($complaint_errors[$complaint_key]) && is_array($complaint_errors[$complaint_key]) ? $complaint_errors[$complaint_key] : [];
+                $complaint_draft  = isset($complaint_drafts[$group_id]) && is_array($complaint_drafts[$group_id]) ? $complaint_drafts[$group_id] : [];
+                $complaint_success_messages = isset($complaint_success[$group_id]) && is_array($complaint_success[$group_id]) ? $complaint_success[$group_id] : [];
+            ?>
+                <?php
+                $cover_url = isset($group['cover_url']) ? (string) $group['cover_url'] : $cover_placeholder;
+                $cover_alt = isset($group['cover_alt']) ? (string) $group['cover_alt'] : esc_html__('Capa do grupo', 'juntaplay');
+                $cover_placeholder_flag = !empty($group['cover_placeholder']);
+                $show_cover_hint = $cover_placeholder_flag && in_array($group_role, ['owner', 'manager'], true);
+                ?>
+                <article class="juntaplay-group-card" data-group-item data-group-role="<?php echo esc_attr($group_role); ?>" data-group-status="<?php echo esc_attr($status); ?>">
+                    <figure class="juntaplay-group-card__cover<?php echo $cover_placeholder_flag ? ' is-placeholder' : ''; ?>">
+                        <img src="<?php echo esc_url($cover_url); ?>" alt="<?php echo esc_attr($cover_alt); ?>" loading="lazy" width="495" height="370" />
+                        <?php if ($show_cover_hint) : ?>
+                            <span><?php esc_html_e('Adicione uma capa para aumentar as conversões.', 'juntaplay'); ?></span>
+                        <?php endif; ?>
+                    </figure>
+                    <div class="juntaplay-group-card__body">
+                        <header class="juntaplay-group-card__header">
+                        <h3 class="juntaplay-group-card__title"><?php echo esc_html($group_title); ?></h3>
+                        <?php if ($status_label !== '') : ?>
+                            <span class="juntaplay-badge juntaplay-badge--<?php echo esc_attr($status_tone ?: 'info'); ?>"><?php echo esc_html($status_label); ?></span>
+                        <?php endif; ?>
+                    </header>
+                    <div class="juntaplay-group-card__meta">
+                        <?php if ($role_label !== '') : ?>
+                            <span class="juntaplay-group-card__role juntaplay-badge juntaplay-badge--<?php echo esc_attr($role_tone ?: 'info'); ?>"><?php echo esc_html($role_label); ?></span>
+                        <?php endif; ?>
+                        <?php if ($created_human !== '') : ?>
+                            <span class="juntaplay-group-card__created"><?php echo esc_html($created_human); ?></span>
+                        <?php endif; ?>
+                        <?php if ($reviewed_human !== '' && $status !== 'pending') : ?>
+                            <span class="juntaplay-group-card__reviewed"><?php echo esc_html($reviewed_human); ?></span>
+                        <?php endif; ?>
+                    </div>
+                    <ul class="juntaplay-group-card__details">
+                        <?php if ($service_name !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Serviço', 'juntaplay'); ?>:</strong>
+                                <?php if ($service_url !== '') : ?>
+                                    <a href="<?php echo esc_url($service_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($service_name); ?></a>
+                                <?php else : ?>
+                                    <?php echo esc_html($service_name); ?>
+                                <?php endif; ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($price_display !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Valor do serviço', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($price_display); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($promo_display !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Oferta promocional', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($promo_display); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($member_display !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Cobrado de cada membro', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($member_display); ?>
+                            </li>
+                        <?php endif; ?>
+                        <li>
+                            <strong><?php echo esc_html__('Tipo', 'juntaplay'); ?>:</strong>
+                            <?php echo esc_html__('Público', 'juntaplay'); ?>
+                        </li>
+                        <?php if ($category_label !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Categoria', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($category_label); ?>
+                            </li>
+                        <?php endif; ?>
+                        <li>
+                            <strong><?php echo esc_html__('Participantes', 'juntaplay'); ?>:</strong>
+                            <?php echo esc_html(number_format_i18n($members_count)); ?>
+                        </li>
+                        <li>
+                            <strong><?php echo esc_html__('Campanha', 'juntaplay'); ?>:</strong>
+                            <?php echo $pool_title !== '' ? esc_html($pool_title) : '<span class="juntaplay-profile__empty">' . esc_html__('Ainda não vinculada', 'juntaplay') . '</span>'; ?>
+                        </li>
+                        <?php if ($slots_summary !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Vagas', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($slots_summary); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($support_channel !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Suporte aos membros', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($support_channel); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($delivery_time !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Envio de acesso', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($delivery_time); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($access_method !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Forma de acesso', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($access_method); ?>
+                            </li>
+                        <?php endif; ?>
+                        <?php if ($instant_label !== '') : ?>
+                            <li>
+                                <strong><?php echo esc_html__('Acesso instantâneo', 'juntaplay'); ?>:</strong>
+                                <?php echo esc_html($instant_label); ?>
+                            </li>
+                        <?php endif; ?>
+                    </ul>
+                    <?php if ($enrollment_total !== '') : ?>
+                        <div class="juntaplay-group-card__enrollment">
+                            <span class="juntaplay-group-card__enrollment-label"><?php echo esc_html__('Total da inscrição', 'juntaplay'); ?></span>
+                            <strong class="juntaplay-group-card__enrollment-value"><?php echo esc_html($enrollment_total); ?></strong>
+                            <?php if ($blocked_notice !== '') : ?>
+                                <p class="juntaplay-group-card__enrollment-note"><?php echo esc_html($blocked_notice); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($member_names) : ?>
+                        <div class="juntaplay-group-card__members">
+                            <h4><?php echo esc_html__('Quem faz parte', 'juntaplay'); ?></h4>
+                            <ul>
+                                <?php foreach ($member_names as $member_name) : ?>
+                                    <li><?php echo esc_html((string) $member_name); ?></li>
+                                <?php endforeach; ?>
+                                <?php if ($members_remaining > 0) : ?>
+                                    <li class="juntaplay-group-card__members-more"><?php echo esc_html(sprintf(_n('e mais %d participante', 'e mais %d participantes', $members_remaining, 'juntaplay'), $members_remaining)); ?></li>
+                                <?php endif; ?>
+                            </ul>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($status_message !== '') : ?>
+                        <p class="juntaplay-group-card__message"><?php echo esc_html($status_message); ?></p>
+                    <?php endif; ?>
+                    <?php if ($group_rules !== '') : ?>
+                        <div class="juntaplay-group-card__rules" role="note">
+                            <strong><?php echo esc_html__('Regras do grupo', 'juntaplay'); ?>:</strong>
+                            <p><?php echo esc_html($group_rules); ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($review_note !== '' && $status !== 'pending') : ?>
+                        <div class="juntaplay-group-card__review" role="note">
+                            <strong><?php echo esc_html__('Observação do administrador', 'juntaplay'); ?>:</strong>
+                            <p><?php echo esc_html($review_note); ?></p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($share_snippet !== '') : ?>
+                        <div class="juntaplay-group-card__share" data-group-share>
+                            <header>
+                                <span class="juntaplay-group-card__share-label"><?php echo esc_html__('Compartilhar', 'juntaplay'); ?></span>
+                                <?php if ($share_domain !== '') : ?>
+                                    <span class="juntaplay-group-card__share-domain"><?php echo esc_html($share_domain); ?></span>
+                                <?php endif; ?>
+                            </header>
+                            <pre class="juntaplay-group-card__share-snippet" data-group-share-snippet><?php echo esc_html($share_snippet); ?></pre>
+                            <textarea class="juntaplay-group-card__share-text" data-group-share-text hidden><?php echo esc_textarea($share_snippet); ?></textarea>
+                            <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-share-copy data-default-label="<?php echo esc_attr__('Copiar resumo', 'juntaplay'); ?>" data-success-label="<?php echo esc_attr__('Resumo copiado!', 'juntaplay'); ?>" data-error-label="<?php echo esc_attr__('Não foi possível copiar agora. Copie manualmente.', 'juntaplay'); ?>">
+                                <?php echo esc_html__('Copiar resumo', 'juntaplay'); ?>
+                            </button>
+                        </div>
+                    <?php endif; ?>
+                    <div class="juntaplay-group-card__complaint" data-group-complaint>
+                        <header class="juntaplay-group-card__complaint-header">
+                            <h4><?php echo esc_html__('Precisa de ajuda com esta cota?', 'juntaplay'); ?></h4>
+                            <?php if ($complaint_status_label !== '') : ?>
+                                <span class="juntaplay-badge juntaplay-badge--<?php echo esc_attr($complaint_status_tone); ?>"><?php echo esc_html(sprintf(__('Última reclamação: %s', 'juntaplay'), $complaint_status_label)); ?></span>
+                            <?php endif; ?>
+                        </header>
+                        <?php if ($complaint_summary_text !== '') : ?>
+                            <p class="juntaplay-group-card__complaint-summary"><?php echo esc_html($complaint_summary_text); ?></p>
+                        <?php endif; ?>
+                        <?php if ($complaint_status_message !== '') : ?>
+                            <p class="juntaplay-group-card__complaint-note"><?php echo esc_html($complaint_status_message); ?></p>
+                        <?php endif; ?>
+                        <?php if ($complaints_open > 0) : ?>
+                            <p class="juntaplay-group-card__complaint-open"><?php echo esc_html(sprintf(_n('Você possui %d reclamação aberta.', 'Você possui %d reclamações abertas.', $complaints_open, 'juntaplay'), $complaints_open)); ?></p>
+                        <?php elseif ($complaints_total > 0) : ?>
+                            <p class="juntaplay-group-card__complaint-open"><?php echo esc_html(sprintf(_n('Você já abriu %d reclamação para este grupo.', 'Você já abriu %d reclamações para este grupo.', $complaints_total, 'juntaplay'), $complaints_total)); ?></p>
+                        <?php endif; ?>
+                        <?php if ($complaint_success_messages) : ?>
+                            <div class="juntaplay-alert juntaplay-alert--success" role="status">
+                                <?php foreach ($complaint_success_messages as $success_message) : ?>
+                                    <p><?php echo esc_html((string) $success_message); ?></p>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($complaint_messages) : ?>
+                            <div class="juntaplay-alert juntaplay-alert--error" role="alert">
+                                <ul>
+                                    <?php foreach ($complaint_messages as $error_message) : ?>
+                                        <li><?php echo esc_html((string) $error_message); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <p class="juntaplay-group-card__complaint-description"><?php echo esc_html__('Se algo não saiu como combinado com este grupo, relate o problema para que possamos ajudar.', 'juntaplay'); ?></p>
+                        <?php
+                        $form_open = !empty($complaint_messages) || !empty($complaint_draft);
+                        $toggle_label = $form_open ? __('Fechar formulário', 'juntaplay') : __('Abrir reclamação', 'juntaplay');
+                        ?>
+                        <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-complaint-toggle data-target="jp-group-complaint-<?php echo esc_attr($group_id); ?>" data-default-label="<?php echo esc_attr__('Abrir reclamação', 'juntaplay'); ?>" data-open-label="<?php echo esc_attr__('Fechar formulário', 'juntaplay'); ?>" aria-expanded="<?php echo $form_open ? 'true' : 'false'; ?>" aria-controls="jp-group-complaint-<?php echo esc_attr($group_id); ?>">
+                            <?php echo esc_html($toggle_label); ?>
+                        </button>
+                        <form id="jp-group-complaint-<?php echo esc_attr($group_id); ?>" class="juntaplay-group-complaint__form<?php echo $form_open ? ' is-open' : ' is-hidden'; ?>" method="post" enctype="multipart/form-data" data-group-complaint-form>
+                            <input type="hidden" name="jp_profile_action" value="1" />
+                            <input type="hidden" name="jp_profile_section" value="group_complaint" />
+                            <input type="hidden" name="jp_profile_complaint_group" value="<?php echo esc_attr((string) $group_id); ?>" />
+                            <?php wp_nonce_field('juntaplay_profile_update', 'jp_profile_nonce'); ?>
+                            <div class="juntaplay-form__group">
+                                <label for="jp-group-complaint-reason-<?php echo esc_attr($group_id); ?>"><?php echo esc_html__('Motivo da reclamação', 'juntaplay'); ?></label>
+                                <select id="jp-group-complaint-reason-<?php echo esc_attr($group_id); ?>" name="jp_profile_complaint_reason" class="juntaplay-form__input">
+                                    <?php foreach ($complaint_reasons as $reason_value => $reason_label) : ?>
+                                        <option value="<?php echo esc_attr((string) $reason_value); ?>" <?php selected(isset($complaint_draft['reason']) ? $complaint_draft['reason'] : 'other', (string) $reason_value); ?>><?php echo esc_html((string) $reason_label); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="juntaplay-form__group">
+                                <label for="jp-group-complaint-message-<?php echo esc_attr($group_id); ?>"><?php echo esc_html__('Descreva o que aconteceu', 'juntaplay'); ?></label>
+                                <textarea id="jp-group-complaint-message-<?php echo esc_attr($group_id); ?>" name="jp_profile_complaint_message" class="juntaplay-form__input" rows="4" placeholder="<?php echo esc_attr__('Conte os detalhes, prazos e se já falou com o administrador.', 'juntaplay'); ?>"><?php echo esc_textarea(isset($complaint_draft['message']) ? $complaint_draft['message'] : ''); ?></textarea>
+                            </div>
+                            <div class="juntaplay-form__group">
+                                <label for="jp-group-complaint-order-<?php echo esc_attr($group_id); ?>"><?php echo esc_html__('Número do pedido (opcional)', 'juntaplay'); ?></label>
+                                <input type="text" id="jp-group-complaint-order-<?php echo esc_attr($group_id); ?>" name="jp_profile_complaint_order" class="juntaplay-form__input" inputmode="numeric" value="<?php echo esc_attr(isset($complaint_draft['order']) ? $complaint_draft['order'] : ''); ?>" placeholder="<?php echo esc_attr__('Ex.: 12345', 'juntaplay'); ?>" />
+                            </div>
+                            <div class="juntaplay-form__group">
+                                <label for="jp-group-complaint-files-<?php echo esc_attr($group_id); ?>"><?php echo esc_html__('Anexar prints ou comprovantes', 'juntaplay'); ?></label>
+                                <input type="file" id="jp-group-complaint-files-<?php echo esc_attr($group_id); ?>" name="jp_profile_complaint_attachments[]" class="juntaplay-form__input" accept="image/*,.pdf" multiple data-group-complaint-files />
+                                <p class="juntaplay-form__help"><?php echo esc_html(sprintf(_n('Até %1$d arquivo de até %2$s MB.', 'Até %1$d arquivos de até %2$s MB cada.', $complaint_max_files, 'juntaplay'), $complaint_max_files, number_format_i18n($complaint_max_size_mb, 1))); ?></p>
+                                <ul class="juntaplay-group-complaint__files" data-group-complaint-preview></ul>
+                            </div>
+                            <div class="juntaplay-group-complaint__actions">
+                                <button type="submit" class="juntaplay-button juntaplay-button--primary"><?php echo esc_html__('Enviar reclamação', 'juntaplay'); ?></button>
+                                <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-complaint-close><?php echo esc_html__('Cancelar', 'juntaplay'); ?></button>
+                            </div>
+                        </form>
+                    </div>
+                    <?php if ($faq_items) : ?>
+                        <div class="juntaplay-group-card__faq">
+                            <h4><?php echo esc_html__('Dúvidas frequentes', 'juntaplay'); ?></h4>
+                            <div class="juntaplay-accordion">
+                                <?php foreach ($faq_items as $faq_item) :
+                                    if (!is_array($faq_item)) {
+                                        continue;
+                                    }
+                                    $faq_question = isset($faq_item['question']) ? (string) $faq_item['question'] : '';
+                                    $faq_answer   = isset($faq_item['answer']) ? (string) $faq_item['answer'] : '';
+                                    if ($faq_question === '' || $faq_answer === '') {
+                                        continue;
+                                    }
+                                ?>
+                                    <details class="juntaplay-accordion__item">
+                                        <summary class="juntaplay-accordion__summary"><?php echo esc_html($faq_question); ?></summary>
+                                        <p class="juntaplay-accordion__content"><?php echo esc_html($faq_answer); ?></p>
+                                    </details>
+                                <?php endforeach; ?>
+                            </div>
+                        </div>
+                    <?php endif; ?>
+                    <footer class="juntaplay-group-card__footer">
+                        <?php if ($pool_link !== '') : ?>
+                            <a class="juntaplay-link" href="<?php echo esc_url($pool_link); ?>" target="_blank" rel="noopener">
+                                <?php echo esc_html__('Ver campanha', 'juntaplay'); ?>
+                            </a>
+                        <?php else : ?>
+                            <span class="juntaplay-group-card__note"><?php echo esc_html__('Campanha será definida pelo administrador.', 'juntaplay'); ?></span>
+                        <?php endif; ?>
+                        <?php if ($campaigns_url) : ?>
+                            <div class="juntaplay-group-card__extras">
+                                <span><?php echo esc_html__('Outras opções', 'juntaplay'); ?></span>
+                                <a class="juntaplay-link" href="<?php echo esc_url($campaigns_url); ?>"><?php echo esc_html__('Explorar campanhas disponíveis', 'juntaplay'); ?></a>
+                            </div>
+                        <?php endif; ?>
+                    </footer>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+            <p class="juntaplay-groups__empty is-hidden" data-group-empty><?php echo esc_html__('Nenhum grupo corresponde aos filtros selecionados.', 'juntaplay'); ?></p>
+        <?php else : ?>
+            <p class="juntaplay-profile__empty"><?php echo esc_html__('Você ainda não participa de nenhum grupo. Crie um novo grupo ou participe de uma campanha para aparecer aqui.', 'juntaplay'); ?></p>
+        <?php endif; ?>
+    </div>
+
+    <div class="juntaplay-groups__create">
+        <h3><?php echo esc_html__('Criar novo grupo', 'juntaplay'); ?></h3>
+        <p><?php echo esc_html__('Os grupos são públicos e passam por análise do super administrador. Assim que o pedido for aprovado, todos os participantes recebem um e-mail de confirmação.', 'juntaplay'); ?></p>
+
+        <?php if ($group_suggestions) : ?>
+            <div class="juntaplay-groups__ideas" aria-live="polite">
+                <h4><?php echo esc_html__('Inspirações para começar', 'juntaplay'); ?></h4>
+                <p class="juntaplay-groups__ideas-description"><?php echo esc_html__('Veja alguns exemplos de campanhas populares e utilize-os como ponto de partida para montar o seu grupo.', 'juntaplay'); ?></p>
+                <div class="juntaplay-groups__ideas-list">
+                    <?php foreach ($group_suggestions as $suggestion) :
+                        if (!is_array($suggestion)) {
+                            continue;
+                        }
+
+                        $idea_title       = isset($suggestion['title']) ? (string) $suggestion['title'] : '';
+                        $idea_price       = isset($suggestion['price']) ? (string) $suggestion['price'] : '';
+                        $idea_amount      = isset($suggestion['amount']) ? (string) $suggestion['amount'] : '';
+                        $idea_category    = isset($suggestion['category']) ? (string) $suggestion['category'] : 'other';
+                        $idea_description = isset($suggestion['description']) ? (string) $suggestion['description'] : '';
+                        $idea_category_label = isset($group_categories[$idea_category]) ? (string) $group_categories[$idea_category] : ucwords(str_replace(['-', '_'], ' ', $idea_category));
+                    ?>
+                        <article class="juntaplay-groups__idea" data-group-suggestion
+                            data-title="<?php echo esc_attr($idea_title); ?>"
+                            data-amount="<?php echo esc_attr($idea_amount); ?>"
+                            data-category="<?php echo esc_attr($idea_category); ?>"
+                            data-description="<?php echo esc_attr($idea_description); ?>">
+                            <header class="juntaplay-groups__idea-header">
+                                <span class="juntaplay-groups__idea-category"><?php echo esc_html($idea_category_label); ?></span>
+                                <h5><?php echo esc_html($idea_title); ?></h5>
+                                <?php if ($idea_price !== '') : ?>
+                                    <span class="juntaplay-groups__idea-price"><?php echo esc_html($idea_price); ?></span>
+                                <?php endif; ?>
+                            </header>
+                            <?php if ($idea_description !== '') : ?>
+                                <p class="juntaplay-groups__idea-description"><?php echo esc_html($idea_description); ?></p>
+                            <?php endif; ?>
+                            <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-suggestion-apply>
+                                <?php echo esc_html__('Usar esta sugestão', 'juntaplay'); ?>
+                            </button>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($form_errors) : ?>
+            <ul class="juntaplay-form__errors" role="alert">
+                <?php foreach ($form_errors as $error_message) : ?>
+                    <li><?php echo esc_html($error_message); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+
+        <form method="post" class="juntaplay-form juntaplay-groups__form">
+            <input type="hidden" name="jp_profile_action" value="1" />
+            <input type="hidden" name="jp_profile_section" value="group_create" />
+            <?php wp_nonce_field('juntaplay_profile_update', 'jp_profile_nonce'); ?>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-name"><?php echo esc_html__('Nome do grupo', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-name"
+                        name="jp_profile_group_name"
+                        class="juntaplay-form__input"
+                        value="<?php echo esc_attr($current_name); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: Amigos do Sorteio de Sábado', 'juntaplay'); ?>"
+                        required
+                        data-group-share-watch
+                    />
+                </div>
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-service"><?php echo esc_html__('Serviço ou assinatura', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-service"
+                        name="jp_profile_group_service"
+                        class="juntaplay-form__input"
+                        value="<?php echo esc_attr($current_service); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: ChatGPT Plus, Netflix, Spotify…', 'juntaplay'); ?>"
+                        required
+                        data-group-share-watch
+                    />
+                </div>
+            </div>
+
+            <div class="juntaplay-form__group">
+                <label for="jp-group-service-url"><?php echo esc_html__('Site oficial do serviço', 'juntaplay'); ?></label>
+                <input
+                    type="url"
+                    id="jp-group-service-url"
+                    name="jp_profile_group_service_url"
+                    class="juntaplay-form__input"
+                    value="<?php echo esc_attr($current_service_url); ?>"
+                    placeholder="<?php echo esc_attr__('https://exemplo.com', 'juntaplay'); ?>"
+                    inputmode="url"
+                    data-group-share-watch
+                />
+            </div>
+
+            <div class="juntaplay-form__group juntaplay-form__group--cover" data-group-cover data-placeholder="<?php echo esc_url($cover_placeholder); ?>">
+                <label for="jp-group-cover"><?php echo esc_html__('Capa do grupo (495x370 px)', 'juntaplay'); ?></label>
+                <div class="juntaplay-cover-picker" data-group-cover-wrapper>
+                    <div class="juntaplay-cover-picker__media" data-group-cover-preview style="background-image: url('<?php echo esc_url($current_cover_preview); ?>');">
+                        <img src="<?php echo esc_url($current_cover_preview); ?>" alt="<?php echo esc_attr__('Pré-visualização da capa do grupo', 'juntaplay'); ?>" loading="lazy" />
+                    </div>
+                    <input type="hidden" id="jp-group-cover" name="jp_profile_group_cover" value="<?php echo esc_attr($current_cover_id); ?>" data-group-cover-input />
+                    <div class="juntaplay-cover-picker__actions">
+                        <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-cover-select><?php echo esc_html__('Escolher imagem', 'juntaplay'); ?></button>
+                        <button type="button" class="juntaplay-button juntaplay-button--subtle" data-group-cover-remove <?php disabled($current_cover_id === 0); ?>><?php echo esc_html__('Remover', 'juntaplay'); ?></button>
+                    </div>
+                    <p class="juntaplay-form__help"><?php echo esc_html__('Essa capa será usada nos cards públicos do seu grupo. Utilize dimensões proporcionais a 495x370 px.', 'juntaplay'); ?></p>
+                </div>
+            </div>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-category"><?php echo esc_html__('Categoria do serviço', 'juntaplay'); ?></label>
+                    <select id="jp-group-category" name="jp_profile_group_category" class="juntaplay-form__input" data-group-share-watch>
+                        <?php foreach ($group_categories as $category_value => $category_name) : ?>
+                            <option value="<?php echo esc_attr((string) $category_value); ?>" <?php selected($current_category, (string) $category_value); ?>><?php echo esc_html((string) $category_name); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="juntaplay-form__group juntaplay-form__group--toggle">
+                    <span class="juntaplay-form__label"><?php echo esc_html__('Acesso instantâneo após aprovação', 'juntaplay'); ?></span>
+                    <label class="juntaplay-toggle" for="jp-group-instant">
+                        <input
+                            type="checkbox"
+                            id="jp-group-instant"
+                            name="jp_profile_group_instant"
+                            value="on"
+                            <?php checked($current_instant); ?>
+                            data-group-share-watch
+                        />
+                        <span class="juntaplay-toggle__slider" aria-hidden="true"></span>
+                        <span class="juntaplay-toggle__caption"
+                            data-toggle-caption-active="<?php echo esc_attr__('Ativado', 'juntaplay'); ?>"
+                            data-toggle-caption-inactive="<?php echo esc_attr__('Desativado', 'juntaplay'); ?>">
+                            <?php echo $current_instant ? esc_html__('Ativado', 'juntaplay') : esc_html__('Desativado', 'juntaplay'); ?>
+                        </span>
+                    </label>
+                    <p class="juntaplay-form__help"><?php echo esc_html__('Quando ativado, o grupo libera o acesso automaticamente assim que for aprovado pelo super administrador.', 'juntaplay'); ?></p>
+                </div>
+            </div>
+
+            <div class="juntaplay-form__group">
+                <label for="jp-group-rules"><?php echo esc_html__('Regras principais para os participantes', 'juntaplay'); ?></label>
+                <textarea
+                    id="jp-group-rules"
+                    name="jp_profile_group_rules"
+                    class="juntaplay-form__input"
+                    rows="3"
+                    placeholder="<?php echo esc_attr__('Ex.: Não compartilhar senhas, manter dados atualizados, respeitar prazos.', 'juntaplay'); ?>"
+                    data-group-share-watch
+                ><?php echo esc_textarea($current_rules); ?></textarea>
+            </div>
+
+            <div class="juntaplay-form__group">
+                <label for="jp-group-description"><?php echo esc_html__('Mensagem para os participantes', 'juntaplay'); ?></label>
+                <textarea
+                    id="jp-group-description"
+                    name="jp_profile_group_description"
+                    class="juntaplay-form__input"
+                    rows="4"
+                    placeholder="<?php echo esc_attr__('Descreva o propósito do grupo, metas e como os participantes podem colaborar.', 'juntaplay'); ?>"
+                    data-group-share-watch
+                ><?php echo esc_textarea($current_description); ?></textarea>
+                <p class="juntaplay-form__help"><?php echo esc_html__('Sem grupos privados: todos podem visualizar e solicitar entrada.', 'juntaplay'); ?></p>
+            </div>
+
+            <div class="juntaplay-form__group">
+                <label for="jp-group-pool"><?php echo esc_html__('Campanha vinculada (opcional)', 'juntaplay'); ?></label>
+                <select id="jp-group-pool" name="jp_profile_group_pool" class="juntaplay-form__input">
+                    <option value=""><?php echo esc_html__('Escolha uma campanha', 'juntaplay'); ?></option>
+                    <?php foreach ($pool_choices as $pool_id => $pool_name) : ?>
+                        <option value="<?php echo esc_attr((string) $pool_id); ?>" <?php selected((string) $pool_id, $current_pool); ?>><?php echo esc_html((string) $pool_name); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-price"><?php echo esc_html__('Valor mensal do serviço', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-price"
+                        name="jp_profile_group_price"
+                        class="juntaplay-form__input"
+                        inputmode="decimal"
+                        value="<?php echo esc_attr($current_price); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: 120,00', 'juntaplay'); ?>"
+                        data-group-price-input
+                        data-group-share-watch
+                        required
+                    />
+                </div>
+                <div class="juntaplay-form__group juntaplay-form__group--inline">
+                    <label class="juntaplay-form__checkbox">
+                        <input type="checkbox" name="jp_profile_group_promo_toggle" value="on" data-group-promo-toggle <?php checked($promo_enabled); ?> />
+                        <span><?php echo esc_html__('Ofereço valor promocional aos membros', 'juntaplay'); ?></span>
+                    </label>
+                    <div class="juntaplay-form__group<?php echo $promo_enabled ? '' : ' is-hidden'; ?>" data-group-promo-field>
+                        <label for="jp-group-price-promo" class="screen-reader-text"><?php echo esc_html__('Valor promocional', 'juntaplay'); ?></label>
+                        <input
+                            type="text"
+                            id="jp-group-price-promo"
+                            name="jp_profile_group_price_promo"
+                            class="juntaplay-form__input"
+                            inputmode="decimal"
+                            value="<?php echo esc_attr($current_promo); ?>"
+                            placeholder="<?php echo esc_attr__('Ex.: 110,00', 'juntaplay'); ?>"
+                            data-group-price-input
+                            data-group-share-watch
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-slots-total"><?php echo esc_html__('Total de vagas', 'juntaplay'); ?></label>
+                    <input
+                        type="number"
+                        id="jp-group-slots-total"
+                        name="jp_profile_group_slots_total"
+                        class="juntaplay-form__input"
+                        min="1"
+                        value="<?php echo esc_attr($current_total); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: 5', 'juntaplay'); ?>"
+                        data-group-slot-input
+                        data-group-share-watch
+                        required
+                    />
+                </div>
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-slots-reserved"><?php echo esc_html__('Vagas reservadas para você', 'juntaplay'); ?></label>
+                    <input
+                        type="number"
+                        id="jp-group-slots-reserved"
+                        name="jp_profile_group_slots_reserved"
+                        class="juntaplay-form__input"
+                        min="0"
+                        value="<?php echo esc_attr($current_reserved); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: 1', 'juntaplay'); ?>"
+                        data-group-slot-input
+                        data-group-share-watch
+                    />
+                    <p class="juntaplay-form__help"><?php echo esc_html__('Lembre-se: o grupo permanece público e auditado pelo super administrador.', 'juntaplay'); ?></p>
+                </div>
+            </div>
+
+            <div class="juntaplay-form__group">
+                <label for="jp-group-member-price"><?php echo esc_html__('Valor cobrado de cada membro', 'juntaplay'); ?></label>
+                <input
+                    type="text"
+                    id="jp-group-member-price"
+                    name="jp_profile_group_member_price"
+                    class="juntaplay-form__input"
+                    inputmode="decimal"
+                    value="<?php echo esc_attr($current_member); ?>"
+                    placeholder="<?php echo esc_attr__('Será sugerido automaticamente', 'juntaplay'); ?>"
+                    data-group-price-input
+                    data-group-member-input
+                    data-group-member-generated="<?php echo $member_was_generated ? 'yes' : 'no'; ?>"
+                    data-group-share-watch
+                />
+                <p class="juntaplay-form__hint juntaplay-groups__price-preview <?php echo $member_preview_text === '' ? 'is-hidden' : ''; ?>" data-group-price-preview data-empty="<?php echo esc_attr__('Informe valor do serviço e vagas para sugerir o valor por membro.', 'juntaplay'); ?>" data-suffix="<?php echo esc_attr__('por membro disponível', 'juntaplay'); ?>">
+                    <?php echo esc_html($member_preview_text); ?>
+                </p>
+            </div>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-support"><?php echo esc_html__('Suporte aos membros', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-support"
+                        name="jp_profile_group_support"
+                        class="juntaplay-form__input"
+                        value="<?php echo esc_attr($current_support); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: E-mail, WhatsApp comercial, Telegram…', 'juntaplay'); ?>"
+                        data-group-share-watch
+                        required
+                    />
+                </div>
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-delivery"><?php echo esc_html__('Prazo para envio de acesso', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-delivery"
+                        name="jp_profile_group_delivery"
+                        class="juntaplay-form__input"
+                        value="<?php echo esc_attr($current_delivery); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: Imediatamente após pagamento', 'juntaplay'); ?>"
+                        data-group-share-watch
+                        required
+                    />
+                </div>
+            </div>
+
+            <div class="juntaplay-form__grid">
+                <div class="juntaplay-form__group">
+                    <label for="jp-group-access"><?php echo esc_html__('Forma de acesso enviada', 'juntaplay'); ?></label>
+                    <input
+                        type="text"
+                        id="jp-group-access"
+                        name="jp_profile_group_access"
+                        class="juntaplay-form__input"
+                        value="<?php echo esc_attr($current_access); ?>"
+                        placeholder="<?php echo esc_attr__('Ex.: Código de ativação, login compartilhado, convite por e-mail…', 'juntaplay'); ?>"
+                        data-group-share-watch
+                        required
+                    />
+                </div>
+            </div>
+
+            <div class="juntaplay-groups__share" data-group-share data-domain="<?php echo esc_attr($site_host); ?>" data-empty="<?php echo esc_attr__('Preencha os campos ao lado para gerar um texto completo de convite.', 'juntaplay'); ?>">
+                <h4><?php echo esc_html__('Prévia para convidar participantes', 'juntaplay'); ?></h4>
+                <p class="juntaplay-groups__share-intro"><?php echo esc_html__('Revise e compartilhe este resumo com interessados antes de enviar para análise.', 'juntaplay'); ?></p>
+                <div class="juntaplay-groups__share-card">
+                    <span class="juntaplay-groups__share-domain"><?php echo esc_html($site_host); ?></span>
+                    <dl class="juntaplay-groups__share-list">
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Serviço', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="service" data-empty="<?php echo esc_attr__('Informe o serviço', 'juntaplay'); ?>"><?php echo $current_service !== '' ? esc_html($current_service) : esc_html__('Informe o serviço', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Nome do grupo', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="name" data-empty="<?php echo esc_attr__('Defina o nome do grupo', 'juntaplay'); ?>"><?php echo $current_name !== '' ? esc_html($current_name) : esc_html__('Defina o nome do grupo', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Tipo', 'juntaplay'); ?></dt>
+                            <dd><?php echo $group_type_label; ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Categoria', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="category" data-empty="<?php echo esc_attr__('Escolha uma categoria', 'juntaplay'); ?>"><?php echo $category_display !== '' ? $category_display : esc_html__('Escolha uma categoria', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Site', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="service_url" data-empty="<?php echo esc_attr__('Inclua o link oficial', 'juntaplay'); ?>"><?php echo $current_service_url !== '' ? esc_html($current_service_url) : esc_html__('Inclua o link oficial', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Regras', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="rules" data-empty="<?php echo esc_attr__('Compartilhe as regras principais', 'juntaplay'); ?>"><?php echo $current_rules !== '' ? esc_html($current_rules) : esc_html__('Compartilhe as regras principais', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Descrição', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="description" data-empty="<?php echo esc_attr__('Descreva o objetivo do grupo', 'juntaplay'); ?>"><?php echo $current_description !== '' ? esc_html($current_description) : esc_html__('Descreva o objetivo do grupo', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Valor do serviço', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="price" data-empty="<?php echo esc_attr__('Informe o valor', 'juntaplay'); ?>"><?php echo $price_display !== '' ? esc_html($price_display) : esc_html__('Informe o valor', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('É valor promocional?', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="promo_flag" data-fallback="<?php echo esc_attr__('Não', 'juntaplay'); ?>"><?php echo $promo_flag; ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Valor promocional', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="promo" data-fallback="<?php echo esc_attr__('Não', 'juntaplay'); ?>"><?php echo esc_html($promo_display); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Vagas totais', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="slots_total" data-empty="<?php echo esc_attr__('Defina o total de vagas', 'juntaplay'); ?>"><?php echo $current_total !== '' ? esc_html($current_total) : esc_html__('Defina o total de vagas', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Reservadas para você', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="slots_reserved" data-empty="0"><?php echo $current_reserved !== '' ? esc_html($current_reserved) : '0'; ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Valor por membro', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="member_price" data-empty="<?php echo esc_attr__('Será calculado automaticamente', 'juntaplay'); ?>"><?php echo $member_display !== '' ? esc_html($member_display) : esc_html__('Será calculado automaticamente', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Suporte', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="support" data-empty="<?php echo esc_attr__('Informe o canal de suporte', 'juntaplay'); ?>"><?php echo $current_support !== '' ? esc_html($current_support) : esc_html__('Informe o canal de suporte', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Envio de acesso', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="delivery" data-empty="<?php echo esc_attr__('Defina o prazo de entrega', 'juntaplay'); ?>"><?php echo $current_delivery !== '' ? esc_html($current_delivery) : esc_html__('Defina o prazo de entrega', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Forma de acesso', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="access" data-empty="<?php echo esc_attr__('Explique como o acesso será enviado', 'juntaplay'); ?>"><?php echo $current_access !== '' ? esc_html($current_access) : esc_html__('Explique como o acesso será enviado', 'juntaplay'); ?></dd>
+                        </div>
+                        <div class="juntaplay-groups__share-row">
+                            <dt><?php echo esc_html__('Acesso instantâneo', 'juntaplay'); ?></dt>
+                            <dd data-group-share-field="instant_access" data-fallback="<?php echo esc_attr__('Desativado', 'juntaplay'); ?>"><?php echo $instant_display; ?></dd>
+                        </div>
+                    </dl>
+                </div>
+                <pre class="juntaplay-groups__share-snippet" data-group-share-snippet><?php echo esc_html($share_text); ?></pre>
+                <textarea class="juntaplay-groups__share-text" data-group-share-text readonly hidden><?php echo esc_textarea($share_text); ?></textarea>
+                <div class="juntaplay-groups__share-actions">
+                    <button type="button" class="juntaplay-button juntaplay-button--ghost" data-group-share-copy data-default-label="<?php echo esc_attr__('Copiar resumo', 'juntaplay'); ?>" data-success-label="<?php echo esc_attr__('Resumo copiado!', 'juntaplay'); ?>" data-error-label="<?php echo esc_attr__('Não foi possível copiar agora. Copie manualmente.', 'juntaplay'); ?>"><?php echo esc_html__('Copiar resumo', 'juntaplay'); ?></button>
+                </div>
+            </div>
+
+            <div class="juntaplay-form__actions">
+                <button type="submit" class="juntaplay-button juntaplay-button--primary"><?php echo esc_html__('Enviar para análise', 'juntaplay'); ?></button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/juntaplay/templates/profile.php
+++ b/juntaplay/templates/profile.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * JuntaPlay profile editing template.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$user             = wp_get_current_user();
+$profile_sections = $profile_sections ?? [];
+$profile_errors   = $profile_errors ?? [];
+$profile_notices  = $profile_notices ?? [];
+$active_section   = $profile_active_section ?? null;
+$display_name     = '';
+
+if ($user && $user->exists()) {
+    $display_name = wp_strip_all_tags((string) $user->display_name);
+}
+
+if ($display_name === '') {
+    $display_name = wp_strip_all_tags(__('Jogue com a gente', 'juntaplay'));
+}
+
+$notifications_unread = \JuntaPlay\Data\Notifications::count_unread(get_current_user_id());
+?>
+<div class="juntaplay-profile" data-profile>
+    <div class="juntaplay-profile__toolbar">
+        <button type="button" class="juntaplay-notification-bell" data-jp-notifications aria-haspopup="true" aria-expanded="false"<?php if ($notifications_unread > 0) : ?> data-count="<?php echo esc_attr($notifications_unread); ?>"<?php endif; ?>>
+            <span class="screen-reader-text"><?php esc_html_e('Abrir notificações', 'juntaplay'); ?></span>
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M12 22a2 2 0 0 0 1.995-1.85L14 20h-4a2 2 0 0 0 1.85 1.995L12 22Zm7-6v-5a7 7 0 0 0-5-6.708V4a2 2 0 1 0-4 0v.292A7.002 7.002 0 0 0 6 11v5l-1.447 2.894A1 1 0 0 0 5.447 20h13.106a1 1 0 0 0 .894-1.447Z" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </button>
+        <div class="juntaplay-notifications" data-jp-notifications-panel aria-hidden="true">
+            <div class="juntaplay-notifications__header">
+                <h4><?php esc_html_e('Notificações', 'juntaplay'); ?></h4>
+            </div>
+            <ul class="juntaplay-notifications__list" data-jp-notifications-list>
+                <li class="juntaplay-notifications__empty"><?php esc_html_e('Carregando notificações...', 'juntaplay'); ?></li>
+            </ul>
+            <div class="juntaplay-notifications__footer">
+                <button type="button" data-jp-notifications-close><?php esc_html_e('Fechar', 'juntaplay'); ?></button>
+            </div>
+        </div>
+    </div>
+    <header class="juntaplay-profile__hero">
+        <div class="juntaplay-profile__eyebrow"><?php echo esc_html__('Meu perfil', 'juntaplay'); ?></div>
+        <h1><?php echo esc_html(sprintf(__('Olá, %s', 'juntaplay'), $display_name)); ?></h1>
+        <p><?php echo esc_html__('Atualize seus dados de contato para aproveitar as oportunidades do JuntaPlay.', 'juntaplay'); ?></p>
+    </header>
+
+    <?php if ($profile_notices) : ?>
+        <div class="juntaplay-profile__alerts">
+            <?php foreach ($profile_notices as $notice) : ?>
+                <div class="juntaplay-alert juntaplay-alert--success"><?php echo esc_html($notice); ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if (!empty($profile_errors['general'])) : ?>
+        <div class="juntaplay-profile__alerts">
+            <?php foreach ($profile_errors['general'] as $message) : ?>
+                <div class="juntaplay-alert juntaplay-alert--error"><?php echo esc_html($message); ?></div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <div class="juntaplay-card juntaplay-profile__card">
+        <div class="juntaplay-card__body">
+            <?php foreach ($profile_sections as $group_key => $group) :
+                if (!is_array($group)) {
+                    continue;
+                }
+
+                $group_items = isset($group['items']) && is_array($group['items']) ? $group['items'] : [];
+
+                if (!$group_items) {
+                    continue;
+                }
+
+                $group_title       = isset($group['title']) ? (string) $group['title'] : '';
+                $group_description = isset($group['description']) ? (string) $group['description'] : '';
+                $group_notice      = isset($group['notice']) ? (string) $group['notice'] : '';
+            ?>
+                <section class="juntaplay-profile__group" data-group="<?php echo esc_attr($group_key); ?>">
+                    <?php if ($group_title || $group_description) : ?>
+                        <header class="juntaplay-profile__group-header">
+                            <?php if ($group_title) : ?>
+                                <h2 class="juntaplay-profile__group-title"><?php echo esc_html($group_title); ?></h2>
+                            <?php endif; ?>
+                            <?php if ($group_description) : ?>
+                                <p class="juntaplay-profile__group-description"><?php echo esc_html($group_description); ?></p>
+                            <?php endif; ?>
+                        </header>
+                    <?php endif; ?>
+
+                    <?php if ($group_notice) : ?>
+                        <div class="juntaplay-profile__alerts">
+                            <div class="juntaplay-alert juntaplay-alert--info"><?php echo esc_html($group_notice); ?></div>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php
+                    $group_summary = [];
+                    if (isset($group['summary']) && is_array($group['summary'])) {
+                        $group_summary = array_filter($group['summary'], 'is_array');
+                    }
+
+                    if ($group_summary) :
+                    ?>
+                        <div class="juntaplay-profile__summary">
+                            <?php foreach ($group_summary as $summary_item) :
+                                $summary_label = isset($summary_item['label']) ? (string) $summary_item['label'] : '';
+                                $summary_value = isset($summary_item['value']) ? (string) $summary_item['value'] : '';
+                                $summary_hint  = isset($summary_item['hint']) ? (string) $summary_item['hint'] : '';
+                                $summary_tone  = isset($summary_item['tone']) ? (string) $summary_item['tone'] : '';
+
+                                $summary_classes = ['juntaplay-profile__summary-item'];
+                                if ($summary_tone !== '') {
+                                    $summary_classes[] = 'juntaplay-profile__summary-item--' . sanitize_html_class($summary_tone);
+                                }
+                            ?>
+                                <article class="<?php echo esc_attr(implode(' ', $summary_classes)); ?>">
+                                    <?php if ($summary_label !== '') : ?>
+                                        <span class="juntaplay-profile__summary-label"><?php echo esc_html($summary_label); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($summary_value !== '') : ?>
+                                        <span class="juntaplay-profile__summary-value"><?php echo esc_html($summary_value); ?></span>
+                                    <?php endif; ?>
+                                    <?php if ($summary_hint !== '') : ?>
+                                        <span class="juntaplay-profile__summary-hint"><?php echo esc_html($summary_hint); ?></span>
+                                    <?php endif; ?>
+                                </article>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <ul class="juntaplay-profile__list" role="list">
+                        <?php foreach ($group_items as $section_key => $section) :
+                            if (!is_array($section)) {
+                                continue;
+                            }
+
+                            $is_editing     = $active_section === $section_key;
+                            $section_errors = $profile_errors[$section_key] ?? [];
+                            if ($section_errors && !$is_editing) {
+                                $is_editing = true;
+                            }
+
+                            $value          = isset($section['value']) ? (string) $section['value'] : '';
+                            $display_value  = isset($section['display_value']) ? (string) $section['display_value'] : $value;
+                            $label          = isset($section['label']) ? (string) $section['label'] : '';
+                            $description    = isset($section['description']) ? (string) $section['description'] : '';
+                            $placeholder    = isset($section['placeholder']) ? (string) $section['placeholder'] : '';
+                            $type           = isset($section['type']) ? (string) $section['type'] : 'text';
+                            $options        = isset($section['options']) && is_array($section['options']) ? $section['options'] : [];
+                            $autocomplete   = isset($section['autocomplete']) ? (string) $section['autocomplete'] : '';
+                              $fields         = isset($section['fields']) && is_array($section['fields']) ? $section['fields'] : [];
+                              $submit_label   = isset($section['submit_label']) ? (string) $section['submit_label'] : __('Salvar', 'juntaplay');
+                              $confirm_message = isset($section['confirmation']) ? (string) $section['confirmation'] : '';
+                              $editable       = array_key_exists('editable', $section) ? (bool) $section['editable'] : true;
+                              $template_name  = isset($section['template']) ? (string) $section['template'] : '';
+                              $context        = isset($section['context']) && is_array($section['context']) ? $section['context'] : [];
+                              $custom_html    = isset($section['html']) ? (string) $section['html'] : '';
+
+                            if ($autocomplete === '') {
+                                if ($section_key === 'email') {
+                                    $autocomplete = 'email';
+                                } elseif ($section_key === 'name') {
+                                    $autocomplete = 'name';
+                                } elseif (in_array($type, ['tel', 'text'], true)) {
+                                    $autocomplete = 'on';
+                                }
+                            }
+
+                              if ($display_value === '' && $value !== '' && isset($options[$value])) {
+                                  $display_value = (string) $options[$value];
+                              }
+
+                              if ($type === 'custom') {
+                                  $row_classes = ['juntaplay-profile__row', 'juntaplay-profile__row--custom'];
+                                  ?>
+                                  <li class="<?php echo esc_attr(implode(' ', $row_classes)); ?>" data-section="<?php echo esc_attr($section_key); ?>">
+                                      <div class="juntaplay-profile__content">
+                                          <?php if ($label !== '') : ?>
+                                              <div class="juntaplay-profile__label"><?php echo esc_html($label); ?></div>
+                                          <?php endif; ?>
+                                          <?php if ($description !== '') : ?>
+                                              <p class="juntaplay-profile__description"><?php echo esc_html($description); ?></p>
+                                          <?php endif; ?>
+                                      </div>
+                                      <div class="juntaplay-profile__custom">
+                                          <?php
+                                          $template_file = '';
+                                          if ($template_name !== '') {
+                                              $template_file = JP_DIR . 'templates/' . ltrim($template_name, '/');
+                                          }
+
+                                          $group_context = $context;
+                                          $group_context['errors']      = $section_errors;
+                                          $group_context['section_key'] = $section_key;
+
+                                          if ($template_file !== '' && file_exists($template_file)) {
+                                              /** @var array<string, mixed> $group_context */
+                                              include $template_file;
+                                          } elseif ($custom_html !== '') {
+                                              echo wp_kses_post($custom_html);
+                                          } else {
+                                              echo '<p class="juntaplay-profile__empty">' . esc_html__('Conteúdo indisponível no momento.', 'juntaplay') . '</p>';
+                                          }
+                                          ?>
+                                      </div>
+                                  </li>
+                                  <?php
+
+                                  continue;
+                              }
+
+                              if (!$editable) {
+                                  $is_editing = false;
+                              }
+
+                              $row_classes = ['juntaplay-profile__row'];
+                              if ($is_editing) {
+                                  $row_classes[] = 'is-editing';
+                              }
+
+                            if ($type === 'action') {
+                                $row_classes[] = 'juntaplay-profile__row--action';
+                            }
+
+                            $button_class = $type === 'action'
+                                ? 'juntaplay-button juntaplay-button--danger'
+                                : 'juntaplay-button juntaplay-button--primary';
+
+                            $show_cancel = true;
+                        ?>
+                            <li class="<?php echo esc_attr(implode(' ', $row_classes)); ?>" data-section="<?php echo esc_attr($section_key); ?>">
+                                <div class="juntaplay-profile__content">
+                                    <div class="juntaplay-profile__label"><?php echo esc_html($label); ?></div>
+                                    <div class="juntaplay-profile__value"><?php echo $display_value !== '' ? esc_html($display_value) : '<span class="juntaplay-profile__empty">' . esc_html__('Não informado', 'juntaplay') . '</span>'; ?></div>
+                                    <?php if ($description) : ?>
+                                        <p class="juntaplay-profile__description"><?php echo esc_html($description); ?></p>
+                                    <?php endif; ?>
+                                </div>
+                                  <?php if ($editable) : ?>
+                                      <div class="juntaplay-profile__actions">
+                                          <button type="button" class="juntaplay-profile__edit" data-toggle="<?php echo esc_attr($section_key); ?>" aria-expanded="<?php echo $is_editing ? 'true' : 'false'; ?>">
+                                              <?php echo esc_html__('Alterar', 'juntaplay'); ?>
+                                          </button>
+                                      </div>
+                                      <div class="juntaplay-profile__form" role="region" aria-hidden="<?php echo $is_editing ? 'false' : 'true'; ?>">
+                                          <form method="post" class="juntaplay-form"<?php echo $confirm_message !== '' ? ' data-confirm="' . esc_attr($confirm_message) . '"' : ''; ?>>
+                                              <input type="hidden" name="jp_profile_action" value="1" />
+                                              <input type="hidden" name="jp_profile_section" value="<?php echo esc_attr($section_key); ?>" />
+                                              <?php wp_nonce_field('juntaplay_profile_update', 'jp_profile_nonce'); ?>
+                                        <?php if ($fields) : ?>
+                                            <?php foreach ($fields as $field) :
+                                                if (!is_array($field) || empty($field['name'])) {
+                                                    continue;
+                                                }
+
+                                                $field_name        = (string) $field['name'];
+                                                $field_id          = 'juntaplay-field-' . $section_key . '-' . $field_name;
+                                                $field_label       = isset($field['label']) ? (string) $field['label'] : '';
+                                                $field_type        = isset($field['type']) ? (string) $field['type'] : 'text';
+                                                $field_placeholder = isset($field['placeholder']) ? (string) $field['placeholder'] : '';
+                                                $field_autocomplete = isset($field['autocomplete']) ? (string) $field['autocomplete'] : '';
+                                                $field_value       = isset($field['value']) ? (string) $field['value'] : '';
+                                                $field_options     = isset($field['options']) && is_array($field['options']) ? $field['options'] : [];
+                                                $field_help        = isset($field['help']) ? (string) $field['help'] : '';
+                                                $field_attributes  = isset($field['attributes']) && is_array($field['attributes']) ? $field['attributes'] : [];
+                                                $attributes_html   = '';
+
+                                                foreach ($field_attributes as $attr_key => $attr_value) {
+                                                    if ($attr_value === null || $attr_value === '') {
+                                                        continue;
+                                                    }
+
+                                                    $attributes_html .= ' ' . esc_attr((string) $attr_key) . '="' . esc_attr((string) $attr_value) . '"';
+                                                }
+                                            ?>
+                                                <div class="juntaplay-form__group">
+                                                    <?php if ($field_label) : ?>
+                                                        <label for="<?php echo esc_attr($field_id); ?>"><?php echo esc_html($field_label); ?></label>
+                                                    <?php endif; ?>
+                                                      <?php if ($field_type === 'select' && $field_options) : ?>
+                                                          <select
+                                                              id="<?php echo esc_attr($field_id); ?>"
+                                                              name="<?php echo esc_attr('jp_profile_' . $field_name); ?>"
+                                                              class="juntaplay-form__input"
+                                                              <?php echo $attributes_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                          >
+                                                              <?php foreach ($field_options as $option_value => $option_label) : ?>
+                                                                  <option value="<?php echo esc_attr((string) $option_value); ?>" <?php selected((string) $option_value, $field_value); ?>><?php echo esc_html((string) $option_label); ?></option>
+                                                              <?php endforeach; ?>
+                                                          </select>
+                                                      <?php elseif ($field_type === 'textarea') : ?>
+                                                          <textarea
+                                                              id="<?php echo esc_attr($field_id); ?>"
+                                                              name="<?php echo esc_attr('jp_profile_' . $field_name); ?>"
+                                                              class="juntaplay-form__input"
+                                                              rows="4"
+                                                              placeholder="<?php echo esc_attr($field_placeholder); ?>"
+                                                              <?php echo $attributes_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                          ><?php echo esc_textarea($field_value); ?></textarea>
+                                                      <?php else : ?>
+                                                          <input
+                                                              type="<?php echo esc_attr($field_type); ?>"
+                                                              id="<?php echo esc_attr($field_id); ?>"
+                                                              name="<?php echo esc_attr('jp_profile_' . $field_name); ?>"
+                                                            class="juntaplay-form__input"
+                                                            value="<?php echo esc_attr($field_value); ?>"
+                                                            placeholder="<?php echo esc_attr($field_placeholder); ?>"
+                                                            autocomplete="<?php echo esc_attr($field_autocomplete ?: 'on'); ?>"
+                                                            <?php echo $attributes_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                        />
+                                                    <?php endif; ?>
+                                                    <?php if ($field_help) : ?>
+                                                        <p class="juntaplay-form__help"><?php echo esc_html($field_help); ?></p>
+                                                    <?php endif; ?>
+                                                </div>
+                                            <?php endforeach; ?>
+                                        <?php elseif ($type !== 'action') : ?>
+                                            <div class="juntaplay-form__group">
+                                                <label for="juntaplay-field-<?php echo esc_attr($section_key); ?>"><?php echo esc_html($label); ?></label>
+                                                  <?php if ($type === 'select') : ?>
+                                                      <select
+                                                          id="juntaplay-field-<?php echo esc_attr($section_key); ?>"
+                                                          name="<?php echo esc_attr('jp_profile_' . $section_key); ?>"
+                                                          class="juntaplay-form__input"
+                                                      >
+                                                          <?php foreach ($options as $option_value => $option_label) : ?>
+                                                              <option value="<?php echo esc_attr((string) $option_value); ?>" <?php selected((string) $option_value, $value); ?>><?php echo esc_html((string) $option_label); ?></option>
+                                                          <?php endforeach; ?>
+                                                      </select>
+                                                  <?php elseif ($type === 'textarea') : ?>
+                                                      <textarea
+                                                          id="juntaplay-field-<?php echo esc_attr($section_key); ?>"
+                                                          name="<?php echo esc_attr('jp_profile_' . $section_key); ?>"
+                                                          class="juntaplay-form__input"
+                                                          rows="4"
+                                                          placeholder="<?php echo esc_attr($placeholder); ?>"
+                                                      ><?php echo esc_textarea($value); ?></textarea>
+                                                  <?php else : ?>
+                                                      <input
+                                                          type="<?php echo esc_attr($type); ?>"
+                                                          id="juntaplay-field-<?php echo esc_attr($section_key); ?>"
+                                                          name="<?php echo esc_attr('jp_profile_' . $section_key); ?>"
+                                                        class="juntaplay-form__input"
+                                                        value="<?php echo esc_attr($value); ?>"
+                                                        placeholder="<?php echo esc_attr($placeholder); ?>"
+                                                        autocomplete="<?php echo esc_attr($autocomplete); ?>"
+                                                    />
+                                                <?php endif; ?>
+                                            </div>
+                                        <?php endif; ?>
+                                        <?php if ($section_errors) : ?>
+                                            <ul class="juntaplay-form__errors" role="alert">
+                                                <?php foreach ($section_errors as $error_message) : ?>
+                                                    <li><?php echo esc_html($error_message); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        <?php endif; ?>
+                                        <div class="juntaplay-form__actions">
+                                            <button type="submit" class="<?php echo esc_attr($button_class); ?>"><?php echo esc_html($submit_label); ?></button>
+                                            <?php if ($show_cancel) : ?>
+                                                <button type="button" class="juntaplay-button juntaplay-button--ghost juntaplay-profile__cancel"><?php echo esc_html__('Cancelar', 'juntaplay'); ?></button>
+                                            <?php endif; ?>
+                                          </div>
+                                      </form>
+                                      </div>
+                                  <?php endif; ?>
+                              </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </section>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</div>

--- a/juntaplay/templates/quota-grid.php
+++ b/juntaplay/templates/quota-grid.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+use JuntaPlay\Data\Pools;
+
+global $wpdb;
+
+$pool = Pools::get($current_pool_id ?? 0);
+
+if (!$pool) {
+    echo '<p class="juntaplay-notice">' . esc_html__('Campanha não encontrada.', 'juntaplay') . '</p>';
+    return;
+}
+
+$table  = "{$wpdb->prefix}jp_quotas";
+$counts = $wpdb->get_results(
+    $wpdb->prepare(
+        "SELECT status, COUNT(*) AS total FROM $table WHERE pool_id = %d GROUP BY status",
+        (int) $pool->id
+    ),
+    ARRAY_A
+);
+
+$stats = [
+    'available' => 0,
+    'reserved'  => 0,
+    'paid'      => 0,
+    'canceled'  => 0,
+    'expired'   => 0,
+];
+
+foreach ($counts as $row) {
+    $status = isset($row['status']) ? (string) $row['status'] : '';
+    if (isset($stats[$status])) {
+        $stats[$status] = (int) ($row['total'] ?? 0);
+    }
+}
+
+$total     = array_sum($stats);
+$available = $stats['available'];
+$reserved  = $stats['reserved'];
+$paid      = $stats['paid'];
+$progress  = $total > 0 ? min(100, (int) round(($paid / $total) * 100)) : 0;
+$currency  = function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : 'BRL';
+$locale    = str_replace('_', '-', get_locale());
+$price     = (float) $pool->price;
+$cart_url  = function_exists('wc_get_cart_url') ? wc_get_cart_url() : home_url('/');
+$per_page  = isset($per_page) ? (int) $per_page : 120;
+?>
+<div
+    class="juntaplay-quota-selector juntaplay-section"
+    data-pool="<?php echo esc_attr((int) $pool->id); ?>"
+    data-per-page="<?php echo esc_attr($per_page); ?>"
+    data-status="available"
+    data-sort="ASC"
+>
+    <header class="juntaplay-summary" aria-label="<?php echo esc_attr__('Resumo de disponibilidade das cotas', 'juntaplay'); ?>">
+        <div class="juntaplay-summary__item">
+            <span class="juntaplay-summary__label"><?php esc_html_e('Disponíveis', 'juntaplay'); ?></span>
+            <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($available)); ?></span>
+        </div>
+        <div class="juntaplay-summary__item">
+            <span class="juntaplay-summary__label"><?php esc_html_e('Reservadas', 'juntaplay'); ?></span>
+            <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($reserved)); ?></span>
+        </div>
+        <div class="juntaplay-summary__item">
+            <span class="juntaplay-summary__label"><?php esc_html_e('Pagas', 'juntaplay'); ?></span>
+            <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($paid)); ?></span>
+        </div>
+        <div class="juntaplay-summary__item">
+            <span class="juntaplay-summary__label"><?php esc_html_e('Total', 'juntaplay'); ?></span>
+            <span class="juntaplay-summary__value"><?php echo esc_html(number_format_i18n($total)); ?></span>
+        </div>
+    </header>
+
+    <div class="juntaplay-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr((string) $progress); ?>">
+        <span class="juntaplay-progress__bar" style="width: <?php echo esc_attr((string) $progress); ?>%;"></span>
+    </div>
+
+    <div class="juntaplay-summary__legend" aria-hidden="true">
+        <?php
+        printf(
+            /* translators: %s: percentage of paid quotas */
+            esc_html__('%s%% das cotas já foram pagas.', 'juntaplay'),
+            esc_html(number_format_i18n($progress))
+        );
+        ?>
+    </div>
+
+    <form class="juntaplay-quota-filter" novalidate>
+        <div class="juntaplay-filters">
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-quota-status"><?php esc_html_e('Status', 'juntaplay'); ?></label>
+                <select id="juntaplay-quota-status" name="status">
+                    <option value="available"><?php esc_html_e('Disponíveis', 'juntaplay'); ?></option>
+                    <option value="open"><?php esc_html_e('Disponíveis e reservadas', 'juntaplay'); ?></option>
+                    <option value="reserved"><?php esc_html_e('Reservadas', 'juntaplay'); ?></option>
+                    <option value="paid"><?php esc_html_e('Pagas', 'juntaplay'); ?></option>
+                    <option value="all"><?php esc_html_e('Todos os números', 'juntaplay'); ?></option>
+                </select>
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-quota-search"><?php esc_html_e('Buscar número ou intervalo', 'juntaplay'); ?></label>
+                <input id="juntaplay-quota-search" type="text" name="search" placeholder="<?php esc_attr_e('Ex.: 10-50', 'juntaplay'); ?>" />
+            </div>
+            <div class="juntaplay-filters__group">
+                <label for="juntaplay-quota-sort"><?php esc_html_e('Ordenar', 'juntaplay'); ?></label>
+                <select id="juntaplay-quota-sort" name="sort">
+                    <option value="ASC"><?php esc_html_e('Menor número', 'juntaplay'); ?></option>
+                    <option value="DESC"><?php esc_html_e('Maior número', 'juntaplay'); ?></option>
+                </select>
+            </div>
+            <div class="juntaplay-filters__actions">
+                <button type="submit" class="juntaplay-button juntaplay-button--secondary"><?php esc_html_e('Aplicar filtros', 'juntaplay'); ?></button>
+            </div>
+        </div>
+    </form>
+
+    <div class="juntaplay-grid-wrap">
+        <div class="juntaplay-grid juntaplay-grid--quotas" data-quota-grid></div>
+        <p class="juntaplay-feedback" data-quota-feedback></p>
+        <div class="juntaplay-grid__actions">
+            <button type="button" class="juntaplay-button juntaplay-button--ghost" data-quota-load><?php esc_html_e('Ver mais números', 'juntaplay'); ?></button>
+        </div>
+    </div>
+
+    <form
+        class="juntaplay-quota-form"
+        method="post"
+        action="<?php echo esc_url($cart_url); ?>"
+        data-message-empty="<?php echo esc_attr__('Selecione ao menos uma cota.', 'juntaplay'); ?>"
+        data-price="<?php echo esc_attr((string) $price); ?>"
+        data-currency="<?php echo esc_attr($currency); ?>"
+        data-locale="<?php echo esc_attr($locale); ?>"
+    >
+        <input type="hidden" name="add-to-cart" value="<?php echo esc_attr((int) $pool->product_id); ?>" />
+        <input type="hidden" name="jp_pool_id" value="<?php echo esc_attr((int) $pool->id); ?>" />
+
+        <div class="juntaplay-selected">
+            <div class="juntaplay-selected__header">
+                <div>
+                    <strong><?php esc_html_e('Cotas selecionadas', 'juntaplay'); ?></strong>
+                    <p class="juntaplay-summary__label"><?php esc_html_e('Clique para adicionar ou remover números.', 'juntaplay'); ?></p>
+                </div>
+                <div class="juntaplay-selected__count-wrapper">
+                    <span class="juntaplay-badge"><span class="juntaplay-selected__count">0</span></span>
+                    <span class="juntaplay-summary__label"><?php esc_html_e('itens', 'juntaplay'); ?></span>
+                </div>
+            </div>
+
+            <div class="juntaplay-selected__numbers" data-empty="<?php echo esc_attr__('Nenhuma cota selecionada ainda.', 'juntaplay'); ?>"></div>
+
+            <div class="juntaplay-selected__footer">
+                <span class="juntaplay-selected__total-label"><?php esc_html_e('Total estimado', 'juntaplay'); ?></span>
+                <span class="juntaplay-selected__total-value" data-empty="<?php echo esc_attr__('—', 'juntaplay'); ?>"><?php esc_html_e('—', 'juntaplay'); ?></span>
+            </div>
+        </div>
+
+        <div style="margin-top:1.5rem; display:flex; justify-content:flex-end;">
+            <button type="submit" class="juntaplay-button juntaplay-button--primary btn btn-theme"><?php esc_html_e('Reservar cotas', 'juntaplay'); ?></button>
+        </div>
+    </form>
+</div>

--- a/juntaplay/templates/statement.php
+++ b/juntaplay/templates/statement.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/** @var WC_Order $statement_order */
+/** @var array<int, array{pool_id:int,title:string,link:string,numbers:array<int,int>,statuses:array<int,string>,line_total:float,quantity:int,line_subtotal:float}> $statement_items */
+/** @var float $statement_balance */
+
+$format_datetime = static function ($datetime) {
+    if (!$datetime) {
+        return '';
+    }
+
+    if (function_exists('wc_format_datetime')) {
+        return wc_format_datetime($datetime);
+    }
+
+    return $datetime->date_i18n(get_option('date_format') . ' ' . get_option('time_format'));
+};
+
+$created_at = $statement_order->get_date_created();
+$updated_at = $statement_order->get_date_modified() ?: $created_at;
+$order_number = $statement_order->get_order_number();
+$order_status = $statement_order->get_status();
+$status_label = function_exists('wc_get_order_status_name') ? wc_get_order_status_name($order_status) : ucfirst((string) $order_status);
+$total_paid = function_exists('wc_price') ? wc_price($statement_order->get_total()) : number_format_i18n((float) $statement_order->get_total(), 2);
+$subtotal = function_exists('wc_price') ? wc_price($statement_order->get_subtotal()) : number_format_i18n((float) $statement_order->get_subtotal(), 2);
+$payment_method = $statement_order->get_payment_method_title() ?: $statement_order->get_payment_method();
+$payment_method = $payment_method ?: __('Não informado', 'juntaplay');
+$updated_at_display = $format_datetime($updated_at);
+$created_at_display = $format_datetime($created_at);
+$balance_display = function_exists('wc_price') ? wc_price($statement_balance) : number_format_i18n($statement_balance, 2);
+$campaigns_id = (int) get_option('juntaplay_page_campanhas');
+$campaigns_link = $campaigns_id ? get_permalink($campaigns_id) : home_url('/');
+
+$status_labels = [
+    'available' => __('Disponível', 'juntaplay'),
+    'reserved'  => __('Reservada', 'juntaplay'),
+    'paid'      => __('Paga', 'juntaplay'),
+    'canceled'  => __('Cancelada', 'juntaplay'),
+    'expired'   => __('Expirada', 'juntaplay'),
+];
+
+$orders_url = wc_get_endpoint_url('orders', '', wc_get_page_permalink('myaccount'));
+?>
+<section class="juntaplay-statement juntaplay-section" aria-labelledby="juntaplay-statement-title">
+    <header class="juntaplay-statement__header">
+        <div>
+            <p class="juntaplay-statement__eyebrow"><?php esc_html_e('Extrato', 'juntaplay'); ?></p>
+            <h1 id="juntaplay-statement-title">#<?php echo esc_html((string) $order_number); ?></h1>
+        </div>
+        <div class="juntaplay-statement__header-meta">
+            <?php if ($created_at_display) : ?>
+                <span><?php echo esc_html(sprintf(__('Criado em %s', 'juntaplay'), $created_at_display)); ?></span>
+            <?php endif; ?>
+            <?php if ($updated_at_display && $updated_at_display !== $created_at_display) : ?>
+                <span><?php echo esc_html(sprintf(__('Atualizado em %s', 'juntaplay'), $updated_at_display)); ?></span>
+            <?php endif; ?>
+        </div>
+    </header>
+
+    <div class="juntaplay-statement__grid">
+        <article class="juntaplay-card juntaplay-card--highlight juntaplay-statement__card" aria-labelledby="juntaplay-statement-info">
+            <header class="juntaplay-card__header">
+                <h2 id="juntaplay-statement-info"><?php esc_html_e('Informações do pedido', 'juntaplay'); ?></h2>
+                <span class="juntaplay-status juntaplay-status--<?php echo esc_attr(sanitize_html_class((string) $order_status)); ?>"><?php echo esc_html($status_label); ?></span>
+            </header>
+            <div class="juntaplay-card__body">
+                <ul class="juntaplay-statement__list">
+                    <li>
+                        <span class="juntaplay-statement__label"><?php esc_html_e('Método de pagamento', 'juntaplay'); ?></span>
+                        <span class="juntaplay-statement__value"><?php echo esc_html($payment_method); ?></span>
+                    </li>
+                    <li>
+                        <span class="juntaplay-statement__label"><?php esc_html_e('Subtotal', 'juntaplay'); ?></span>
+                        <span class="juntaplay-statement__value"><?php echo wp_kses_post($subtotal); ?></span>
+                    </li>
+                    <li>
+                        <span class="juntaplay-statement__label"><?php esc_html_e('Total pago', 'juntaplay'); ?></span>
+                        <span class="juntaplay-statement__value juntaplay-statement__value--total"><?php echo wp_kses_post($total_paid); ?></span>
+                    </li>
+                    <li>
+                        <span class="juntaplay-statement__label"><?php esc_html_e('Saldo disponível', 'juntaplay'); ?></span>
+                        <span class="juntaplay-statement__value"><?php echo wp_kses_post($balance_display); ?></span>
+                    </li>
+                </ul>
+            </div>
+            <footer class="juntaplay-card__footer">
+                <a class="juntaplay-button juntaplay-button--primary" href="<?php echo esc_url($campaigns_link); ?>">
+                    <?php esc_html_e('Comprar cotas', 'juntaplay'); ?>
+                </a>
+                <a class="juntaplay-button" href="<?php echo esc_url($orders_url); ?>">
+                    <?php esc_html_e('Voltar para pedidos', 'juntaplay'); ?>
+                </a>
+            </footer>
+        </article>
+
+        <div class="juntaplay-statement__details">
+            <?php foreach ($statement_items as $item) :
+                $item_numbers = $item['numbers'];
+                $item_total_display = function_exists('wc_price') ? wc_price($item['line_total']) : number_format_i18n((float) $item['line_total'], 2);
+                $pool_link = $item['link'];
+                ?>
+                <article class="juntaplay-card juntaplay-card--compact">
+                    <header class="juntaplay-card__header">
+                        <div>
+                            <h3>
+                                <?php if ($pool_link) : ?>
+                                    <a class="juntaplay-link" href="<?php echo esc_url($pool_link); ?>"><?php echo esc_html($item['title']); ?></a>
+                                <?php else : ?>
+                                    <?php echo esc_html($item['title']); ?>
+                                <?php endif; ?>
+                            </h3>
+                            <p class="juntaplay-card__meta"><?php echo esc_html(sprintf(_n('%s cota selecionada', '%s cotas selecionadas', count($item_numbers), 'juntaplay'), number_format_i18n(count($item_numbers)))); ?></p>
+                        </div>
+                        <div class="juntaplay-card__price">
+                            <?php echo wp_kses_post($item_total_display); ?>
+                        </div>
+                    </header>
+                    <div class="juntaplay-card__body">
+                        <div class="juntaplay-statement__numbers" aria-label="<?php esc_attr_e('Cotas adquiridas', 'juntaplay'); ?>">
+                            <?php foreach ($item_numbers as $number) :
+                                $status_key = $item['statuses'][$number] ?? '';
+                                $status_label_quota = $status_key && isset($status_labels[$status_key]) ? $status_labels[$status_key] : ($status_key ? ucfirst($status_key) : __('N/A', 'juntaplay'));
+                                ?>
+                                <span class="juntaplay-bubble">
+                                    <strong><?php echo esc_html(number_format_i18n($number)); ?></strong>
+                                    <?php if ($status_key) : ?>
+                                        <small class="juntaplay-status juntaplay-status--<?php echo esc_attr(sanitize_html_class($status_key)); ?>"><?php echo esc_html($status_label_quota); ?></small>
+                                    <?php endif; ?>
+                                </span>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</section>

--- a/juntaplay/templates/terms.php
+++ b/juntaplay/templates/terms.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+?>
+<section class="juntaplay-terms">
+    <h2><?php esc_html_e('Termos e Condições', 'juntaplay'); ?></h2>
+    <p><?php esc_html_e('Adicione aqui seus termos, condições e regras de participação nas campanhas.', 'juntaplay'); ?></p>
+</section>

--- a/juntaplay/uninstall.php
+++ b/juntaplay/uninstall.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+defined('WP_UNINSTALL_PLUGIN') || exit;
+
+// Mantemos dados por padrão. Remova opções se necessário.


### PR DESCRIPTION
## Summary
- replace the bundled group cover artwork with an inline SVG placeholder shared across front-end and data layers
- require creators to supply a 495x370 cover, styling dashboards and cards to fit the new format while falling back to the placeholder
- teach the demo data seeder to generate a PNG cover at runtime so sample groups remain editable without storing binaries

## Testing
- find . -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68e04f2f04d8832b9f5b50962925895f