### PR TITLE
Fix stepper image paths to resolve from active theme directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,283 @@
+# RMA ONGs Platform (subdomínio `https://ongs.`)
+
+Este repositório contém um **MVP modular** para o ecossistema de ONGs da RMA em WordPress, seguindo a estratégia por domínio (plugins desacoplados por hooks/meta/REST).
+
+## Módulos implementados
+
+- `rma-core-entities`
+  - CPT `rma_entidade`
+  - Metadados padronizados (CNPJ, contato, endereço, status de governança e financeiro)
+  - Endpoint para validação/autopreenchimento de CNPJ (`/wp-json/rma/v1/cnpj/{cnpj}`) com cache de validação oficial
+  - Tratamento explícito de falha na consulta oficial de CNPJ com resposta `503` quando o serviço externo está indisponível
+  - Erros `429/5xx` do provedor oficial são tratados como indisponibilidade temporária (não como CNPJ inexistente)
+  - Endpoint de cadastro de entidade com consentimento LGPD (`/wp-json/rma/v1/entities`)
+  - Criação de entidade aceita payload JSON e fallback para parâmetros de request quando JSON não estiver presente
+  - Consentimento LGPD validado de forma estrita (`rest_sanitize_boolean`)
+  - Endpoint de criação reforça autenticação no handler (`401`) como defesa em profundidade
+  - Endpoint de status da entidade para painel/checklist (`/wp-json/rma/v1/entities/{id}/status`) com `pending_items`, `next_actions`, `documents_count`, `cnpj_validated_at`, `approvals_remaining` e `publish_eligible`
+  - Endpoints de documentos privados por entidade (`GET/POST/DELETE /wp-json/rma/v1/entities/{id}/documents (DELETE em /{doc_id})` e download autenticado)
+  - Endpoints de documentos/status reforçam validação de entidade inválida com `404` (defesa em profundidade)
+  - Limite de 30 documentos por entidade no upload (com resposta `409` quando excedido)
+  - Validação de limite ocorre antes da escrita física do arquivo (evita IO/descarte desnecessário)
+  - Armazenamento privado de PDFs com validação de tipo/tamanho e bloqueio de acesso direto
+  - Verificação adicional de origem do upload (`is_uploaded_file`) antes de mover para área privada
+  - Verificação de legibilidade do temporário antes das validações de MIME/extensão
+  - Nome de arquivo é saneado com fallback seguro (`documento.pdf`) quando vazio
+  - Validação de PDF usa `finfo` com fallback para checagem nativa do WordPress (`wp_check_filetype_and_ext`)
+  - Remoção segura de documentos com validação de propriedade/caminho
+  - Download valida tamanho/legibilidade do arquivo antes de enviar headers para evitar resposta corrompida
+  - Rate-limit por usuário autenticado (ou IP/fallback anônimo) para consulta CNPJ, criação de entidade e upload/download/remoção de documentos
+  - Em documentos, validação de entidade ocorre antes do rate-limit para evitar consumo desnecessário com IDs inválidos
+  - Bloqueio de CNPJ duplicado no cadastro
+  - Validação adicional de CNPJ ativo na criação (consulta oficial)
+  - Enriquecimento automático com dados oficiais (razão social/UF/cidade) e priorização de dados oficiais no cadastro
+
+- `rma-governance`
+  - Workflow de 3 aceites com usuários distintos
+  - Bloqueio de recusa direta para entidade já aprovada (exige novo ciclo)
+  - Reprovação com motivo obrigatório
+  - Comentários/motivos de governança são sanitizados e limitados a 1000 caracteres
+  - Limitação textual compatível com ambientes sem `mbstring` (fallback seguro para `substr`)
+  - Log de auditoria de ações de governança (incluindo IP em rejeição/reenvio), com retenção das 200 entradas mais recentes
+  - Endpoints de governança reforçam validação de autenticação no handler (401 em defesa em profundidade)
+  - Publicação automática após o 3º aceite
+  - Reenvio para análise após recusa via endpoint de governança
+  - Bloqueio de auto-aceite (autor da entidade não pode aprovar a própria submissão)
+  - Bloqueio de novos aceites enquanto a entidade permanecer com status `recusado` (exige reenvio)
+  - Bloqueio de recusa repetida para entidade já `recusado` (mantém fluxo consistente)
+  - Recusa permitida apenas em estados `pendente`/`em_analise`
+  - Compatibilidade com entidades legadas sem `governance_status` (tratadas como `pendente`)
+
+- `rma-maps-directory`
+  - Endpoint público para mapa/diretório (`/wp-json/rma-public/v1/entities`) com paginação (`page`/`per_page`), validação de UF, filtros `area`/`situacao` (`ativa|inadimplente|todas`) e headers `X-WP-Total`/`X-WP-TotalPages`
+  - Endpoint público de perfil (`/wp-json/rma-public/v1/entities/{id}`) para página individual da entidade (dados institucionais + localização + áreas + `profile_url`)
+  - UF também normalizada na resposta pública para consistência do consumidor
+  - Campos textuais públicos (`nome`, `cidade`, `nome_fantasia`, `slug`) são normalizados/sanitizados na resposta
+  - Filtros por UF, área de interesse e busca textual
+  - Termo de busca normalizado (lowercase/trim) para reduzir variação desnecessária de chaves de cache
+  - Regra configurável para exibir apenas adimplentes
+  - Cache com transients e invalidação por índice de chaves (inclui eventos de trash/untrash/delete), com retenção das 500 chaves mais recentes
+  - Invalidação de cache também em criação/remoção de metas relevantes (`added_post_meta`/`deleted_post_meta`)
+  - Índice de chaves atualizado apenas quando há alteração (evita escrita desnecessária em option)
+
+- `rma-woo-sync`
+  - Escuta mudanças de pedido WooCommerce
+  - Atualiza `finance_status` para `adimplente`/`inadimplente`
+  - Endpoint de polling de pagamento para UX de PIX em tempo real (`GET /wp-json/rma/v1/entities/{id}/finance/payment-status`) com `should_redirect` para Minha Conta
+  - Geração automática anual de cobranças via cron (`rma_generate_annual_dues`) para entidades aprovadas, com controle de ciclo por `rma_due_year` e data configurável (`rma_due_day_month`)
+  - Registra histórico anual financeiro (ano com base no pagamento do pedido quando disponível), com retenção das 500 entradas mais recentes
+  - Ano do histórico usa timestamp de pagamento em formato canônico (`Y`) para evitar variações locale-dependentes
+
+- `rma-automations`
+- `rma-admin-settings`
+  - Painel de campos personalizáveis para Superadmin (`RMA Configurações`)
+  - Campos: valor da anuidade, ID produto Woo da anuidade, data de início do ciclo (`dd-mm`), chave PIX institucional, Google Maps API Key, e-mail institucional, URL API de notificações e toggle “somente adimplentes no diretório”
+
+  - Rotina diária via WP-Cron
+  - Processamento paginado de entidades na automação diária (evita truncar execuções com base >500 registros)
+  - Alertas de mandato (60/30/7 dias) para entidades aprovadas
+  - Alertas de anuidade pendente (com janela de vencimento quando `anuidade_vencimento` existir)
+  - Log de envios por entidade, com retenção das 200 entradas mais recentes
+  - Evita disparos duplicados no mesmo dia/contexto
+
+- `rma-analytics`
+  - Endpoint de resumo administrativo (inclui `faturamento_total`, `faturamento_pago`, `ticket_medio_pago`, `inadimplencia_percentual`, `adimplencia_percentual` e ordenação por UF)
+  - Normalização de UF no resumo (agrega caixa mista/inválida em `N/D` para consistência)
+  - Exportação CSV reutiliza a mesma normalização de UF para manter consistência com o resumo
+  - Endpoint de exportação CSV
+  - Exportação CSV com escaping/quoting consistente de colunas textuais para reduzir ambiguidades de parsing
+  - Exportação CSV usa consulta por IDs (`fields=ids`) para reduzir uso de memória em bases grandes
+  - Consultas de analytics desativam cálculos/caches desnecessários (`no_found_rows` e caches de termo/meta)
+  - Indicador agregado de faturamento por histórico financeiro
+
+- `rma-demo-seeder`
+  - WP-CLI para homologação: `wp rma seed-demo --entities=60 --simulate-emails`, setup incremental via `wp rma setup-next --entities=60 --simulate-emails` e limpeza via `wp rma clear-demo`
+  - Página admin `RMA → Dados Demonstrativos` com botões para gerar/limpar massa de dados demo
+  - Gera entidades demo (`rma_is_demo=1`), aprovações, pedidos Woo, documentos dummy, logs de e-mail e validações de consistência (inclui contagem por UF e matriz de segurança por autor)
+
+## Como instalar
+
+1. Copie os diretórios de `wp-content/plugins/*` para o WordPress do subdomínio.
+2. Ative os plugins na seguinte ordem:
+   1. RMA Core Entities
+   2. RMA Governance
+   3. RMA Maps & Directory
+   4. RMA Woo Sync
+   5. RMA Automations
+   6. RMA Analytics
+   7. RMA Admin Settings
+   8. (Opcional homologação) RMA Demo Seeder
+3. Garanta que WooCommerce + gateway PIX estejam ativos para o fluxo financeiro.
+4. Configure no menu `RMA Configurações` os campos de operação (anuidade, PIX, Google Maps API Key, notificações e motor de e-mail: WordPress ou WooCommerce).
+5. (Opcional financeiro anual) Configure as options `rma_annual_dues_product_id` e `rma_annual_due_value` para geração automática anual de pedidos.
+
+## Pontos para o tema
+
+Como cadastro/login serão gerenciados no tema, o tema deve:
+
+- Consumir `/rma/v1/cnpj/{cnpj}` no passo 1 do wizard.
+- Enviar payload final para `/rma/v1/entities`.
+- Exibir status e pendências lendo os metas da entidade vinculada ao usuário.
+- Acionar endpoints de governança apenas em telas administrativas (RMA).
+
+### Diretriz visual oficial (tema)
+
+Para as telas do tema que consumirem este MVP, seguir o padrão visual abaixo:
+
+- **Fonte principal:** Federo
+- **Cor primária:** `#7bad39`
+- **Cor escura/base (preto):** `#37302c`
+- **Estilo de interface:** glasmorphism branco “ultra” (cartões/containers translúcidos claros, blur de fundo e bordas suaves)
+
+Tokens sugeridos para implementação no tema:
+
+```css
+:root {
+  --rma-font-family: 'Federo', sans-serif;
+  --rma-color-primary: #7bad39;
+  --rma-color-dark: #37302c;
+  --rma-glass-bg: rgba(255, 255, 255, 0.72);
+  --rma-glass-border: rgba(255, 255, 255, 0.58);
+  --rma-glass-shadow: 0 12px 40px rgba(55, 48, 44, 0.18);
+  --rma-glass-blur: blur(18px);
+}
+```
+
+
+Para acelerar a implementação no tema, há um kit inicial em `ui/`:
+
+- `ui/rma-glass-theme.css` (tokens e componentes base, incluindo estado de foco acessível e responsividade)
+- `ui/rma-glass-theme-preview.html` (preview estático com topbar, status chips, KPIs, wizard de cadastro e formulário)
+- `ui/rma-glass-theme-wordpress-snippet.php` (snippet de integração completo: enqueue, shortcodes `[rma_glass_card_demo]` e `[rma_conta_setup]`, redirect para `/conta/` e anti-loop)
+- `ui/rma-glass-theme.js` (comportamento opcional do wizard: avançar/voltar/reiniciar, suporte a múltiplos wizards, sync de etapa atual em `data-rma-current-step` e atalhos ←/→ e ESC no preview)
+- `ui/assets/` com SVGs de apoio visual (`rma-logo-mark.svg`, `rma-map-pin.svg`, `rma-document.svg`) para UI mais profissional
+
+
+Uso rápido no tema (WordPress):
+
+1. Copie `ui/rma-glass-theme.css`, `ui/rma-glass-theme.js` e `ui/rma-glass-theme-wordpress-snippet.php` para dentro do tema (ex.: `wp-content/themes/seu-tema/ui/`).
+2. **Atualize o `functions.php`** para carregar o snippet (sem isso, o formulário não muda):
+
+   ```php
+   require_once get_stylesheet_directory() . '/ui/rma-glass-theme-wordpress-snippet.php';
+   ```
+
+   Alternativa (mais segura): copie também `ui/rma-functions-loader.php` e use:
+
+   ```php
+   require_once get_stylesheet_directory() . '/ui/rma-functions-loader.php';
+   ```
+
+3. Crie a página `/conta/` com shortcode `[rma_conta_setup]` para onboarding da entidade (CNPJ + criação via REST).
+4. Após criar a entidade, a própria página `/conta/` vira hub de fluxo com links de Status, Documentos e Financeiro; enquanto as etapas não forem concluídas, o usuário permanece no fluxo e qualquer tentativa de abrir outras rotas (incluindo `/dashboard/`) volta para `/conta/`.
+5. Para validar rapidamente o visual, use `[rma_glass_card_demo]` em uma página de teste.
+- O bloco `/conta/` inclui checklist de documentos obrigatórios com tooltips orientativos e upload de PDFs por item (pré-seleção no cadastro e envio direto no passo de documentos).
+
+Debug de fluxo (quando ainda redirecionar para dashboard):
+
+- Ative `WP_DEBUG` no `wp-config.php`.
+- Acesse a URL com `?rma_debug_flow=1` (ex.: `/rma/conta/?rma_debug_flow=1`).
+- O snippet registra no `error_log` eventos com prefixo `[RMA_FLOW]` explicando por que permitiu/negou rota e quando redirecionou para `/conta/`.
+
+Checklist visual (100%):
+
+- [x] Fonte Federo aplicada
+- [x] Cor primária `#7bad39` em ações/destaques
+- [x] Cor base `#37302c` para leitura principal
+- [x] Cartões glasmorphism branco ultra com blur e sombra
+- [x] Componentes responsivos (desktop/mobile)
+- [x] Foco acessível em campos e botões
+- [x] Exemplo de wizard de 5 etapas com estados (done/current/pending)
+- [x] Navegação do wizard por botões e teclado (setas ←/→ + ESC para reiniciar), com `aria-keyshortcuts` no preview
+
+Exemplo de container visual:
+
+```css
+.rma-glass-card {
+  font-family: var(--rma-font-family);
+  background: var(--rma-glass-bg);
+  border: 1px solid var(--rma-glass-border);
+  backdrop-filter: var(--rma-glass-blur);
+  -webkit-backdrop-filter: var(--rma-glass-blur);
+  box-shadow: var(--rma-glass-shadow);
+  border-radius: 20px;
+  color: var(--rma-color-dark);
+}
+
+.rma-glass-card .rma-accent {
+  color: var(--rma-color-primary);
+}
+```
+
+## Próximos passos recomendados
+
+1. Criar UI do wizard (5 passos) no tema com nonces e mensagens de erro/pendência.
+2. Implementar gestão de documentos privados com endpoint autenticado (download controlado).
+3. Adicionar geocoding automático em criação/edição de endereço.
+4. Criar tela administrativa de governança com trilha de auditoria visual.
+5. Integrar geração de pedido da anuidade por ano no painel da entidade.
+6. Adicionar testes automatizados (WP-CLI + integração REST).
+
+
+## Validação local
+
+- `find wp-content -name '*.php' -print0 | xargs -0 -n1 php -l`
+
+
+
+## Checklist de homologação (meta 100%)
+
+Use este roteiro para validar o MVP no WordPress de ponta a ponta.
+
+1. **Setup de ambiente**
+   - Ativar plugins na ordem recomendada.
+   - Garantir WooCommerce + gateway PIX + método de envio de e-mail funcionando.
+   - Configurar `RMA Configurações` (anuidade, ciclo, PIX, API Maps e motor de e-mail).
+
+2. **Massa de dados**
+   - Gerar base demo: `wp rma seed-demo --entities=60 --simulate-emails`
+   - (Opcional incremental): `wp rma setup-next --entities=60 --simulate-emails`
+
+3. **REST (core + diretório)**
+   - Validar CNPJ: `GET /wp-json/rma/v1/cnpj/{cnpj}`
+   - Cadastrar entidade: `POST /wp-json/rma/v1/entities`
+   - Listar diretório público: `GET /wp-json/rma-public/v1/entities?page=1&per_page=20`
+   - Validar perfil público: `GET /wp-json/rma-public/v1/entities/{id}`
+
+4. **Governança**
+   - Executar fluxo de 3 aprovações com usuários distintos.
+   - Validar recusa com motivo e reenvio para nova análise.
+
+5. **Financeiro (Woo + PIX)**
+   - Confirmar mudança de `finance_status` por alteração de status do pedido Woo.
+   - Testar polling de pagamento: `GET /wp-json/rma/v1/entities/{id}/finance/payment-status`.
+   - Rodar ciclo anual manualmente: `wp cron event run rma_generate_annual_dues`.
+
+6. **Automações/e-mail**
+   - Rodar automação manual: `wp cron event run rma_daily_automation`.
+   - Testar em `RMA Configurações` os 2 motores de e-mail:
+     - `WordPress padrão (wp_mail)`
+     - `WooCommerce (layout/template de e-mail)`
+
+7. **Analytics/CSV**
+   - Conferir resumo administrativo.
+   - Exportar CSV e validar colunas, escaping e consistência dos números.
+
+8. **Limpeza de homologação**
+   - Limpar massa demo: `wp rma clear-demo`
+
+Critério de aceite para 100%: todos os itens acima executados sem erro funcional e com evidência (print/log/comando) por etapa.
+
+## Dados demonstrativos (homologação)
+
+1. Ative o plugin **RMA Demo Seeder**.
+2. Gere dados demo via WP-CLI:
+   - `wp rma seed-demo --entities=60 --simulate-emails`
+3. Ou via Admin: `RMA → Dados Demonstrativos` (com botão **Avançar setup demo** para instalar os demos em etapas).
+4. Para limpar somente massa demo:
+   - `wp rma clear-demo`
+
+Observações:
+- Dados demo são marcados com meta `rma_is_demo=1`.
+- Limpeza remove entidades demo, pedidos Woo demo, anexos demo e logs demo auxiliares.
+- Usuários demo criados: `admin_rma_demo`, `aprovador_demo`, `entidade_demo_a` e `entidade_demo_b`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Este repositório contém um **MVP modular** para o ecossistema de ONGs da RMA e
   - Bloqueio de recusa repetida para entidade já `recusado` (mantém fluxo consistente)
   - Recusa permitida apenas em estados `pendente`/`em_analise`
   - Compatibilidade com entidades legadas sem `governance_status` (tratadas como `pendente`)
+  - Tela administrativa de governança (`Entidades → Governança`) com status, contagem de aceites/documentos e último evento de auditoria
 
 - `rma-maps-directory`
   - Endpoint público para mapa/diretório (`/wp-json/rma-public/v1/entities`) com paginação (`page`/`per_page`), validação de UF, filtros `area`/`situacao` (`ativa|inadimplente|todas`) e headers `X-WP-Total`/`X-WP-TotalPages`
@@ -214,9 +215,8 @@ Exemplo de container visual:
 1. Criar UI do wizard (5 passos) no tema com nonces e mensagens de erro/pendência.
 2. Implementar gestão de documentos privados com endpoint autenticado (download controlado).
 3. Adicionar geocoding automático em criação/edição de endereço.
-4. Criar tela administrativa de governança com trilha de auditoria visual.
-5. Integrar geração de pedido da anuidade por ano no painel da entidade.
-6. Adicionar testes automatizados (WP-CLI + integração REST).
+4. Integrar geração de pedido da anuidade por ano no painel da entidade.
+5. Adicionar testes automatizados (WP-CLI + integração REST).
 
 
 ## Validação local

--- a/ui/assets/rma-approval.svg
+++ b/ui/assets/rma-approval.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="8" stroke="#7bad39" stroke-width="1.6"/>
+  <path d="M8.5 12.5L11 15L15.5 10.5" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ui/assets/rma-document.svg
+++ b/ui/assets/rma-document.svg
@@ -1,0 +1,6 @@
+<svg width="42" height="48" viewBox="0 0 42 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Documento RMA">
+  <rect x="5" y="2" width="32" height="44" rx="8" fill="white" stroke="#7bad39" stroke-width="2"/>
+  <path d="M12 16H30" stroke="#37302c" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M12 24H30" stroke="#37302c" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M12 32H24" stroke="#37302c" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/ui/assets/rma-logo-mark.svg
+++ b/ui/assets/rma-logo-mark.svg
@@ -1,0 +1,12 @@
+<svg width="180" height="44" viewBox="0 0 180 44" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="RMA ONGs">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7bad39"/>
+      <stop offset="100%" stop-color="#5f8f2b"/>
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="42" height="42" rx="12" fill="url(#g)"/>
+  <path d="M12 28L17.5 16L23 28L28.5 16L34 28" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="54" y="20" fill="#37302c" font-size="16" font-family="Federo, Arial, sans-serif">RMA ONGs</text>
+  <text x="54" y="34" fill="#7bad39" font-size="11" font-family="Federo, Arial, sans-serif">Rede da Mata Atlântica</text>
+</svg>

--- a/ui/assets/rma-map-pin.svg
+++ b/ui/assets/rma-map-pin.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="48" viewBox="0 0 36 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Pin RMA">
+  <path d="M18 46C18 46 33 31.5 33 19C33 10.7 26.3 4 18 4C9.7 4 3 10.7 3 19C3 31.5 18 46 18 46Z" fill="#7bad39"/>
+  <circle cx="18" cy="19" r="7" fill="white"/>
+  <circle cx="18" cy="19" r="3.5" fill="#37302c"/>
+</svg>

--- a/ui/assets/rma-payment.svg
+++ b/ui/assets/rma-payment.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="6" width="18" height="12" rx="3" stroke="#7bad39" stroke-width="1.6"/>
+  <path d="M3 10H21" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M7 14H11" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/ui/assets/rma-security.svg
+++ b/ui/assets/rma-security.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 3L5 6V11C5 15.4 8 19.5 12 21C16 19.5 19 15.4 19 11V6L12 3Z" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M9.5 11.5L11.2 13.2L14.7 9.7" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ui/assets/rma-verification.svg
+++ b/ui/assets/rma-verification.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="16" height="16" rx="4" stroke="#7bad39" stroke-width="1.6"/>
+  <path d="M8 12L11 15L16 9" stroke="#7bad39" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ui/rma-functions-loader.php
+++ b/ui/rma-functions-loader.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Loader mínimo para colar no functions.php do tema.
+ *
+ * Uso recomendado:
+ * 1) Copie este arquivo e o rma-glass-theme-wordpress-snippet.php para /wp-content/themes/seu-tema/ui/
+ * 2) No functions.php do tema, adicione:
+ *
+ *    require_once get_stylesheet_directory() . '/ui/rma-functions-loader.php';
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('rma_load_theme_onboarding_snippet')) {
+    function rma_load_theme_onboarding_snippet() {
+        $candidates = [
+            trailingslashit(get_stylesheet_directory()) . 'ui/rma-glass-theme-wordpress-snippet.php',
+            trailingslashit(get_template_directory()) . 'ui/rma-glass-theme-wordpress-snippet.php',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                require_once $candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+add_action('after_setup_theme', function () {
+    $loaded = rma_load_theme_onboarding_snippet();
+
+    if (! $loaded && is_admin()) {
+        add_action('admin_notices', function () {
+            echo '<div class="notice notice-error"><p><strong>RMA:</strong> arquivo <code>ui/rma-glass-theme-wordpress-snippet.php</code> não encontrado no tema.</p></div>';
+        });
+    }
+}, 1);

--- a/ui/rma-glass-theme-preview.html
+++ b/ui/rma-glass-theme-preview.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RMA Visual Preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="./rma-glass-theme.css" />
+  </head>
+  <body class="rma-glass-page">
+    <main class="rma-glass-shell">
+      <section class="rma-glass-card rma-topbar">
+        <div class="rma-brand-wrap"><img class="rma-brand-logo" src="./assets/rma-logo-mark.svg" alt="RMA ONGs" /><div class="rma-brand"><strong>Onboarding</strong> • SaaS Premium</div></div>
+        <span class="rma-badge">RMA • Fluxo Seguro</span>
+      </section>
+
+      <section class="rma-glass-card" style="max-width:900px;margin:0 auto;">
+        <h2 class="rma-glass-title">Central de Ativação RMA</h2>
+        <p class="rma-glass-subtitle">Finalize as etapas pendentes para liberar seu ambiente exclusivo na plataforma RMA.</p>
+
+        <div style="border:1px solid #edf1f4;border-radius:18px;padding:22px;max-width:640px;margin:24px auto 10px;">
+          <h3 style="margin:0 0 8px;color:#1f2937;font-weight:700;text-align:center;">Confirmação de Identidade</h3>
+          <p style="margin:0 0 14px;color:#4b5563;text-align:center;">Para sua segurança, valide o código enviado ao seu email institucional.</p>
+
+          <div style="display:grid;grid-template-columns:repeat(6,minmax(0,52px));gap:10px;justify-content:center;max-width:370px;margin:0 auto;">
+            <input class="rma-input" maxlength="1" />
+            <input class="rma-input" maxlength="1" />
+            <input class="rma-input" maxlength="1" />
+            <input class="rma-input" maxlength="1" />
+            <input class="rma-input" maxlength="1" />
+            <input class="rma-input" maxlength="1" />
+          </div>
+
+          <div style="display:flex;justify-content:space-between;gap:10px;margin-top:14px;">
+            <button class="rma-button rma-button--ghost" id="btnVoltar">Voltar</button>
+            <button class="rma-button">Validar Código</button>
+          </div>
+
+          <a href="#" style="display:inline-block;margin-top:10px;color:#4b5563;text-decoration:none;">Reenviar código em 60s</a>
+        </div>
+      </section>
+    </main>
+    <script src="./rma-glass-theme.js"></script>
+  </body>
+</html>

--- a/ui/rma-glass-theme-wordpress-snippet.php
+++ b/ui/rma-glass-theme-wordpress-snippet.php
@@ -1,0 +1,1480 @@
+<?php
+/**
+ * Functions/snippet completo do fluxo RMA para colar no functions.php.
+ *
+ * O que entrega:
+ * - Enqueue do UI kit + fonte Federo
+ * - Shortcode [rma_glass_card_demo]
+ * - Shortcode [rma_conta_setup] com formulário atualizado (novos inputs)
+ * - Checklist de documentos (PDF, imagem ou Word) com tooltip + upload
+ * - Redirect forçado para /conta/ até concluir governança + docs + financeiro
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+function rma_ui_theme_base() {
+    $child_path = trailingslashit(get_stylesheet_directory()) . 'ui';
+    if (is_dir($child_path)) {
+        return [
+            'uri'  => trailingslashit(get_stylesheet_directory_uri()) . 'ui',
+            'path' => $child_path,
+        ];
+    }
+
+    $parent_path = trailingslashit(get_template_directory()) . 'ui';
+    if (is_dir($parent_path)) {
+        return [
+            'uri'  => trailingslashit(get_template_directory_uri()) . 'ui',
+            'path' => $parent_path,
+        ];
+    }
+
+    return null;
+}
+
+function rma_account_setup_url() {
+    return trailingslashit(home_url('/conta/'));
+}
+
+function rma_account_setup_path() {
+    $path = wp_parse_url(rma_account_setup_url(), PHP_URL_PATH);
+    return is_string($path) ? untrailingslashit($path) : '';
+}
+
+
+function rma_theme_image_uri($filename) {
+    $filename = ltrim((string) $filename, '/');
+    return trailingslashit(get_template_directory_uri()) . 'images/' . $filename;
+}
+
+function rma_get_entity_id_by_author($user_id) {
+    $query = new WP_Query([
+        'post_type'              => 'rma_entidade',
+        'post_status'            => ['publish', 'draft', 'pending', 'private'],
+        'author'                 => (int) $user_id,
+        'posts_per_page'         => 1,
+        'fields'                 => 'ids',
+        'no_found_rows'          => true,
+        'update_post_meta_cache' => false,
+        'update_post_term_cache' => false,
+    ]);
+
+    $entity_id = ! empty($query->posts) ? (int) $query->posts[0] : 0;
+    wp_reset_postdata();
+
+    return $entity_id;
+}
+
+function rma_flow_debug_enabled() {
+    return defined('WP_DEBUG') && WP_DEBUG && isset($_GET['rma_debug_flow']) && sanitize_text_field((string) $_GET['rma_debug_flow']) === '1';
+}
+
+function rma_flow_debug_log($message, array $context = []) {
+    if (! rma_flow_debug_enabled()) {
+        return;
+    }
+
+    if (! empty($context)) {
+        $message .= ' | ' . wp_json_encode($context);
+    }
+
+    error_log('[RMA_FLOW] ' . $message);
+}
+
+
+function rma_session_bootstrap(): void {
+    if (headers_sent()) {
+        return;
+    }
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+}
+add_action('init', 'rma_session_bootstrap', 1);
+
+function rma_mark_2fa_verified(int $user_id): void {
+    rma_session_bootstrap();
+    $_SESSION['rma_2fa_verified'] = true;
+    $_SESSION['rma_2fa_verified_expires_at'] = time() + (30 * MINUTE_IN_SECONDS);
+    update_user_meta($user_id, 'rma_otp_verified_at', time());
+}
+
+
+
+function rma_clear_2fa_verification_state(?int $user_id = null): void {
+    rma_session_bootstrap();
+
+    unset($_SESSION['rma_2fa_verified'], $_SESSION['rma_2fa_verified_expires_at']);
+
+    $target_user_id = $user_id ?: get_current_user_id();
+    if ($target_user_id > 0) {
+        delete_user_meta($target_user_id, 'rma_otp_verified_at');
+    }
+}
+
+add_action('wp_logout', function () {
+    $user_id = get_current_user_id();
+    rma_clear_2fa_verification_state($user_id > 0 ? (int) $user_id : null);
+});
+
+add_action('wp_login', function ($user_login, $user) {
+    if ($user instanceof WP_User) {
+        // Garante sessão limpa para novo login e força 2FA por sessão.
+        rma_clear_2fa_verification_state((int) $user->ID);
+    }
+}, 10, 2);
+
+function rma_is_2fa_verified(int $user_id): bool {
+    rma_session_bootstrap();
+
+    if (isset($_SESSION['rma_2fa_verified'], $_SESSION['rma_2fa_verified_expires_at']) && $_SESSION['rma_2fa_verified'] === true) {
+        $expires_at = (int) $_SESSION['rma_2fa_verified_expires_at'];
+        if ($expires_at > time()) {
+            return true;
+        }
+    }
+
+    $verified_at = (int) get_user_meta($user_id, 'rma_otp_verified_at', true);
+    if ($verified_at > 0 && ($verified_at + (30 * MINUTE_IN_SECONDS)) > time()) {
+        $_SESSION['rma_2fa_verified'] = true;
+        $_SESSION['rma_2fa_verified_expires_at'] = $verified_at + (30 * MINUTE_IN_SECONDS);
+        return true;
+    }
+
+    unset($_SESSION['rma_2fa_verified'], $_SESSION['rma_2fa_verified_expires_at']);
+    return false;
+}
+
+
+function rma_otp_transient_key(int $user_id): string {
+    return 'rma_otp_code_' . $user_id;
+}
+
+function rma_otp_send_lock_key(int $user_id): string {
+    return 'rma_otp_send_lock_' . $user_id;
+}
+
+function rma_send_security_email(string $to, string $subject, string $html_message): bool {
+    $headers = ['Content-Type: text/html; charset=UTF-8'];
+    $sender_mode = (string) get_option('rma_email_sender_mode', 'wp_mail');
+
+    if ($sender_mode === 'woo_mail' && function_exists('WC') && WC() && method_exists(WC(), 'mailer')) {
+        $mailer = WC()->mailer();
+        if ($mailer && method_exists($mailer, 'send')) {
+            // Não usar wrap_message para OTP: manter layout custom sem o cabeçalho/container padrão do Woo.
+            return (bool) $mailer->send($to, $subject, $html_message, $headers, []);
+        }
+    }
+
+    return (bool) wp_mail($to, $subject, $html_message, $headers);
+}
+
+function rma_send_otp_code_for_user(int $user_id) {
+    $user = get_user_by('id', $user_id);
+    if (! $user || ! $user->user_email) {
+        return new WP_Error('rma_otp_user_invalid', 'Usuário inválido para verificação.');
+    }
+
+    if (get_transient(rma_otp_send_lock_key($user_id))) {
+        return new WP_Error('rma_otp_rate_limited', 'Aguarde alguns segundos antes de solicitar um novo código.');
+    }
+
+    set_transient(rma_otp_send_lock_key($user_id), '1', 30);
+
+    $code = (string) wp_rand(100000, 999999);
+    $payload = [
+        'code' => $code,
+        'expires_at' => time() + (10 * MINUTE_IN_SECONDS),
+        'attempts' => 0,
+    ];
+    set_transient(rma_otp_transient_key($user_id), $payload, 10 * MINUTE_IN_SECONDS);
+
+    $subject = 'Código de verificação de segurança - RMA';
+    $message = function_exists('rma_render_verification_email_template')
+        ? rma_render_verification_email_template([
+            'nome' => (string) $user->display_name,
+            'codigo' => $code,
+            'data' => wp_date('d/m/Y H:i'),
+            'empresa' => (string) get_option('rma_email_verification_company', 'RMA'),
+        ])
+        : ('Seu código de verificação é: ' . $code);
+
+    $sent = rma_send_security_email((string) $user->user_email, $subject, (string) $message);
+
+    if (! $sent) {
+        delete_transient(rma_otp_transient_key($user_id));
+        return new WP_Error('rma_otp_send_failed', 'Não foi possível enviar o código no momento. Tente novamente ou verifique sua caixa de spam.');
+    }
+
+    return true;
+}
+
+add_action('rest_api_init', function () {
+    register_rest_route('rma/v1', '/otp/send', [
+        'methods' => 'POST',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        },
+        'callback' => function () {
+            $result = rma_send_otp_code_for_user(get_current_user_id());
+            if (is_wp_error($result)) {
+                return new WP_REST_Response(['message' => $result->get_error_message()], 503);
+            }
+            return new WP_REST_Response(['sent' => true, 'message' => 'Código enviado para seu email institucional.']);
+        },
+    ]);
+
+
+    register_rest_route('rma/v1', '/otp/status', [
+        'methods' => 'GET',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        },
+        'callback' => function () {
+            $user_id = get_current_user_id();
+            $is_valid = rma_is_2fa_verified($user_id);
+            $verified_at = (int) get_user_meta($user_id, 'rma_otp_verified_at', true);
+            $valid_until = $verified_at > 0 ? ($verified_at + (30 * MINUTE_IN_SECONDS)) : 0;
+            return new WP_REST_Response([
+                'verified' => $is_valid,
+                'verified_at' => $verified_at,
+                'valid_until' => $valid_until,
+            ]);
+        },
+    ]);
+
+
+
+    // Compat route para evitar 404 em ambientes com JS legado apontando para /onboarding/status.
+    // Evita re-registro quando o plugin rma-core-entities já expõe a mesma rota.
+    $routes = rest_get_server()->get_routes();
+    if (! isset($routes['/rma/v1/onboarding/status'])) {
+        register_rest_route('rma/v1', '/onboarding/status', [
+            'methods' => 'GET',
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+            'callback' => function () {
+                $user_id = get_current_user_id();
+                $entity_id = rma_get_entity_id_by_author($user_id);
+                if ($entity_id <= 0) {
+                    return new WP_REST_Response([
+                        'entity_id' => 0,
+                        'governance_status' => 'pendente',
+                        'finance_status' => 'pendente',
+                        'documentos_status' => 'pendente',
+                        'rejected_document_types' => [],
+                    ]);
+                }
+
+                return new WP_REST_Response([
+                    'entity_id' => $entity_id,
+                    'governance_status' => (string) get_post_meta($entity_id, 'governance_status', true),
+                    'finance_status' => (string) get_post_meta($entity_id, 'finance_status', true),
+                    'documentos_status' => (string) get_post_meta($entity_id, 'documentos_status', true),
+                    'rejected_document_types' => array_values(array_filter(array_map('sanitize_key', (array) get_post_meta($entity_id, 'documentos_reprovados', true)))),
+                ]);
+            },
+        ]);
+    }
+
+    register_rest_route('rma/v1', '/otp/verify', [
+        'methods' => 'POST',
+        'permission_callback' => function () {
+            return is_user_logged_in();
+        },
+        'callback' => function (WP_REST_Request $request) {
+            $user_id = get_current_user_id();
+            $code = preg_replace('/\D+/', '', (string) $request->get_param('code'));
+
+            $payload = get_transient(rma_otp_transient_key($user_id));
+            if (! is_array($payload) || empty($payload['code'])) {
+                return new WP_REST_Response(['verified' => false, 'message' => 'Código expirado. Solicite um novo envio.'], 410);
+            }
+
+            $attempts = (int) ($payload['attempts'] ?? 0) + 1;
+            $payload['attempts'] = $attempts;
+            set_transient(rma_otp_transient_key($user_id), $payload, max(30, ((int) ($payload['expires_at'] ?? time())) - time()));
+
+            if ($attempts > 5) {
+                delete_transient(rma_otp_transient_key($user_id));
+                return new WP_REST_Response(['verified' => false, 'message' => 'Muitas tentativas inválidas. Solicite novo código.'], 429);
+            }
+
+            if ((int) ($payload['expires_at'] ?? 0) < time()) {
+                delete_transient(rma_otp_transient_key($user_id));
+                return new WP_REST_Response(['verified' => false, 'message' => 'Código expirado. Solicite novo envio.'], 410);
+            }
+
+            if (! hash_equals((string) $payload['code'], (string) $code)) {
+                return new WP_REST_Response(['verified' => false, 'message' => 'Código inválido. Digite os 6 dígitos enviados por email.'], 422);
+            }
+
+            rma_mark_2fa_verified($user_id);
+            delete_transient(rma_otp_transient_key($user_id));
+
+            return new WP_REST_Response(['verified' => true, 'message' => 'Verificação confirmada.']);
+        },
+    ]);
+});
+
+add_action('wp_enqueue_scripts', function () {
+    $base = rma_ui_theme_base();
+    if (! $base) {
+        return;
+    }
+
+    $css_file = trailingslashit($base['path']) . 'rma-glass-theme.css';
+    $js_file  = trailingslashit($base['path']) . 'rma-glass-theme.js';
+
+    if (file_exists($css_file)) {
+        wp_enqueue_style('rma-glass-theme', trailingslashit($base['uri']) . 'rma-glass-theme.css', [], (string) filemtime($css_file));
+    }
+
+    if (file_exists($js_file)) {
+        wp_enqueue_script('rma-glass-theme-js', trailingslashit($base['uri']) . 'rma-glass-theme.js', [], (string) filemtime($js_file), true);
+    }
+
+    wp_enqueue_style('rma-federo-font', 'https://fonts.googleapis.com/css2?family=Federo&display=swap', [], null);
+    wp_enqueue_style('rma-mavenpro-font', 'https://fonts.googleapis.com/css2?family=Maven+Pro:wght@400;500;600;700&display=swap', [], null);
+});
+
+add_shortcode('rma_glass_card_demo', function () {
+    ob_start();
+    ?>
+    <section class="rma-glass-card" style="margin:20px 0;">
+        <span class="rma-badge">RMA • Glasmorphism Ultra White</span>
+        <h2 class="rma-glass-title">Card de demonstração</h2>
+        <p class="rma-glass-subtitle">Este bloco usa Federo, #7bad39 e #37302c com acabamento translúcido branco.</p>
+        <div class="rma-actions">
+            <a class="rma-button" href="<?php echo esc_url(rma_account_setup_url()); ?>">Ir para conta</a>
+        </div>
+    </section>
+    <?php
+    return (string) ob_get_clean();
+});
+
+add_shortcode('rma_conta_setup', function () {
+    if (! is_user_logged_in()) {
+        return '<p>Você precisa estar logado para completar o cadastro da entidade.</p>';
+    }
+
+    $required_docs = [
+        'ficha_inscricao' => ['label' => 'Ficha de inscrição cadastral', 'tip' => 'Ficha preenchida e assinada. Assinatura gov.br é aceita.'],
+        'comprovante_cnpj' => ['label' => 'Comprovante de CNPJ', 'tip' => 'Comprovante de Inscrição e Situação Cadastral (Receita Federal).'],
+        'ata_fundacao' => ['label' => 'Ata de fundação', 'tip' => 'Ata registrada ou PDF escaneado legível.'],
+        'ata_diretoria' => ['label' => 'Ata da diretoria atual', 'tip' => 'Ata da eleição da diretoria atual.'],
+        'estatuto' => ['label' => 'Estatuto e alterações', 'tip' => 'Estatuto e alterações consolidadas.'],
+        'relatorio_atividades' => ['label' => 'Relatório de atividades', 'tip' => 'Últimos 2 anos de atividades.'],
+        'cartas_recomendacao' => ['label' => '2 cartas de recomendação', 'tip' => 'De organizações filiadas à RMA.'],
+    ];
+
+    $current_user_id = get_current_user_id();
+    $entity_id = rma_get_entity_id_by_author($current_user_id);
+    $otp_verified = rma_is_2fa_verified($current_user_id);
+    $rest_base = rest_url('rma/v1');
+    $rest_nonce = wp_create_nonce('wp_rest');
+
+    $dashboard_url = home_url('/dashboard/');
+    $docs_url = apply_filters('rma_docs_page_url', home_url('/documentos/'));
+    $finance_url = apply_filters('rma_finance_page_url', home_url('/financeiro/'));
+    $checkout_url = apply_filters('rma_checkout_url', home_url('/checkout/'));
+    $annual_product_id = (int) get_option('rma_annual_dues_product_id', 0);
+    if ($annual_product_id <= 0) {
+        $annual_product_id = (int) get_option('rma_woo_product_id', 0);
+    }
+    $checkout_payment_url = $annual_product_id > 0
+        ? add_query_arg('add-to-cart', $annual_product_id, $checkout_url)
+        : $checkout_url;
+    $checkout_payment_path = (string) wp_parse_url($checkout_payment_url, PHP_URL_PATH);
+    $checkout_payment_query = (string) wp_parse_url($checkout_payment_url, PHP_URL_QUERY);
+    $checkout_payment_url_attr = $checkout_payment_path . ($checkout_payment_query !== '' ? ('?' . $checkout_payment_query) : '');
+    if ($checkout_payment_url_attr === '') {
+        $checkout_payment_url_attr = $checkout_payment_url;
+    }
+    $layout_tune_css = '<style id="rma-layout-tune">
+'
+        . '.rma-premium-card,.rma-premium-card--setup{max-width:900px;margin:0 auto;border-radius:18px;background:#fff;border:1px solid #edf1f4;box-shadow:0 16px 40px rgba(0,0,0,.05);padding:28px;}
+'
+        . '.rma-premium-form{display:grid;gap:16px;}
+'
+        . '.rma-grid-2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;}
+'
+        . '.rma-grid-3{display:grid;grid-template-columns:1.2fr .6fr .8fr;gap:14px;}
+'
+        . '.rma-field-label{display:block;font-size:.88rem;color:#5a6472;margin:0 0 6px;}
+'
+        . '.rma-auth-card{background:#fff;border:1px solid #edf1f4;border-radius:18px;padding:20px;margin:14px 0 18px;}
+'
+        . '.rma-auth-title{margin:0 0 6px;font-size:1.35rem;font-weight:700;color:#1f2937;text-align:center;}
+'
+        . '.rma-auth-subtitle{margin:0 0 14px;color:#4b5563;font-size:.95rem;text-align:center;}
+'
+        . '.rma-otp-grid{display:grid;grid-template-columns:repeat(6,minmax(0,50px));gap:10px;margin:0 auto 12px;justify-content:center;}
+'
+        . '.rma-otp-input{height:50px;border:1px solid #d7dee7;border-radius:12px;text-align:center;font-size:1.1rem;font-weight:600;outline:none;transition:border-color .2s ease,box-shadow .2s ease;}
+'
+        . '.rma-otp-input:focus{border-color:#7bad39;box-shadow:0 0 0 3px rgba(123,173,57,.16);}
+'
+        . '.rma-otp-input.is-error{border-color:#ef4444;}
+'
+        . '.rma-otp-input.is-success{border-color:#22c55e;}
+'
+        . '.rma-resend-link{color:#4b5563;font-size:.86rem;text-decoration:none;display:inline-block;margin-top:8px;}
+'
+        . '.rma-resend-link[aria-disabled="true"]{pointer-events:none;opacity:.55;}
+'
+        . '.rma-flow-stepper{position:relative;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px;margin:12px 0 14px;--rma-progress:0%;}
+'
+        . '.rma-flow-stepper::before{content:"";position:absolute;left:8%;right:8%;top:24px;height:4px;border-radius:999px;background:#e9eef3;z-index:0;}
+'
+        . '.rma-flow-stepper::after{content:"";position:absolute;left:8%;top:24px;height:4px;border-radius:999px;width:var(--rma-progress);background:linear-gradient(135deg,#7bad39,#5ddabb);z-index:1;transition:width .35s ease;}
+'
+        . '.rma-flow-step{position:relative;z-index:2;background:#fff;border:1px solid #e8edf2;border-radius:12px;padding:10px 14px;box-shadow:0 10px 30px rgba(0,0,0,.06);display:flex;flex-direction:column;align-items:center;gap:8px;text-align:center;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,filter .25s ease;}
+'
+        . '.rma-flow-step:hover{transform:translateY(-2px);box-shadow:0 14px 32px rgba(0,0,0,.1);}
+'
+        . '.rma-flow-step-figure{width:40px;height:40px;border-radius:12px;background:radial-gradient(circle at 30% 25%,rgba(93,218,187,.35),rgba(123,173,57,.14));display:flex;align-items:center;justify-content:center;box-shadow:inset 0 0 0 1px rgba(123,173,57,.2);}
+'
+        . '.rma-flow-step-figure svg,.rma-flow-step-figure img{width:40px;height:40px;display:block;}\n'
+        . '.rma-flow-step-label{font-size:13px;font-weight:500;color:#475569;line-height:1.1;}
+'
+        . '.rma-flow-step-badge{position:absolute;top:6px;right:6px;width:20px;height:20px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.75rem;font-weight:700;background:#e7edf4;color:#90a0b3;}
+'
+        . '.rma-flow-step.is-done{border-color:#bfe3b0;}
+'
+        . '.rma-flow-step.is-done .rma-flow-step-label{color:#2f7d32;}
+'
+        . '.rma-flow-step.is-done .rma-flow-step-badge{background:#2f7d32;color:#fff;}
+'
+        . '.rma-flow-step.is-current{border-color:transparent;background:linear-gradient(#fff,#fff) padding-box,linear-gradient(135deg,#7bad39,#5ddabb) border-box;transform:translateY(-2px);}
+'
+        . '.rma-flow-step.is-current .rma-flow-step-figure{transform:scale(1.06);box-shadow:0 8px 20px rgba(93,218,187,.32), inset 0 0 0 1px rgba(93,218,187,.4);animation:rma-step-float 1.8s ease-in-out infinite;}
+'
+        . '.rma-flow-step.is-current .rma-flow-step-label{color:#0f172a;}
+'
+        . '.rma-flow-step.is-current .rma-flow-step-badge{background:linear-gradient(135deg,#7bad39,#5ddabb);color:#fff;}
+'
+        . '.rma-flow-step.is-locked{background:#f8fafc;border-color:#e5e9ef;filter:saturate(.3);}
+'
+        . '.rma-flow-step.is-locked .rma-flow-step-label{color:#94a3b8;}
+'
+        . '.rma-flow-step.is-locked .rma-flow-step-badge{background:#eef2f7;color:#a9b4c2;}
+'
+        . '@keyframes rma-step-float{0%,100%{transform:translateY(0) scale(1.06);}50%{transform:translateY(-2px) scale(1.06);}}
+'
+        . '.rma-actions{display:flex;justify-content:space-between;align-items:center;margin-top:18px;gap:10px;width:100%;}\n'
+        . '.rma-primary-cta,.rma-nav-actions{display:flex;gap:10px;align-items:center;}\n'
+        . '.rma-primary-cta{margin-left:auto;}\n'
+        . '.rma-primary-cta .btn-rma-primary{margin-left:auto;}\n'
+        . '.rma-auth-actions{display:flex;justify-content:space-between;align-items:center;gap:10px;margin:8px 0 2px;}\n'
+        . '.rma-auth-actions .btn-rma-primary{margin-left:auto;}\n'
+        . '.rma-auth-card{text-align:center;}\n'
+        . '.rma-glass-title{color:#1f2937;font-weight:700;}\n'
+        . '.rma-glass-subtitle{color:#4b5563;}\n'
+        . '.btn-rma-primary{background:linear-gradient(135deg,#7bad39,#5ddabb)!important;border:none!important;color:#fff!important;font-weight:600;padding:12px 24px;border-radius:14px;transition:all .3s ease;box-shadow:0 8px 18px rgba(0,0,0,.08);}
+'
+        . '.btn-rma-primary:hover{transform:translateY(-2px);filter:brightness(1.04);box-shadow:0 12px 24px rgba(0,0,0,.12);}
+'
+        . '.btn-rma-secondary{background:#fff!important;border:1px solid #d7dee7!important;color:#4b5563!important;font-weight:600;padding:12px 20px;border-radius:14px;transition:all .3s ease;}
+'
+        . '.btn-rma-secondary:hover{transform:translateY(-2px);box-shadow:0 8px 16px rgba(0,0,0,.06);}
+'
+        . '.rma-modern-dropzone{border:1px dashed #cfd8e3;border-radius:14px;padding:12px;background:#fbfcfd;}
+'
+        . '.rma-phone-row{display:grid;grid-template-columns:120px 1fr;gap:10px;}\n'
+        . '.rma-drop-item{position:relative;}\n'
+        . '.rma-dropzone{border:1px dashed #cfd8e3;border-radius:12px;padding:12px;background:#fbfcfd;display:flex;flex-direction:column;gap:8px;}\n'
+        . '.rma-dropzone.is-drag{border-color:#7bad39;background:#f4fbef;}\n'
+        . '.rma-file-preview{font-size:.82rem;color:#4b5563;word-break:break-word;}\n'
+        . '@media(max-width:860px){.rma-grid-2,.rma-grid-3{grid-template-columns:1fr;}.rma-flow-stepper{display:flex;overflow-x:auto;padding-bottom:6px;scroll-snap-type:x mandatory;}.rma-flow-step{min-width:132px;scroll-snap-align:start;}.rma-flow-stepper::before,.rma-flow-stepper::after{display:none;}.rma-otp-grid{grid-template-columns:repeat(6,minmax(0,1fr));}}\n'
+        . '@media(max-width:600px){.rma-actions{flex-direction:column;gap:10px;align-items:stretch;}.rma-primary-cta,.rma-nav-actions{width:100%;}.rma-primary-cta .btn-rma-primary,.rma-nav-actions .btn-rma-secondary{width:100%;}.rma-primary-hint,#rma-primary-hint{text-align:left!important;}}\n'
+        . '</style>';
+
+    if ($entity_id > 0) {
+        $governance = (string) get_post_meta($entity_id, 'governance_status', true);
+        $finance = (string) get_post_meta($entity_id, 'finance_status', true);
+        $docs_status = (string) get_post_meta($entity_id, 'documentos_status', true);
+        $all_steps_done = ($governance === 'aprovado' && $finance === 'adimplente' && $docs_status === 'enviado');
+
+        $docs_reupload_statuses = ['rejeitado', 'negado', 'pendente_reenvio', 'correcao', 'reprovado'];
+        $docs_upload_sent = ($docs_status === 'enviado');
+        $show_docs_upload = (! $docs_upload_sent) || in_array($docs_status, $docs_reupload_statuses, true);
+
+        $rejected_document_types = get_post_meta($entity_id, 'documentos_reprovados', true);
+        $rejected_document_types = is_array($rejected_document_types)
+            ? array_values(array_filter(array_map('sanitize_key', $rejected_document_types)))
+            : [];
+
+        $docs_to_render = $required_docs;
+        $docs_approved_statuses = ['aprovado', 'validado', 'aceito'];
+        $docs_approved = in_array($docs_status, $docs_approved_statuses, true);
+        $docs_waiting_approval = ($docs_status === 'enviado' && empty($rejected_document_types));
+
+        if ($show_docs_upload && ! empty($rejected_document_types)) {
+            $docs_to_render = [];
+            foreach ($rejected_document_types as $doc_key) {
+                if (isset($required_docs[$doc_key])) {
+                    $docs_to_render[$doc_key] = $required_docs[$doc_key];
+                }
+            }
+            if (empty($docs_to_render)) {
+                $docs_to_render = $required_docs;
+            }
+        }
+
+        ob_start();
+        ?>
+        <?php echo $layout_tune_css; ?>
+        <section class="rma-glass-card rma-premium-card" style="margin:20px 0;">
+            <h2 class="rma-glass-title">Central de Ativação RMA</h2>
+            <p class="rma-glass-subtitle">Finalize as etapas pendentes para liberar seu ambiente exclusivo na plataforma RMA.</p>
+
+            <section class="rma-auth-card" id="rma-auth-card">
+                <h3 class="rma-auth-title">Confirmação de Identidade</h3>
+                <p class="rma-auth-subtitle">Para sua segurança, valide o código enviado ao seu email institucional.</p>
+                <div class="rma-otp-grid" id="rma-otp-grid">
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="0" />
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="1" />
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="2" />
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="3" />
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="4" />
+                    <input class="rma-otp-input" inputmode="numeric" maxlength="1" data-otp-index="5" />
+                </div>
+                <div class="rma-auth-actions">
+                    <button class="rma-button btn-rma-secondary" type="button" id="btnVoltar">Voltar</button>
+                    <button class="rma-button btn-rma-primary" type="button" id="rma-validate-code">Validar Código</button>
+                </div>
+                <a href="#" class="rma-resend-link" id="rma-resend-code" aria-disabled="true">Reenviar código em <span id="rma-resend-timer">60</span>s</a>
+            </section>
+
+            <div id="rma-onboarding-main" style="display:none;">
+            <div class="rma-flow-stepper" id="rma-flow-stepper">
+                <div class="rma-flow-step is-done" data-step="1">
+                    <span class="rma-flow-step-badge">✓</span>
+                    <div class="rma-flow-step-figure"><img src="<?php echo esc_url(rma_theme_image_uri('verificacao.gif')); ?>" alt="Verificação" loading="lazy" /></div>
+                    <div class="rma-flow-step-label">Verificação</div>
+                </div>
+                <div class="rma-flow-step is-done" data-step="2">
+                    <span class="rma-flow-step-badge">✓</span>
+                    <div class="rma-flow-step-figure"><img src="<?php echo esc_url(rma_theme_image_uri('cadastro.gif')); ?>" alt="Cadastro" loading="lazy" /></div>
+                    <div class="rma-flow-step-label">Cadastro</div>
+                </div>
+                <div class="rma-flow-step is-current" data-step="3">
+                    <span class="rma-flow-step-badge">•</span>
+                    <div class="rma-flow-step-figure"><img src="<?php echo esc_url(rma_theme_image_uri('documentos.gif')); ?>" alt="Documentos" loading="lazy" /></div>
+                    <div class="rma-flow-step-label">Documentos</div>
+                </div>
+                <div class="rma-flow-step is-locked" data-step="4">
+                    <span class="rma-flow-step-badge">○</span>
+                    <div class="rma-flow-step-figure"><img src="<?php echo esc_url(rma_theme_image_uri('validacao.gif')); ?>" alt="Validação" loading="lazy" /></div>
+                    <div class="rma-flow-step-label">Validação</div>
+                </div>
+                <div class="rma-flow-step is-locked" data-step="5">
+                    <span class="rma-flow-step-badge">○</span>
+                    <div class="rma-flow-step-figure"><img src="<?php echo esc_url(rma_theme_image_uri('pagamento.gif')); ?>" alt="Pagamento" loading="lazy" /></div>
+                    <div class="rma-flow-step-label">Pagamento</div>
+                </div>
+            </div>
+
+            <ul style="margin:12px 0 16px 18px;">
+                <li><strong>Governança:</strong> <span id="rma-status-governanca"><?php echo esc_html($governance ?: 'pendente'); ?></span></li>
+                <li><strong>Documentos:</strong> <span id="rma-status-documentos"><?php echo esc_html($docs_status ?: 'pendente'); ?></span></li>
+                <li><strong>Financeiro:</strong> <span id="rma-status-financeiro"><?php echo esc_html($finance ?: 'pendente'); ?></span></li>
+            </ul>
+
+            <div style="margin:0 0 14px;">
+                <h3 class="rma-premium-section-title">Etapa de documentos</h3>
+
+                <?php if ($show_docs_upload) : ?>
+                <?php if (! empty($rejected_document_types)) : ?>
+                    <div class="rma-alert" style="margin:8px 0 10px;">
+                        A Equipe RMA identificou ajustes necessários. Apenas os itens abaixo precisam ser reenviados para continuidade da validação.
+                    </div>
+                <?php endif; ?>
+
+                    <ul class="rma-docs-list rma-modern-dropzone" id="rma-doc-upload-block">
+                        <?php foreach ($docs_to_render as $doc_key => $doc_meta) : ?>
+                            <li>
+                                <label style="display:flex;align-items:center;gap:8px;">
+                                    <span><?php echo esc_html($doc_meta['label']); ?></span>
+                                    <span title="<?php echo esc_attr($doc_meta['tip']); ?>" style="cursor:help;">ⓘ</span>
+                                </label>
+                                <div class="rma-drop-item"><label class="rma-dropzone" for="rma-doc-file-<?php echo esc_attr($doc_key); ?>"><span>Arraste e solte ou selecione arquivo</span><input type="file" id="rma-doc-file-<?php echo esc_attr($doc_key); ?>" data-doc-key="<?php echo esc_attr($doc_key); ?>" class="rma-doc-file" accept="application/pdf,image/*,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" /><small class="rma-file-preview" id="rma-preview-<?php echo esc_attr($doc_key); ?>">Nenhum arquivo selecionado</small></label></div>
+                                <button class="rma-button rma-doc-upload" type="button" data-doc-key="<?php echo esc_attr($doc_key); ?>">Enviar arquivo</button>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php else : ?>
+                    <div class="rma-alert" id="rma-doc-upload-block" style="margin-top:8px;">
+                        Seus documentos foram recebidos e estão em análise pela Equipe RMA.
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <div class="rma-actions">
+                <div class="rma-nav-actions">
+                    <button class="rma-button btn-rma-secondary" type="button" id="rma-back-action">Voltar</button>
+                </div>
+                <div class="rma-primary-cta">
+                    <button class="rma-button btn-rma-primary" type="button" id="btnPagamento" data-checkout-url="<?php echo esc_url($checkout_payment_url_attr); ?>" data-product-id="<?php echo (int) $annual_product_id; ?>" data-rma-pay="1">Avançar para Pagamento</button>
+                </div>
+            </div>
+            <span id="rma-primary-hint" style="display:block;width:100%;text-align:right;font-size:.92rem;color:#6b6b6b;margin-top:6px;"></span>
+
+            <div id="rma-flow-feedback" class="rma-feedback"></div>
+            </div>
+        </section>
+
+        <script>
+        (function () {
+            var entityId = <?php echo (int) $entity_id; ?>;
+            var base = <?php echo wp_json_encode($rest_base); ?>;
+            var nonce = <?php echo wp_json_encode($rest_nonce); ?>;
+            var feedback = document.getElementById('rma-flow-feedback');
+            var primaryAction = document.getElementById('btnPagamento') || document.getElementById('rma-primary-action');
+            var primaryHint = document.getElementById('rma-primary-hint');
+            var checkoutUrl = <?php echo wp_json_encode($checkout_url); ?>;
+            var checkoutPaymentUrl = <?php echo wp_json_encode($checkout_payment_url); ?>;
+            var annualProductId = <?php echo (int) $annual_product_id; ?>;
+            var dashboardUrl = <?php echo wp_json_encode($dashboard_url); ?>;
+            var stepper = document.getElementById('rma-flow-stepper');
+            var backAction = document.getElementById('rma-back-action');
+            var authBackButton = document.getElementById('btnVoltar');
+            var onboardingMain = document.getElementById('rma-onboarding-main');
+            var currentUiStep = 1;
+            var isOtpVerified = <?php echo $otp_verified ? 'true' : 'false'; ?>;
+            var paymentUnlocked = false;
+
+            function revealMainFlow() {
+                var card = document.getElementById('rma-auth-card');
+                if (card) card.style.display = 'none';
+                if (onboardingMain) onboardingMain.style.display = 'block';
+            }
+
+            function sendOtpCode(initial) {
+                return fetch(base + '/otp/send', { method: 'POST', credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } })
+                    .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                    .then(function (result) {
+                        if (!result.ok) {
+                            showFeedback((result.json && result.json.message) ? result.json.message : 'Não foi possível enviar o código no momento. Tente novamente ou verifique sua caixa de spam.', false);
+                            return false;
+                        }
+                        if (!initial) showFeedback('Novo código enviado para seu email.', true);
+                        return true;
+                    })
+                    .catch(function () {
+                        showFeedback('Não foi possível enviar o código no momento. Tente novamente ou verifique sua caixa de spam.', false);
+                        return false;
+                    });
+            }
+
+            function resolveCheckoutPaymentUrl() {
+                var productId = annualProductId > 0 ? annualProductId : 3407;
+                if (productId <= 0) {
+                    return checkoutUrl;
+                }
+                return checkoutUrl + (checkoutUrl.indexOf('?') === -1 ? '?' : '&') + 'add-to-cart=' + productId;
+            }
+
+            function redirectToCheckout() {
+                var paymentUrl = resolveCheckoutPaymentUrl();
+
+                if (!primaryAction) {
+                    window.location.href = paymentUrl;
+                    return;
+                }
+
+                primaryAction.disabled = true;
+                primaryAction.textContent = 'Processando pagamento...';
+                showFeedback('Processando pagamento... redirecionando para checkout.', true);
+                window.location.href = paymentUrl;
+            }
+
+            if (primaryAction && primaryAction.id === 'btnPagamento') {
+                primaryAction.addEventListener('click', function () {
+                    redirectToCheckout();
+                });
+            }
+
+            if (authBackButton) {
+                authBackButton.addEventListener('click', function () {
+                    window.history.back();
+                });
+            }
+
+            function showFeedback(message, ok) {
+                if (!feedback) return;
+                feedback.innerHTML = '<div style="padding:10px;border-radius:10px;background:' + (ok ? '#edf9ec' : '#fdecec') + ';">' + message + '</div>';
+            }
+
+
+            function initDropzones(selector) {
+                document.querySelectorAll(selector).forEach(function (input) {
+                    var zone = input.closest('.rma-dropzone');
+                    if (!zone || zone.getAttribute('data-drop-init') === '1') return;
+                    zone.setAttribute('data-drop-init', '1');
+                    var preview = zone.querySelector('.rma-file-preview');
+                    function update() {
+                        var file = input.files && input.files[0] ? input.files[0] : null;
+                        if (preview) preview.textContent = file ? (file.name + ' • ' + Math.ceil(file.size / 1024) + ' KB') : 'Nenhum arquivo selecionado';
+                    }
+                    input.addEventListener('change', update);
+                    zone.addEventListener('dragover', function (event) { event.preventDefault(); zone.classList.add('is-drag'); });
+                    zone.addEventListener('dragleave', function () { zone.classList.remove('is-drag'); });
+                    zone.addEventListener('drop', function (event) {
+                        event.preventDefault();
+                        zone.classList.remove('is-drag');
+                        if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files[0]) {
+                            input.files = event.dataTransfer.files;
+                            update();
+                        }
+                    });
+                });
+            }
+
+            function applyStepper(currentStep, doneOverrides) {
+                if (!stepper) return;
+                currentUiStep = currentStep;
+                doneOverrides = Array.isArray(doneOverrides) ? doneOverrides : [];
+                var progress = ((Math.max(1, Math.min(5, currentStep)) - 1) / 4) * 84;
+                stepper.style.setProperty('--rma-progress', progress + '%');
+
+                stepper.querySelectorAll('.rma-flow-step').forEach(function (item) {
+                    var n = parseInt(item.getAttribute('data-step') || '0', 10);
+                    var badge = item.querySelector('.rma-flow-step-badge');
+                    item.classList.remove('is-done', 'is-current', 'is-locked');
+                    if (n < currentStep || doneOverrides.indexOf(n) !== -1) {
+                        item.classList.add('is-done');
+                        if (badge) badge.textContent = '✓';
+                    } else if (n === currentStep) {
+                        item.classList.add('is-current');
+                        if (badge) badge.textContent = '•';
+                    } else {
+                        item.classList.add('is-locked');
+                        if (badge) badge.textContent = '○';
+                    }
+                });
+
+                if (backAction) {
+                    backAction.disabled = currentStep <= 1;
+                }
+            }
+
+            function applyPrimaryAction(payload) {
+                if (!primaryAction) return;
+                if (!isOtpVerified) {
+                    primaryAction.disabled = true;
+                    primaryAction.textContent = 'Valide o código para continuar';
+                    primaryAction.removeAttribute('data-rma-pay');
+                    if (primaryHint) primaryHint.textContent = 'Confirme o código enviado para seu email para liberar as próximas etapas.';
+                    return;
+                }
+                var docs = payload.documentos_status || 'pendente';
+                var finance = payload.finance_status || 'pendente';
+                var governance = payload.governance_status || 'pendente';
+                var rejected = Array.isArray(payload.rejected_document_types) ? payload.rejected_document_types : [];
+                var docsApproved = ['aprovado', 'validado', 'aceito'].indexOf(docs) !== -1;
+                var docsWaiting = docs === 'enviado' && rejected.length === 0;
+                var docsNeedUpload = (docs !== 'enviado' && !docsApproved) || rejected.length > 0;
+
+                paymentUnlocked = false;
+                primaryAction.disabled = false;
+                primaryAction.textContent = 'Continuar';
+                primaryAction.removeAttribute('data-rma-pay');
+                primaryAction.onclick = null;
+                if (primaryHint) primaryHint.textContent = '';
+
+                if (docsNeedUpload) {
+                    applyStepper(3);
+                    primaryAction.textContent = 'Reenviar Documentos';
+                    primaryAction.onclick = function () {
+                        var el = document.getElementById('rma-doc-upload-block');
+                        if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'});
+                    };
+                    if (primaryHint) primaryHint.textContent = 'Identificamos ajustes necessários na documentação enviada. Revise as orientações e realize o reenvio para continuidade do processo.';
+                    return;
+                }
+
+                if (docsWaiting && finance === 'adimplente') {
+                    applyStepper(4, [5]);
+                    primaryAction.textContent = 'Aguardando Aprovação da Equipe';
+                    primaryAction.disabled = true;
+                    if (primaryHint) primaryHint.textContent = 'Pagamento confirmado. Sua entidade permanece em validação até o parecer final da equipe.';
+                    return;
+                }
+
+                if (docsWaiting) {
+                    applyStepper(4);
+                    paymentUnlocked = true;
+                    primaryAction.textContent = annualProductId > 0 ? 'Avançar para Pagamento' : 'Ir para Checkout';
+                    primaryAction.setAttribute('data-rma-pay', '1');
+                    primaryAction.setAttribute('data-checkout-url', checkoutPaymentUrl);
+                    primaryAction.onclick = redirectToCheckout;
+                    if (primaryHint) primaryHint.textContent = '';
+                    return;
+                }
+
+                if (docsApproved && finance !== 'adimplente') {
+                    applyStepper(4);
+                    paymentUnlocked = true;
+                    primaryAction.textContent = annualProductId > 0 ? 'Avançar para Pagamento' : 'Ir para Checkout';
+                    primaryAction.id = 'btnPagamento';
+                    primaryAction.setAttribute('data-rma-pay', '1');
+                    primaryAction.setAttribute('data-checkout-url', checkoutPaymentUrl);
+                    primaryAction.onclick = redirectToCheckout;
+                    if (primaryHint) primaryHint.textContent = 'Próxima etapa: concluir pagamento no checkout.';
+                    return;
+                }
+
+                if (docsApproved && finance === 'adimplente' && governance !== 'aprovado') {
+                    applyStepper(4, [5]);
+                    primaryAction.textContent = 'Aguardando Aprovação da Equipe';
+                    primaryAction.disabled = true;
+                    primaryAction.removeAttribute('data-rma-pay');
+                    if (primaryHint) primaryHint.textContent = 'Pagamento confirmado. Sua entidade permanece em validação até o parecer final da equipe.';
+                    return;
+                }
+
+                if (docsApproved && finance === 'adimplente' && governance === 'aprovado') {
+                    applyStepper(5);
+                    primaryAction.textContent = 'Acessar Painel da Entidade';
+                    primaryAction.disabled = false;
+                    primaryAction.onclick = function () { window.location.assign(dashboardUrl); };
+                    if (primaryHint) primaryHint.textContent = 'Tudo concluído. Acesse seu painel para acompanhar os próximos passos.';
+                    return;
+                }
+
+                applyStepper(1);
+                primaryAction.textContent = 'Aguardando Status';
+                primaryAction.disabled = true;
+                if (primaryHint) primaryHint.textContent = 'Acompanhe a etapa de status/governança.';
+            }
+
+            function updateState(payload) {
+                var g = document.getElementById('rma-status-governanca');
+                var d = document.getElementById('rma-status-documentos');
+                var f = document.getElementById('rma-status-financeiro');
+                if (g) g.textContent = payload.governance_status || 'pendente';
+                if (d) d.textContent = payload.documentos_status || 'pendente';
+                if (f) f.textContent = payload.finance_status || 'pendente';
+                applyPrimaryAction(payload || {});
+            }
+
+            function refreshStatus() {
+                fetch(base + '/entities/' + entityId + '/status', {
+                    credentials: 'same-origin',
+                    headers: { 'X-WP-Nonce': nonce }
+                })
+                .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                .then(function (result) {
+                    if (!result.ok) {
+                        showFeedback((result.json && result.json.message) ? result.json.message : 'Falha ao atualizar status automaticamente.', false);
+                        return;
+                    }
+                    updateState(result.json || {});
+                })
+                .catch(function () {
+                    showFeedback('Erro de conexão ao atualizar status automaticamente.', false);
+                });
+            }
+
+            function uploadDoc(docKey, file) {
+                if (!file) {
+                    showFeedback('Selecione um arquivo antes de enviar.', false);
+                    return;
+                }
+
+                var data = new FormData();
+                data.append('document_type', docKey);
+                data.append('file', file);
+
+                showFeedback('Enviando ' + docKey + '...', true);
+                fetch(base + '/entities/' + entityId + '/documents', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'X-WP-Nonce': nonce },
+                    body: data
+                })
+                .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                .then(function (result) {
+                    if (!result.ok) {
+                        showFeedback((result.json && result.json.message) ? result.json.message : 'Falha no upload do documento.', false);
+                        return;
+                    }
+                    showFeedback('Documento enviado com sucesso (' + docKey + ').', true);
+                    refreshStatus();
+                })
+                .catch(function () {
+                    showFeedback('Erro de conexão no upload.', false);
+                });
+            }
+
+            initDropzones('.rma-doc-file');
+
+            if (backAction) {
+                backAction.addEventListener('click', function () {
+                    if (currentUiStep <= 1) {
+                        return;
+                    }
+
+                    if (currentUiStep <= 2) {
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                        return;
+                    }
+
+                    if (document.referrer) {
+                        window.history.back();
+                        return;
+                    }
+
+                    var uploadBlock = document.getElementById('rma-doc-upload-block');
+                    if (uploadBlock) uploadBlock.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                });
+            }
+
+
+            var otpInputs = Array.prototype.slice.call(document.querySelectorAll('.rma-otp-input'));
+            var validateCodeButton = document.getElementById('rma-validate-code');
+            var resendCodeLink = document.getElementById('rma-resend-code');
+            var resendTimerElement = document.getElementById('rma-resend-timer');
+            var resendSeconds = 60;
+
+            function setOtpState(state) {
+                otpInputs.forEach(function (input) {
+                    input.classList.remove('is-error', 'is-success');
+                    if (state) input.classList.add(state);
+                });
+            }
+
+            function otpCode() {
+                return otpInputs.map(function (input) { return (input.value || '').trim(); }).join('');
+            }
+
+            otpInputs.forEach(function (input, index) {
+                input.addEventListener('input', function () {
+                    input.value = (input.value || '').replace(/\D+/g, '').slice(0, 1);
+                    if (input.value && otpInputs[index + 1]) otpInputs[index + 1].focus();
+                });
+                input.addEventListener('keydown', function (event) {
+                    if (event.key === 'Backspace' && !input.value && otpInputs[index - 1]) {
+                        otpInputs[index - 1].focus();
+                    }
+                });
+                input.addEventListener('paste', function (event) {
+                    var text = (event.clipboardData || window.clipboardData).getData('text') || '';
+                    var digits = text.replace(/\D+/g, '').slice(0, 6).split('');
+                    if (!digits.length) return;
+                    event.preventDefault();
+                    otpInputs.forEach(function (el, i) { el.value = digits[i] || ''; });
+                    var next = otpInputs[Math.min(digits.length, 5)];
+                    if (next) next.focus();
+                });
+            });
+
+            if (validateCodeButton) {
+                validateCodeButton.addEventListener('click', function () {
+                    if (otpCode().length !== 6) {
+                        setOtpState('is-error');
+                        showFeedback('Código inválido. Digite os 6 dígitos enviados por email.', false);
+                        return;
+                    }
+
+                    fetch(base + '/otp/verify', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': nonce },
+                        body: JSON.stringify({ code: otpCode() })
+                    })
+                    .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                    .then(function (result) {
+                        if (!result.ok || !result.json || !result.json.verified) {
+                            setOtpState('is-error');
+                            showFeedback((result.json && result.json.message) ? result.json.message : 'Código inválido. Digite os 6 dígitos enviados por email.', false);
+                            return;
+                        }
+
+                        isOtpVerified = true;
+                        setOtpState('is-success');
+                    var card = document.getElementById('rma-auth-card');
+                    if (card) card.style.display = 'none';
+                    if (onboardingMain) onboardingMain.style.display = 'block';
+                        showFeedback('Documentos enviados.', true);
+                        refreshStatus();
+                    })
+                    .catch(function () {
+                        setOtpState('is-error');
+                        showFeedback('Não foi possível validar o código no momento. Tente novamente.', false);
+                    });
+                });
+            }
+
+            var resendTimerInterval = setInterval(function () {
+                resendSeconds = Math.max(0, resendSeconds - 1);
+                if (resendTimerElement) resendTimerElement.textContent = String(resendSeconds);
+                if (resendSeconds === 0 && resendCodeLink) {
+                    resendCodeLink.setAttribute('aria-disabled', 'false');
+                    resendCodeLink.textContent = 'Reenviar código';
+                    clearInterval(resendTimerInterval);
+                }
+            }, 1000);
+
+            if (resendCodeLink) {
+                resendCodeLink.addEventListener('click', function (event) {
+                    if (resendCodeLink.getAttribute('aria-disabled') === 'true') {
+                        event.preventDefault();
+                        return;
+                    }
+                    event.preventDefault();
+                    resendSeconds = 60;
+                    resendCodeLink.setAttribute('aria-disabled', 'true');
+                    resendCodeLink.innerHTML = 'Reenviar código em <span id="rma-resend-timer">60</span>s';
+                    resendTimerElement = document.getElementById('rma-resend-timer');
+                    sendOtpCode(false);
+                    resendTimerInterval = setInterval(function () {
+                        resendSeconds = Math.max(0, resendSeconds - 1);
+                        if (resendTimerElement) resendTimerElement.textContent = String(resendSeconds);
+                        if (resendSeconds === 0) {
+                            resendCodeLink.setAttribute('aria-disabled', 'false');
+                            resendCodeLink.textContent = 'Reenviar código';
+                            clearInterval(resendTimerInterval);
+                        }
+                    }, 1000);
+                });
+            }
+
+
+            if (onboardingMain) onboardingMain.style.display = 'none';
+
+            if (isOtpVerified) {
+                revealMainFlow();
+            }
+
+            fetch(base + '/otp/status', { credentials: 'same-origin', headers: { 'X-WP-Nonce': nonce } })
+                .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                .then(function (result) {
+                    if (result.ok && result.json && result.json.verified) {
+                        isOtpVerified = true;
+                        revealMainFlow();
+                        return;
+                    }
+                    if (isOtpVerified) {
+                        return;
+                    }
+                    sendOtpCode(true).then(function (sent) {
+                        if (sent) showFeedback('Código enviado para seu email institucional.', true);
+                    });
+                })
+                .catch(function () {
+                    if (isOtpVerified) {
+                        return;
+                    }
+                    sendOtpCode(true).then(function (sent) {
+                        if (sent) showFeedback('Código enviado para seu email institucional.', true);
+                    });
+                });
+
+            updateState({
+                governance_status: <?php echo wp_json_encode($governance); ?>,
+                documentos_status: <?php echo wp_json_encode($docs_status); ?>,
+                finance_status: <?php echo wp_json_encode($finance); ?>,
+                rejected_document_types: <?php echo wp_json_encode($rejected_document_types); ?>
+            });
+
+            document.querySelectorAll('.rma-doc-upload').forEach(function (button) {
+                button.addEventListener('click', function () {
+                    var key = button.getAttribute('data-doc-key');
+                    var fileInput = document.querySelector('.rma-doc-file[data-doc-key="' + key + '"]');
+                    uploadDoc(key, fileInput && fileInput.files ? fileInput.files[0] : null);
+                });
+            });
+
+            function pollStatusSilently() {
+                fetch(base + '/entities/' + entityId + '/status', {
+                    credentials: 'same-origin',
+                    headers: { 'X-WP-Nonce': nonce }
+                })
+                .then(function (res) { return res.ok ? res.json() : Promise.reject(); })
+                .then(function (data) { updateState(data || {}); })
+                .catch(function () {
+                    // polling silencioso para não bloquear o CTA de pagamento
+                });
+            }
+
+            setInterval(pollStatusSilently, 10000);
+        })();
+        </script>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    ob_start();
+    ?>
+    <?php echo $layout_tune_css; ?>
+    <section class="rma-glass-card rma-premium-card rma-premium-card--setup" style="margin:20px 0;">
+        <span class="rma-badge">RMA • Conta da Entidade</span>
+        <h2 class="rma-glass-title">Complete seu cadastro institucional</h2>
+        <p class="rma-glass-subtitle">Valide o CNPJ, confirme dados e envie para análise.</p>
+
+        <form id="rma-conta-setup-form" class="rma-premium-form">
+            <div class="rma-cnpj-row">
+                <input type="text" id="rma-cnpj" placeholder="CNPJ" required />
+                <button class="rma-button rma-button--ghost" type="button" id="rma-buscar-cnpj">Buscar CNPJ</button>
+            </div>
+
+            <div class="rma-grid-2">
+                <input type="text" id="rma-razao-social" placeholder="Razão social" required />
+                <input type="text" id="rma-nome-fantasia" placeholder="Nome fantasia" />
+            </div>
+
+            <div class="rma-grid-2">
+                <input type="email" id="rma-email" placeholder="E-mail de contato" required />
+                <input type="text" id="rma-representante" placeholder="Nome do representante legal" />
+            </div>
+
+            <div class="rma-grid-2">
+                <input type="text" id="rma-endereco" placeholder="Endereço" />
+                <input type="text" id="rma-bairro" placeholder="Bairro" />
+            </div>
+
+            <div class="rma-grid-3">
+                <input type="text" id="rma-cidade" placeholder="Cidade" />
+                <input type="text" id="rma-uf" placeholder="UF" maxlength="2" />
+                <input type="text" id="rma-cep" placeholder="CEP" />
+            </div>
+
+            <div class="rma-grid-2">
+                <div class="rma-phone-row"><select id="rma-phone-country"><option value="55">🇧🇷 +55</option><option value="1">🇺🇸 +1</option><option value="351">🇵🇹 +351</option><option value="34">🇪🇸 +34</option></select><input type="tel" id="rma-telefone" placeholder="(11) 99999-9999" /></div>
+                <div>
+                    <label for="rma-data-fundacao" class="rma-field-label">Data de Criação da Entidade</label>
+                    <input type="date" id="rma-data-fundacao" />
+                </div>
+            </div>
+
+            <textarea id="rma-atividades" placeholder="Resumo de atividades (últimos 2 anos)" rows="4"></textarea>
+
+            <div class="rma-docs-block">
+                <p class="rma-premium-section-title"><strong>Documentos obrigatórios (PDF, imagem ou Word)</strong></p>
+                <ul class="rma-docs-list">
+                    <?php foreach ($required_docs as $doc_key => $doc_meta) : ?>
+                        <li>
+                            <label style="display:flex;align-items:center;gap:8px;">
+                                <span><?php echo esc_html($doc_meta['label']); ?></span>
+                                <span title="<?php echo esc_attr($doc_meta['tip']); ?>" style="cursor:help;">ⓘ</span>
+                            </label>
+                            <div class="rma-drop-item"><label class="rma-dropzone" for="rma-pre-doc-file-<?php echo esc_attr($doc_key); ?>"><span>Arraste e solte ou selecione arquivo</span><input type="file" id="rma-pre-doc-file-<?php echo esc_attr($doc_key); ?>" class="rma-pre-doc-file" data-doc-key="<?php echo esc_attr($doc_key); ?>" accept="application/pdf,image/*,.doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document" /><small class="rma-file-preview" id="rma-pre-preview-<?php echo esc_attr($doc_key); ?>">Nenhum arquivo selecionado</small></label></div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+
+            <label><input type="checkbox" id="rma-consent-lgpd" required /> Concordo com LGPD</label>
+
+            <div class="rma-actions rma-actions--left">
+                <button class="rma-button" type="submit">Salvar entidade</button>
+            </div>
+        </form>
+
+        <div id="rma-feedback" class="rma-feedback"></div>
+    </section>
+
+    <script>
+    (function () {
+        var base = <?php echo wp_json_encode($rest_base); ?>;
+        var nonce = <?php echo wp_json_encode($rest_nonce); ?>;
+        var contaUrl = <?php echo wp_json_encode(rma_account_setup_url()); ?>;
+
+        var form = document.getElementById('rma-conta-setup-form');
+        if (!form) return;
+
+        var feedback = document.getElementById('rma-feedback');
+        var fields = {
+            cnpj: document.getElementById('rma-cnpj'),
+            razao_social: document.getElementById('rma-razao-social'),
+            nome_fantasia: document.getElementById('rma-nome-fantasia'),
+            email_contato: document.getElementById('rma-email'),
+            representante: document.getElementById('rma-representante'),
+            endereco: document.getElementById('rma-endereco'),
+            bairro: document.getElementById('rma-bairro'),
+            cidade: document.getElementById('rma-cidade'),
+            uf: document.getElementById('rma-uf'),
+            cep: document.getElementById('rma-cep'),
+            phone_country: document.getElementById('rma-phone-country'),
+            telefone_contato: document.getElementById('rma-telefone'),
+            data_fundacao: document.getElementById('rma-data-fundacao'),
+            atividades: document.getElementById('rma-atividades'),
+            consent_lgpd: document.getElementById('rma-consent-lgpd')
+        };
+
+        if (fields.telefone_contato) {
+            fields.telefone_contato.addEventListener('input', function () {
+                var country = fields.phone_country ? fields.phone_country.value : '55';
+                var digits = normalizePhone(fields.telefone_contato.value);
+                fields.telefone_contato.value = formatPhoneByCountry(country, digits);
+            });
+        }
+
+        initDropzones('.rma-pre-doc-file');
+
+        function cleanCnpj(value) { return (value || '').replace(/\D+/g, ''); }
+        function showMessage(message, ok) {
+            if (!feedback) return;
+            feedback.innerHTML = '<div style="padding:10px;border-radius:10px;background:' + (ok ? '#edf9ec' : '#fdecec') + ';">' + message + '</div>';
+        }
+
+        function normalizePhone(raw) {
+            return (raw || '').replace(/\D+/g, '');
+        }
+
+        function formatPhoneByCountry(country, digits) {
+            if (country === '55') {
+                if (digits.length >= 11) return '(' + digits.slice(0,2) + ') ' + digits.slice(2,7) + '-' + digits.slice(7,11);
+                if (digits.length >= 10) return '(' + digits.slice(0,2) + ') ' + digits.slice(2,6) + '-' + digits.slice(6,10);
+            }
+            return digits;
+        }
+
+        function initDropzones(selector) {
+            document.querySelectorAll(selector).forEach(function (input) {
+                var zone = input.closest('.rma-dropzone');
+                if (!zone) return;
+                var preview = zone.querySelector('.rma-file-preview');
+                function update() {
+                    var file = input.files && input.files[0] ? input.files[0] : null;
+                    if (preview) preview.textContent = file ? (file.name + ' • ' + Math.ceil(file.size / 1024) + ' KB') : 'Nenhum arquivo selecionado';
+                }
+                input.addEventListener('change', update);
+                zone.addEventListener('dragover', function (event) { event.preventDefault(); zone.classList.add('is-drag'); });
+                zone.addEventListener('dragleave', function () { zone.classList.remove('is-drag'); });
+                zone.addEventListener('drop', function (event) {
+                    event.preventDefault();
+                    zone.classList.remove('is-drag');
+                    if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files[0]) {
+                        input.files = event.dataTransfer.files;
+                        update();
+                    }
+                });
+            });
+        }
+
+        function collectPreSelectedDocs() {
+            var items = [];
+            document.querySelectorAll('.rma-pre-doc-file').forEach(function (input) {
+                if (input.files && input.files[0]) {
+                    items.push({ key: input.getAttribute('data-doc-key'), file: input.files[0] });
+                }
+            });
+            return items;
+        }
+
+        function uploadPreDocs(entityId, docs) {
+            if (!docs.length) {
+                return Promise.resolve();
+            }
+
+            var chain = Promise.resolve();
+            docs.forEach(function (doc) {
+                chain = chain.then(function () {
+                    var data = new FormData();
+                    data.append('document_type', doc.key);
+                    data.append('file', doc.file);
+                    showMessage('Enviando documento: ' + doc.key + '...', true);
+                    return fetch(base + '/entities/' + entityId + '/documents', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: { 'X-WP-Nonce': nonce },
+                        body: data
+                    })
+                    .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+                    .then(function (result) {
+                        if (!result.ok) {
+                            throw new Error((result.json && result.json.message) ? result.json.message : 'Falha no upload de ' + doc.key);
+                        }
+                    });
+                });
+            });
+            return chain;
+        }
+
+        document.getElementById('rma-buscar-cnpj').addEventListener('click', function () {
+            var cnpj = cleanCnpj(fields.cnpj.value);
+            if (!cnpj) {
+                showMessage('Informe um CNPJ válido.', false);
+                return;
+            }
+
+            showMessage('Consultando CNPJ...', true);
+            fetch(base + '/cnpj/' + encodeURIComponent(cnpj), {
+                credentials: 'same-origin',
+                headers: { 'X-WP-Nonce': nonce }
+            })
+            .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+            .then(function (result) {
+                if (!result.ok) {
+                    showMessage((result.json && result.json.message) ? result.json.message : 'Não foi possível consultar o CNPJ.', false);
+                    return;
+                }
+                fields.razao_social.value = result.json.razao_social || fields.razao_social.value;
+                fields.nome_fantasia.value = result.json.nome_fantasia || fields.nome_fantasia.value;
+                fields.cidade.value = result.json.cidade || fields.cidade.value;
+                fields.uf.value = (result.json.uf || fields.uf.value || '').toUpperCase();
+                fields.endereco.value = result.json.logradouro || fields.endereco.value;
+                fields.bairro.value = result.json.bairro || fields.bairro.value;
+                fields.cep.value = result.json.cep || fields.cep.value;
+                showMessage('CNPJ validado e dados preenchidos.', true);
+            })
+            .catch(function () {
+                showMessage('Erro de conexão ao consultar CNPJ.', false);
+            });
+        });
+
+        form.addEventListener('submit', function (event) {
+            event.preventDefault();
+
+            if (!fields.consent_lgpd.checked) {
+                showMessage('É obrigatório aceitar LGPD para continuar.', false);
+                return;
+            }
+
+            var docs = collectPreSelectedDocs();
+            var payload = {
+                cnpj: cleanCnpj(fields.cnpj.value),
+                razao_social: (fields.razao_social.value || '').trim(),
+                nome_fantasia: (fields.nome_fantasia.value || '').trim(),
+                email_contato: (fields.email_contato.value || '').trim(),
+                telefone_contato: '+' + (fields.phone_country ? fields.phone_country.value : '55') + ' ' + (fields.telefone_contato.value || '').trim(),
+                cidade: (fields.cidade.value || '').trim(),
+                uf: (fields.uf.value || '').trim().toUpperCase(),
+                endereco: (fields.endereco.value || '').trim(),
+                bairro: (fields.bairro.value || '').trim(),
+                cep: (fields.cep.value || '').trim(),
+                consent_lgpd: true,
+                observacoes: [
+                    'Representante legal: ' + (fields.representante.value || '').trim(),
+                    'DDI telefone: +' + (fields.phone_country ? fields.phone_country.value : '55'),
+                    'Telefone limpo: ' + normalizePhone(fields.telefone_contato.value || ''),
+                    'Data de fundação: ' + (fields.data_fundacao.value || '').trim(),
+                    'Atividades: ' + (fields.atividades.value || '').trim()
+                ].join(' | ')
+            };
+
+            showMessage('Salvando entidade...', true);
+
+            fetch(base + '/entities', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': nonce
+                },
+                body: JSON.stringify(payload)
+            })
+            .then(function (res) { return res.json().then(function (json) { return {ok: res.ok, json: json}; }); })
+            .then(function (result) {
+                if (!result.ok) {
+                    showMessage((result.json && result.json.message) ? result.json.message : 'Falha ao salvar entidade.', false);
+                    return Promise.reject(new Error('create-failed'));
+                }
+
+                var entityId = result.json && (result.json.id || result.json.post_id) ? (result.json.id || result.json.post_id) : 0;
+                if (!entityId) {
+                    showMessage('Entidade criada, mas não foi possível identificar o ID (id/post_id) para upload dos documentos.', false);
+                    return Promise.reject(new Error('missing-id'));
+                }
+
+                return uploadPreDocs(entityId, docs).then(function () {
+                    showMessage('Entidade criada e documentos enviados. Redirecionando para checkout...', true);
+                    setTimeout(function () {
+                        window.location.replace(<?php echo wp_json_encode($checkout_url); ?>);
+                    }, 900);
+                });
+            })
+            .catch(function (error) {
+                if (error && (error.message === 'create-failed' || error.message === 'missing-id')) {
+                    return;
+                }
+                showMessage(error && error.message ? error.message : 'Erro de conexão ao salvar entidade.', false);
+            });
+        });
+    })();
+    </script>
+    <?php
+
+    return (string) ob_get_clean();
+});
+
+add_action('template_redirect', function () {
+    if (is_admin() || wp_doing_ajax() || wp_doing_cron() || (defined('REST_REQUEST') && REST_REQUEST)) {
+        return;
+    }
+
+    if (! is_user_logged_in()) {
+        return;
+    }
+
+    $request_uri  = isset($_SERVER['REQUEST_URI']) ? (string) $_SERVER['REQUEST_URI'] : '';
+    $request_path = wp_parse_url($request_uri, PHP_URL_PATH);
+    $request_path = is_string($request_path) ? untrailingslashit($request_path) : '';
+
+    if ($request_path === '') {
+        return;
+    }
+
+    $account_path = rma_account_setup_path();
+    if ($account_path !== '' && $request_path === $account_path) {
+        return;
+    }
+
+    foreach (['/login', '/register', '/wp-login.php'] as $safe_suffix) {
+        if (substr($request_path, -strlen($safe_suffix)) === $safe_suffix) {
+            return;
+        }
+    }
+
+    $current_user_id = get_current_user_id();
+    $entity_id = rma_get_entity_id_by_author($current_user_id);
+    $otp_verified = rma_is_2fa_verified($current_user_id);
+    if ($entity_id <= 0) {
+        rma_flow_debug_log('redirect_no_entity', ['to' => rma_account_setup_url()]);
+        wp_safe_redirect(rma_account_setup_url());
+        exit;
+    }
+
+    $governance = (string) get_post_meta($entity_id, 'governance_status', true);
+    $finance = (string) get_post_meta($entity_id, 'finance_status', true);
+    $docs_status = (string) get_post_meta($entity_id, 'documentos_status', true);
+
+    $all_steps_done = ($governance === 'aprovado' && $finance === 'adimplente' && $docs_status === 'enviado');
+    if ($all_steps_done) {
+        return;
+    }
+
+    $checkout_path = (string) wp_parse_url(apply_filters('rma_checkout_url', home_url('/checkout/')), PHP_URL_PATH);
+
+    $allowed_paths = array_filter(array_map('untrailingslashit', [
+        rma_account_setup_path(),
+        (string) wp_parse_url(home_url('/documentos/'), PHP_URL_PATH),
+        (string) wp_parse_url(home_url('/financeiro/'), PHP_URL_PATH),
+        (string) wp_parse_url(home_url('/status/'), PHP_URL_PATH),
+        ($otp_verified ? $checkout_path : ''),
+    ]));
+
+    foreach ($allowed_paths as $allowed_path) {
+        if ($allowed_path !== '' && $request_path === $allowed_path) {
+            return;
+        }
+    }
+
+    rma_flow_debug_log('redirect_incomplete_flow', [
+        'to' => rma_account_setup_url(),
+        'entity_id' => $entity_id,
+        'governance' => $governance,
+        'finance' => $finance,
+        'docs_status' => $docs_status,
+    ]);
+    wp_safe_redirect(rma_account_setup_url());
+    exit;
+}, 20);

--- a/ui/rma-glass-theme.css
+++ b/ui/rma-glass-theme.css
@@ -1,0 +1,598 @@
+:root {
+  --rma-font-family: 'Federo', sans-serif;
+  --rma-color-primary: #7bad39;
+  --rma-color-dark: #37302c;
+
+  /* Ultra white glass tokens */
+  --rma-glass-bg: rgba(255, 255, 255, 0.84);
+  --rma-glass-bg-soft: rgba(255, 255, 255, 0.7);
+  --rma-glass-border: rgba(255, 255, 255, 0.76);
+  --rma-glass-highlight: rgba(255, 255, 255, 0.92);
+  --rma-glass-shadow: 0 22px 70px rgba(55, 48, 44, 0.2);
+  --rma-glass-blur: blur(24px);
+  --rma-radius: 24px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.rma-glass-page {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--rma-font-family);
+  color: var(--rma-color-dark);
+  background:
+    radial-gradient(circle at 10% 10%, rgba(123, 173, 57, 0.42), transparent 30%),
+    radial-gradient(circle at 90% 15%, rgba(255, 255, 255, 0.88), transparent 45%),
+    linear-gradient(135deg, #f8fbf3 0%, #efece8 100%);
+  padding: 40px 20px;
+}
+
+.rma-glass-shell {
+  max-width: 980px;
+  margin: 0 auto;
+  display: grid;
+  gap: 20px;
+}
+
+.rma-glass-card {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--rma-glass-bg) 0%, var(--rma-glass-bg-soft) 100%);
+  border: 1px solid var(--rma-glass-border);
+  backdrop-filter: var(--rma-glass-blur);
+  -webkit-backdrop-filter: var(--rma-glass-blur);
+  border-radius: var(--rma-radius);
+  box-shadow: var(--rma-glass-shadow);
+  padding: 24px;
+}
+
+.rma-glass-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(120deg, var(--rma-glass-highlight), rgba(255, 255, 255, 0));
+  opacity: 0.45;
+}
+
+.rma-glass-title {
+  margin: 0 0 8px;
+  font-size: clamp(1.55rem, 2.8vw, 2rem);
+  line-height: 1.1;
+}
+
+.rma-glass-subtitle {
+  margin: 0;
+  opacity: 0.88;
+}
+
+.rma-grid-2 {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.rma-badge {
+  display: inline-block;
+  background: rgba(123, 173, 57, 0.17);
+  color: var(--rma-color-primary);
+  border: 1px solid rgba(123, 173, 57, 0.46);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.rma-label {
+  display: block;
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+  opacity: 0.8;
+}
+
+.rma-input {
+  width: 100%;
+  border: 1px solid rgba(55, 48, 44, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--rma-color-dark);
+  border-radius: 12px;
+  padding: 11px 12px;
+  font-family: var(--rma-font-family);
+}
+
+.rma-input:focus-visible,
+.rma-button:focus-visible {
+  outline: 2px solid var(--rma-color-primary);
+  outline-offset: 2px;
+}
+
+.rma-button {
+  appearance: none;
+  border: 0;
+  border-radius: 14px;
+  background: var(--rma-color-primary);
+  color: #fff;
+  font-family: var(--rma-font-family);
+  font-weight: 700;
+  padding: 12px 18px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+  box-shadow: 0 11px 26px rgba(123, 173, 57, 0.35);
+}
+
+.rma-button:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.02);
+  box-shadow: 0 16px 31px rgba(123, 173, 57, 0.39);
+}
+
+.rma-actions {
+  margin-top: 14px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .rma-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  body.rma-glass-page {
+    padding: 24px 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rma-button {
+    transition: none;
+  }
+}
+
+
+.rma-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+}
+
+.rma-brand {
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.rma-status-list {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.rma-status-chip {
+  border-radius: 999px;
+  font-size: 0.82rem;
+  padding: 6px 10px;
+  border: 1px solid rgba(55, 48, 44, 0.2);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.rma-status-chip.is-ok {
+  border-color: rgba(123, 173, 57, 0.45);
+  color: var(--rma-color-primary);
+}
+
+.rma-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rma-kpi {
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.9);
+}
+
+.rma-kpi strong {
+  display: block;
+  font-size: 1.4rem;
+}
+
+@media (max-width: 900px) {
+  .rma-kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+
+.rma-wizard-steps {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.rma-step {
+  border-radius: 12px;
+  border: 1px solid rgba(55, 48, 44, 0.18);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 8px 10px;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.rma-step.is-current {
+  border-color: rgba(123, 173, 57, 0.58);
+  box-shadow: 0 8px 20px rgba(123, 173, 57, 0.22);
+  color: var(--rma-color-primary);
+  font-weight: 700;
+}
+
+.rma-step.is-done {
+  border-color: rgba(123, 173, 57, 0.4);
+}
+
+.rma-alert {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(123, 173, 57, 0.34);
+  background: rgba(123, 173, 57, 0.1);
+  color: var(--rma-color-dark);
+}
+
+@media (max-width: 900px) {
+  .rma-wizard-steps {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+
+.rma-button[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+
+.rma-button--muted {
+  background: rgba(55, 48, 44, 0.72);
+  box-shadow: 0 9px 22px rgba(55, 48, 44, 0.28);
+}
+
+.rma-button--ghost {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--rma-color-dark);
+  border: 1px solid rgba(55, 48, 44, 0.22);
+  box-shadow: none;
+}
+
+.rma-actions {
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+
+.rma-brand-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.rma-brand-logo {
+  width: 148px;
+  height: auto;
+  display: block;
+}
+
+.rma-icon-row {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.rma-icon-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.88);
+}
+
+.rma-icon-card img {
+  width: 28px;
+  height: 28px;
+}
+
+/* Premium form system */
+:root {
+  --rma-premium-bg: #ffffff;
+  --rma-premium-bg-soft: #fafafa;
+  --rma-premium-text: #2e2e2e;
+  --rma-premium-muted: #6b6b6b;
+  --rma-premium-border: #eaeaea;
+  --rma-premium-focus: #3a8dff;
+  --rma-premium-focus-soft: rgba(58, 141, 255, 0.22);
+  --rma-premium-cta-a: #3a8dff;
+  --rma-premium-cta-b: #7b5cff;
+  --rma-premium-warm: #ffb547;
+}
+
+.rma-premium-card {
+  max-width: 520px;
+  margin-inline: auto;
+  padding: clamp(28px, 4vw, 42px);
+  border-radius: 24px;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfcff 100%);
+  border: 1px solid #f0f2f8;
+  box-shadow: 0 24px 60px rgba(39, 58, 109, 0.12), 0 2px 10px rgba(40, 40, 50, 0.05);
+  animation: rmaCardIn 0.45s ease;
+}
+
+.rma-premium-card .rma-glass-title {
+  font-family: 'Maven Pro', 'Federo', 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: clamp(1.85rem, 3.2vw, 2.2rem);
+  line-height: 1.15;
+  margin: 0 0 6px;
+  color: var(--rma-premium-text);
+  letter-spacing: -0.02em;
+}
+
+.rma-premium-card .rma-glass-subtitle {
+  color: var(--rma-premium-muted);
+  font-size: 1rem;
+  margin-bottom: 10px;
+}
+
+.rma-premium-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 14px;
+}
+
+.rma-premium-form input,
+.rma-premium-form textarea,
+.rma-premium-card input,
+.rma-premium-card textarea,
+.rma-premium-card select {
+  width: 100%;
+  border: 1px solid var(--rma-premium-border);
+  background: var(--rma-premium-bg);
+  color: var(--rma-premium-text);
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-family: 'Maven Pro', 'Federo', 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: 15px;
+  transition: border-color .25s ease, box-shadow .25s ease, transform .2s ease;
+}
+
+.rma-premium-form input:hover,
+.rma-premium-form textarea:hover,
+.rma-premium-card input:hover,
+.rma-premium-card textarea:hover {
+  border-color: #d6dbe8;
+}
+
+.rma-premium-form input:focus,
+.rma-premium-form textarea:focus,
+.rma-premium-card input:focus,
+.rma-premium-card textarea:focus {
+  border-color: var(--rma-premium-focus);
+  box-shadow: 0 0 0 3px var(--rma-premium-focus-soft);
+  outline: none;
+}
+
+.rma-premium-form textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.rma-cnpj-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.rma-grid-city-uf {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 96px;
+  gap: 10px;
+}
+
+.rma-docs-block {
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+  border: 1px solid #eef1f8;
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+
+.rma-premium-section-title {
+  margin: 0 0 10px;
+  font-size: .95rem;
+  color: var(--rma-premium-text);
+}
+
+.rma-docs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.rma-docs-list li label {
+  color: var(--rma-premium-muted);
+  font-size: .93rem;
+}
+
+.rma-button {
+  background-image: linear-gradient(135deg, var(--rma-premium-cta-a), var(--rma-premium-cta-b));
+  border-radius: 14px;
+  min-height: 50px;
+  padding: 12px 20px;
+  box-shadow: 0 14px 28px rgba(80, 89, 201, 0.25);
+  font-family: 'Maven Pro', 'Federo', 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+.rma-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(80, 89, 201, 0.32);
+}
+
+.rma-button:active {
+  transform: translateY(1px);
+}
+
+.rma-button.rma-button--ghost {
+  background: #fff;
+  color: var(--rma-premium-cta-a);
+  border: 1px solid #dce6ff;
+  box-shadow: 0 10px 20px rgba(58, 141, 255, 0.12);
+  min-width: 140px;
+}
+
+.rma-actions--left {
+  justify-content: flex-start;
+}
+
+.rma-actions--spread {
+  justify-content: flex-start;
+}
+
+.rma-feedback {
+  margin-top: 12px;
+}
+
+.rma-premium-card label {
+  color: var(--rma-premium-muted);
+  font-size: .95rem;
+}
+
+.rma-premium-card input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  accent-color: var(--rma-premium-cta-a);
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+body.rma-glass-page,
+body {
+  background:
+    radial-gradient(circle at 12% 8%, rgba(58, 141, 255, 0.08), transparent 34%),
+    radial-gradient(circle at 87% 12%, rgba(123, 92, 255, 0.09), transparent 36%),
+    radial-gradient(circle at 78% 88%, rgba(255, 181, 71, 0.09), transparent 34%),
+    linear-gradient(160deg, #ffffff 0%, #f8faff 52%, #fffdf8 100%);
+}
+
+@keyframes rmaCardIn {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 680px) {
+  .rma-premium-card {
+    max-width: 100%;
+    border-radius: 20px;
+    padding: 24px 18px;
+  }
+
+  .rma-cnpj-row,
+  .rma-grid-city-uf {
+    grid-template-columns: 1fr;
+  }
+
+  .rma-button.rma-button--ghost {
+    width: 100%;
+  }
+}
+
+/* SaaS premium refresh */
+:root {
+  --rma-font-family: 'Inter', 'Maven Pro', system-ui, -apple-system, sans-serif;
+}
+
+body.rma-glass-page,
+body {
+  background: #f8fafb;
+  color: #111827;
+}
+
+.rma-glass-shell { max-width: 1100px; gap: 24px; }
+
+.rma-glass-card,
+.rma-premium-card,
+.rma-premium-card--setup {
+  background: #ffffff;
+  border: 1px solid #edf1f4;
+  border-radius: 18px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.05);
+  backdrop-filter: none;
+}
+
+.rma-button {
+  background-image: linear-gradient(135deg, #7bad39, #5ddabb);
+  border-radius: 14px;
+  font-weight: 600;
+  padding: 12px 22px;
+  transition: all 0.3s ease;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
+}
+
+.rma-button:hover {
+  filter: brightness(1.04);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+}
+
+.rma-button.rma-button--ghost {
+  background: #fff;
+  border: 1px solid #7bad39;
+  color: #7bad39;
+}
+
+.rma-input,
+.rma-premium-card input,
+.rma-premium-card textarea {
+  border: 1px solid #dbe2ea;
+  border-radius: 12px;
+  background: #fff;
+  padding: 13px 12px;
+}
+
+.rma-input:focus,
+.rma-premium-card input:focus,
+.rma-premium-card textarea:focus {
+  border-color: #7bad39;
+  box-shadow: 0 0 0 3px rgba(123, 173, 57, 0.15);
+  outline: none;
+}
+
+.rma-field-floating { position: relative; }
+.rma-field-floating label {
+  position: absolute;
+  top: 10px;
+  left: 12px;
+  font-size: .82rem;
+  color: #6b7280;
+  pointer-events: none;
+  transition: all .2s ease;
+  background: #fff;
+  padding: 0 4px;
+}
+.rma-field-floating input:focus + label,
+.rma-field-floating input:not(:placeholder-shown) + label {
+  top: -8px;
+  font-size: .73rem;
+  color: #7bad39;
+}

--- a/ui/rma-glass-theme.js
+++ b/ui/rma-glass-theme.js
@@ -1,0 +1,23 @@
+(function () {
+  'use strict';
+
+  var buttonPagamento = document.getElementById('btnPagamento');
+  if (buttonPagamento) {
+    buttonPagamento.addEventListener('click', function () {
+      var checkoutBase = '/rma/checkout/';
+      var productId = Number(buttonPagamento.getAttribute('data-product-id') || 3407);
+      var target = buttonPagamento.getAttribute('data-checkout-url') || (checkoutBase + '?add-to-cart=' + productId);
+      buttonPagamento.disabled = true;
+      buttonPagamento.textContent = 'Processando pagamento...';
+      window.location.href = target;
+    });
+  }
+
+  var buttonVoltar = document.getElementById('btnVoltar');
+  if (buttonVoltar) {
+    buttonVoltar.addEventListener('click', function () {
+      window.history.back();
+    });
+  }
+
+})();

--- a/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
+++ b/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
@@ -83,7 +83,7 @@ final class RMA_Admin_Settings {
             'rma_admin_emails_verification',
             'Configurações > Emails > Verificação',
             static function () {
-                echo '<p>Personalize o template do e-mail de verificação em 2 fatores. Variáveis suportadas: <code>{{nome}}</code>, <code>{{codigo}}</code>, <code>{{data}}</code>, <code>{{empresa}}</code>.</p>';
+                echo '<p>Personalize o template do e-mail de verificação em 2 fatores. Variáveis suportadas: <code>{{nome}}</code>, <code>{{codigo}}</code>, <code>{{data}}</code>, <code>{{empresa}}</code>. Header/footer seguem o padrão institucional com degradê.</p>';
             },
             'rma-admin-settings'
         );
@@ -220,7 +220,11 @@ function rma_render_verification_email_template(array $context = []): string {
         'empresa' => (string) get_option('rma_email_verification_company', 'RMA'),
     ]);
 
-    $logo = (string) get_option('rma_email_verification_logo', 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/logo-.png');
+    $logo = trim((string) get_option('rma_email_verification_logo', ''));
+    if ($logo === '') {
+        $logo = 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/logo-.png';
+    }
+
     $favicon = 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/favicon.png';
     $body = (string) get_option('rma_email_verification_body', 'Utilize o código abaixo para confirmar seu acesso à plataforma RMA.');
 

--- a/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
+++ b/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Plugin Name: RMA Admin Settings
+ * Description: Configurações centralizadas para Equipe RMA (anuidade, API Maps, PIX e notificações).
+ * Version: 0.1.0
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Admin_Settings {
+    private const OPTION_GROUP = 'rma_admin_settings_group';
+
+    private const OPTIONS = [
+        'rma_annual_due_value',
+        'rma_annual_dues_product_id',
+        'rma_due_day_month',
+        'rma_pix_key',
+        'rma_google_maps_api_key',
+        'rma_maps_only_adimplente',
+        'rma_institutional_email',
+        'rma_notifications_api_url',
+        'rma_email_sender_mode',
+        'rma_email_verification_header_image',
+        'rma_email_verification_logo',
+        'rma_email_verification_bg_color',
+        'rma_email_verification_button_color',
+        'rma_email_verification_body',
+        'rma_email_verification_footer',
+        'rma_email_verification_company',
+    ];
+
+    public function __construct() {
+        add_action('admin_menu', [$this, 'register_menu']);
+        add_action('admin_init', [$this, 'register_settings']);
+    }
+
+    public function register_menu(): void {
+        add_menu_page(
+            'RMA Configurações',
+            'RMA Configurações',
+            'manage_options',
+            'rma-admin-settings',
+            [$this, 'render_page'],
+            'dashicons-admin-generic',
+            58
+        );
+    }
+
+    public function register_settings(): void {
+        foreach (self::OPTIONS as $option) {
+            register_setting(self::OPTION_GROUP, $option, [
+                'type' => 'string',
+                'sanitize_callback' => function ($value) use ($option) {
+                    return $this->sanitize_option($option, $value);
+                },
+                'show_in_rest' => false,
+            ]);
+        }
+
+        add_settings_section(
+            'rma_admin_main',
+            'Parâmetros principais da operação RMA',
+            static function () {
+                echo '<p>Campos personalizáveis para operação do ciclo anual, mapa, financeiro e notificações.</p>';
+            },
+            'rma-admin-settings'
+        );
+
+        $this->add_field('rma_annual_due_value', 'Valor da anuidade (R$)', 'number', 'Ex.: 1200.00');
+        $this->add_field('rma_annual_dues_product_id', 'ID do produto Woo da anuidade', 'number', 'Ex.: 123');
+        $this->add_field('rma_due_day_month', 'Data de início do ciclo anual (dd-mm)', 'text', 'Ex.: 01-02');
+        $this->add_field('rma_pix_key', 'Chave PIX institucional', 'text', 'Ex.: financeiro@rma.org.br');
+        $this->add_field('rma_google_maps_api_key', 'Google Maps API Key', 'text', 'Usada pelo tema para renderização do mapa');
+        $this->add_field('rma_maps_only_adimplente', 'Diretório mostra apenas adimplentes por padrão', 'checkbox', '');
+        $this->add_field('rma_institutional_email', 'E-mail institucional (notificações)', 'email', 'Ex.: secretaria@rma.org.br');
+        $this->add_field('rma_notifications_api_url', 'URL da API de notificações (opcional)', 'url', 'Ex.: https://api.seudominio/notify');
+        $this->add_field('rma_email_sender_mode', 'Motor de envio de e-mails', 'select', '');
+
+        add_settings_section(
+            'rma_admin_emails_verification',
+            'Configurações > Emails > Verificação',
+            static function () {
+                echo '<p>Personalize o template do e-mail de verificação em 2 fatores. Variáveis suportadas: <code>{{nome}}</code>, <code>{{codigo}}</code>, <code>{{data}}</code>, <code>{{empresa}}</code>.</p>';
+            },
+            'rma-admin-settings'
+        );
+
+        $this->add_field('rma_email_verification_header_image', 'Imagem de header (URL)', 'url', 'https://.../header.jpg', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_logo', 'Logo (URL)', 'url', 'https://.../logo.png', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_bg_color', 'Cor de fundo do e-mail', 'text', '#f8fafb', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_button_color', 'Cor do botão', 'text', '#7bad39', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_body', 'Texto editável do corpo', 'textarea', 'Olá {{nome}}, seu código é {{codigo}}.', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_footer', 'Footer editável', 'textarea', 'Equipe RMA • {{data}}', 'rma_admin_emails_verification');
+        $this->add_field('rma_email_verification_company', 'Nome da empresa', 'text', 'RMA', 'rma_admin_emails_verification');
+
+    }
+
+    private function add_field(string $name, string $label, string $type, string $placeholder, string $section = 'rma_admin_main'): void {
+        add_settings_field(
+            $name,
+            $label,
+            function () use ($name, $type, $placeholder) {
+                $value = (string) get_option($name, '');
+                if ($type === 'checkbox') {
+                    echo '<input type="hidden" name="' . esc_attr($name) . '" value="0" />';
+                    echo '<label><input type="checkbox" name="' . esc_attr($name) . '" value="1" ' . checked($value, '1', false) . ' /> Sim</label>';
+                    return;
+                }
+
+                if ($type === 'textarea') {
+                    echo '<textarea class="large-text" rows="5" name="' . esc_attr($name) . '" placeholder="' . esc_attr($placeholder) . '">' . esc_textarea($value) . '</textarea>';
+                    return;
+                }
+
+                if ($type === 'select' && $name === 'rma_email_sender_mode') {
+                    $options = [
+                        'wp_mail' => 'WordPress padrão (wp_mail)',
+                        'woo_mail' => 'WooCommerce (layout/template de e-mail)',
+                    ];
+                    echo '<select name="' . esc_attr($name) . '">';
+                    foreach ($options as $option_value => $option_label) {
+                        echo '<option value="' . esc_attr($option_value) . '" ' . selected($value ?: 'wp_mail', $option_value, false) . '>' . esc_html($option_label) . '</option>';
+                    }
+                    echo '</select>';
+                    return;
+                }
+
+                echo '<input type="' . esc_attr($type) . '" class="regular-text" name="' . esc_attr($name) . '" value="' . esc_attr($value) . '" placeholder="' . esc_attr($placeholder) . '" />';
+            },
+            'rma-admin-settings',
+            $section
+        );
+    }
+
+    private function sanitize_option(string $option, $value): string {
+        if ($option === 'rma_maps_only_adimplente') {
+            return rest_sanitize_boolean($value) ? '1' : '0';
+        }
+
+        if ($option === 'rma_annual_due_value') {
+            $numeric = is_numeric($value) ? (float) $value : 0;
+            return number_format(max(0, $numeric), 2, '.', '');
+        }
+
+        if ($option === 'rma_annual_dues_product_id') {
+            return (string) absint((int) $value);
+        }
+
+        if ($option === 'rma_due_day_month') {
+            $v = sanitize_text_field((string) $value);
+            if (! preg_match('/^(\d{2})-(\d{2})$/', $v, $matches)) {
+                return '01-01';
+            }
+
+            $day = (int) $matches[1];
+            $month = (int) $matches[2];
+
+            return checkdate($month, $day, 2024) ? sprintf('%02d-%02d', $day, $month) : '01-01';
+        }
+
+        if ($option === 'rma_institutional_email') {
+            return sanitize_email((string) $value);
+        }
+
+        if ($option === 'rma_notifications_api_url') {
+            return esc_url_raw((string) $value);
+        }
+
+        if (in_array($option, ['rma_email_verification_header_image', 'rma_email_verification_logo'], true)) {
+            return esc_url_raw((string) $value);
+        }
+
+        if (in_array($option, ['rma_email_verification_bg_color', 'rma_email_verification_button_color'], true)) {
+            $color = sanitize_hex_color((string) $value);
+            return $color ?: '#7bad39';
+        }
+
+        if (in_array($option, ['rma_email_verification_body', 'rma_email_verification_footer'], true)) {
+            return wp_kses_post((string) $value);
+        }
+
+        if ($option === 'rma_email_sender_mode') {
+            $mode = sanitize_key((string) $value);
+            return in_array($mode, ['wp_mail', 'woo_mail'], true) ? $mode : 'wp_mail';
+        }
+
+        return sanitize_text_field((string) $value);
+    }
+
+    public function render_page(): void {
+        if (! current_user_can('manage_options')) {
+            return;
+        }
+        ?>
+        <div class="wrap">
+          <h1>RMA Configurações (Equipe RMA)</h1>
+          <form method="post" action="options.php">
+            <?php
+            settings_fields(self::OPTION_GROUP);
+            do_settings_sections('rma-admin-settings');
+            submit_button('Salvar configurações');
+            ?>
+          </form>
+        </div>
+        <?php
+    }
+}
+
+new RMA_Admin_Settings();
+
+
+function rma_render_verification_email_template(array $context = []): string {
+    $context = wp_parse_args($context, [
+        'nome' => 'Associado',
+        'codigo' => '000000',
+        'data' => wp_date('d/m/Y H:i'),
+        'empresa' => (string) get_option('rma_email_verification_company', 'RMA'),
+    ]);
+
+    $header = (string) get_option('rma_email_verification_header_image', '');
+    $logo = (string) get_option('rma_email_verification_logo', 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/logo-.png');
+    $bg = (string) get_option('rma_email_verification_bg_color', '#f6f8fb');
+    $button = (string) get_option('rma_email_verification_button_color', '#7bad39');
+    $body = (string) get_option('rma_email_verification_body', 'Utilize o código abaixo para confirmar seu acesso à plataforma RMA.');
+    $footer = (string) get_option('rma_email_verification_footer', 'Se você não solicitou esta verificação, ignore este email.');
+
+    $replace = [
+        '{{nome}}' => (string) $context['nome'],
+        '{{codigo}}' => (string) $context['codigo'],
+        '{{data}}' => (string) $context['data'],
+        '{{empresa}}' => (string) $context['empresa'],
+    ];
+
+    $body = strtr($body, $replace);
+    $footer = strtr($footer, $replace);
+
+    ob_start();
+    ?>
+    <div style="background:<?php echo esc_attr($bg); ?>;padding:30px 14px;font-family:'Segoe UI',Inter,Arial,sans-serif;">
+      <div style="max-width:620px;margin:0 auto;background:#ffffff;border-radius:20px;overflow:hidden;border:1px solid #e9eef3;box-shadow:0 18px 48px rgba(15,23,42,.14);">
+        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:26px 22px 22px;text-align:center;color:#fff;">
+          <?php if ($logo) : ?><img src="<?php echo esc_url($logo); ?>" alt="Logo RMA" style="display:block;max-width:190px;width:100%;height:auto;margin:0 auto 14px;" /><?php endif; ?>
+          <?php if ($header) : ?><img src="<?php echo esc_url($header); ?>" alt="Header" style="width:100%;max-width:540px;border-radius:12px;margin:0 auto 14px;display:block;" /><?php endif; ?>
+          <p style="margin:0;font-size:13px;line-height:1.4;letter-spacing:.12em;text-transform:uppercase;font-weight:700;opacity:.95;">Verificação em 2 fatores</p>
+          <h2 style="margin:8px 0 0;font-size:30px;line-height:1.12;font-weight:800;">Proteja seu acesso</h2>
+        </div>
+
+        <div style="padding:28px 26px 22px;text-align:center;">
+          <p style="margin:0 0 16px;color:#334155;line-height:1.7;font-size:16px;"><?php echo wp_kses_post($body); ?></p>
+
+          <div style="display:inline-block;margin:0 auto 16px;padding:16px 24px;border-radius:14px;background:#f8fbff;border:1px solid #dbe7f3;color:#0f172a;font-size:34px;letter-spacing:9px;font-weight:800;box-shadow:inset 0 1px 0 rgba(255,255,255,.8);">
+            <?php echo esc_html((string) $context['codigo']); ?>
+          </div>
+
+          <p style="margin:0 0 16px;color:#64748b;font-size:13px;line-height:1.5;">Este código expira em poucos minutos. Nunca compartilhe com terceiros.</p>
+
+          <div style="margin:0 0 8px;">
+            <a href="#" style="display:inline-block;text-decoration:none;background-image:linear-gradient(135deg,#7bad39,#5ddabb);color:#fff;padding:12px 24px;border-radius:999px;font-weight:700;font-size:14px;letter-spacing:.01em;box-shadow:0 10px 24px rgba(93,218,187,.35);">Confirmar verificação</a>
+          </div>
+
+          <p style="color:#475569;font-size:13px;line-height:1.6;margin:14px 0 0;"><?php echo wp_kses_post($footer); ?></p>
+        </div>
+
+        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:16px 24px;text-align:center;">
+          <p style="margin:0;color:#ffffff;font-size:16px;line-height:1.4;font-weight:700;letter-spacing:.02em;">rma.org.br</p>
+        </div>
+      </div>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}

--- a/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
+++ b/wp-content/plugins/rma-admin-settings/rma-admin-settings.php
@@ -220,12 +220,9 @@ function rma_render_verification_email_template(array $context = []): string {
         'empresa' => (string) get_option('rma_email_verification_company', 'RMA'),
     ]);
 
-    $header = (string) get_option('rma_email_verification_header_image', '');
     $logo = (string) get_option('rma_email_verification_logo', 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/logo-.png');
-    $bg = (string) get_option('rma_email_verification_bg_color', '#f6f8fb');
-    $button = (string) get_option('rma_email_verification_button_color', '#7bad39');
+    $favicon = 'https://www.agenciadigitalsaopaulo.com.br/rma/wp-content/uploads/2021/02/favicon.png';
     $body = (string) get_option('rma_email_verification_body', 'Utilize o código abaixo para confirmar seu acesso à plataforma RMA.');
-    $footer = (string) get_option('rma_email_verification_footer', 'Se você não solicitou esta verificação, ignore este email.');
 
     $replace = [
         '{{nome}}' => (string) $context['nome'],
@@ -235,36 +232,33 @@ function rma_render_verification_email_template(array $context = []): string {
     ];
 
     $body = strtr($body, $replace);
-    $footer = strtr($footer, $replace);
 
     ob_start();
     ?>
-    <div style="background:<?php echo esc_attr($bg); ?>;padding:30px 14px;font-family:'Segoe UI',Inter,Arial,sans-serif;">
-      <div style="max-width:620px;margin:0 auto;background:#ffffff;border-radius:20px;overflow:hidden;border:1px solid #e9eef3;box-shadow:0 18px 48px rgba(15,23,42,.14);">
-        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:26px 22px 22px;text-align:center;color:#fff;">
-          <?php if ($logo) : ?><img src="<?php echo esc_url($logo); ?>" alt="Logo RMA" style="display:block;max-width:190px;width:100%;height:auto;margin:0 auto 14px;" /><?php endif; ?>
-          <?php if ($header) : ?><img src="<?php echo esc_url($header); ?>" alt="Header" style="width:100%;max-width:540px;border-radius:12px;margin:0 auto 14px;display:block;" /><?php endif; ?>
-          <p style="margin:0;font-size:13px;line-height:1.4;letter-spacing:.12em;text-transform:uppercase;font-weight:700;opacity:.95;">Verificação em 2 fatores</p>
-          <h2 style="margin:8px 0 0;font-size:30px;line-height:1.12;font-weight:800;">Proteja seu acesso</h2>
+    <div style="background:#ffffff;padding:24px 12px;font-family:'Maven Pro','Segoe UI',Arial,sans-serif;">
+      <div style="max-width:520px;margin:0 auto;background:rgba(255,255,255,.94);border-radius:20px;overflow:hidden;border:1px solid #e9eef3;box-shadow:0 16px 42px rgba(15,23,42,.10);">
+        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:24px 20px;text-align:center;color:#fff;">
+          <?php if ($logo) : ?><img src="<?php echo esc_url($logo); ?>" alt="Logo RMA" style="display:block;max-width:180px;width:100%;height:auto;margin:0 auto 14px;" /><?php endif; ?>
+          <p style="margin:0;font-size:12px;line-height:1.4;letter-spacing:.12em;text-transform:uppercase;font-weight:700;opacity:.95;color:#fff;text-align:center;">Verificação em 2 fatores</p>
+          <h2 style="margin:8px 0 0;font-size:34px;line-height:1.1;font-weight:800;color:#ffffff;text-align:center;">Proteja seu acesso</h2>
         </div>
 
-        <div style="padding:28px 26px 22px;text-align:center;">
+        <div style="padding:26px 24px 20px;text-align:center;background:rgba(255,255,255,.92);">
           <p style="margin:0 0 16px;color:#334155;line-height:1.7;font-size:16px;"><?php echo wp_kses_post($body); ?></p>
 
-          <div style="display:inline-block;margin:0 auto 16px;padding:16px 24px;border-radius:14px;background:#f8fbff;border:1px solid #dbe7f3;color:#0f172a;font-size:34px;letter-spacing:9px;font-weight:800;box-shadow:inset 0 1px 0 rgba(255,255,255,.8);">
+          <div style="display:inline-block;margin:0 auto 16px;padding:16px 24px;border-radius:14px;background:rgba(255,255,255,.96);border:1px solid #dbe7f3;color:#0f172a;font-size:34px;letter-spacing:9px;font-weight:800;box-shadow:0 10px 24px rgba(15,23,42,.08);">
             <?php echo esc_html((string) $context['codigo']); ?>
           </div>
 
           <p style="margin:0 0 16px;color:#64748b;font-size:13px;line-height:1.5;">Este código expira em poucos minutos. Nunca compartilhe com terceiros.</p>
 
-          <div style="margin:0 0 8px;">
+          <div style="margin:0 0 2px;">
             <a href="#" style="display:inline-block;text-decoration:none;background-image:linear-gradient(135deg,#7bad39,#5ddabb);color:#fff;padding:12px 24px;border-radius:999px;font-weight:700;font-size:14px;letter-spacing:.01em;box-shadow:0 10px 24px rgba(93,218,187,.35);">Confirmar verificação</a>
           </div>
-
-          <p style="color:#475569;font-size:13px;line-height:1.6;margin:14px 0 0;"><?php echo wp_kses_post($footer); ?></p>
         </div>
 
-        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:16px 24px;text-align:center;">
+        <div style="background-image:linear-gradient(135deg,#7bad39,#5ddabb);padding:14px 24px;text-align:center;">
+          <img src="<?php echo esc_url($favicon); ?>" alt="RMA" style="display:block;max-width:20px;width:20px;height:20px;margin:0 auto 6px;" />
           <p style="margin:0;color:#ffffff;font-size:16px;line-height:1.4;font-weight:700;letter-spacing:.02em;">rma.org.br</p>
         </div>
       </div>

--- a/wp-content/plugins/rma-analytics/rma-analytics.php
+++ b/wp-content/plugins/rma-analytics/rma-analytics.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Plugin Name: RMA Analytics
+ * Description: Relatórios administrativos e exportação CSV para entidades RMA.
+ * Version: 0.4.3
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Analytics {
+    public function __construct() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    public function register_routes(): void {
+        register_rest_route('rma/v1', '/analytics/summary', [
+            'methods' => 'GET',
+            'callback' => [$this, 'summary'],
+            'permission_callback' => [$this, 'can_view'],
+        ]);
+
+        register_rest_route('rma/v1', '/analytics/export', [
+            'methods' => 'GET',
+            'callback' => [$this, 'export_csv'],
+            'permission_callback' => [$this, 'can_view'],
+        ]);
+    }
+
+    public function can_view(): bool {
+        return current_user_can('manage_options');
+    }
+
+    public function summary(): WP_REST_Response {
+        $all = new WP_Query([
+            'post_type' => 'rma_entidade',
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+        ]);
+
+        $data = [
+            'total' => count($all->posts),
+            'ativos' => 0,
+            'inativos' => 0,
+            'adimplentes' => 0,
+            'inadimplentes' => 0,
+            'por_uf' => [],
+            'faturamento_total' => 0.0,
+            'faturamento_pago' => 0.0,
+            'tickets_pagos' => 0,
+            'ticket_medio_pago' => 0.0,
+            'inadimplencia_percentual' => 0.0,
+            'adimplencia_percentual' => 0.0,
+        ];
+
+        foreach ($all->posts as $id) {
+            $governance = get_post_meta($id, 'governance_status', true);
+            $finance = get_post_meta($id, 'finance_status', true);
+            $uf = $this->normalized_uf((string) get_post_meta($id, 'uf', true));
+
+            $data['por_uf'][$uf] = ($data['por_uf'][$uf] ?? 0) + 1;
+            if ($governance === 'aprovado') {
+                $data['ativos']++;
+            } else {
+                $data['inativos']++;
+            }
+
+            if ($finance === 'adimplente') {
+                $data['adimplentes']++;
+            } else {
+                $data['inadimplentes']++;
+            }
+
+            $history = get_post_meta($id, 'finance_history', true);
+            $history = is_array($history) ? $history : [];
+            foreach ($history as $event) {
+                $value = (float) ($event['total'] ?? 0);
+                $data['faturamento_total'] += $value;
+                if ((string) ($event['finance_status'] ?? '') === 'adimplente') {
+                    $data['faturamento_pago'] += $value;
+                    $data['tickets_pagos']++;
+                }
+            }
+        }
+
+        if ($data['tickets_pagos'] > 0) {
+            $data['ticket_medio_pago'] = round($data['faturamento_pago'] / $data['tickets_pagos'], 2);
+        }
+
+        if ($data['total'] > 0) {
+            $data['inadimplencia_percentual'] = round(($data['inadimplentes'] / $data['total']) * 100, 2);
+            $data['adimplencia_percentual'] = round(($data['adimplentes'] / $data['total']) * 100, 2);
+        }
+
+        ksort($data['por_uf']);
+
+        wp_reset_postdata();
+
+        return new WP_REST_Response($data);
+    }
+
+    public function export_csv(): WP_REST_Response {
+        $query = new WP_Query([
+            'post_type' => 'rma_entidade',
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+        ]);
+
+        $lines = ['id,nome,uf,governance_status,finance_status'];
+        foreach ($query->posts as $id) {
+            $id = (int) $id;
+            $line = [
+                $id,
+                $this->csv_quoted($this->csv_safe(get_the_title($id))),
+                $this->csv_quoted($this->csv_safe($this->normalized_uf((string) get_post_meta($id, 'uf', true)))),
+                $this->csv_quoted($this->csv_safe((string) get_post_meta($id, 'governance_status', true))),
+                $this->csv_quoted($this->csv_safe((string) get_post_meta($id, 'finance_status', true))),
+            ];
+            $lines[] = implode(',', $line);
+        }
+
+        wp_reset_postdata();
+
+        return new WP_REST_Response([
+            'filename' => 'rma-entities-' . gmdate('Ymd-His') . '.csv',
+            'csv' => implode("\n", $lines),
+        ]);
+    }
+
+
+    private function normalized_uf(string $value): string {
+        $uf = strtoupper(trim($value));
+
+        if (! preg_match('/^[A-Z]{2}$/', $uf)) {
+            return 'N/D';
+        }
+
+        return $uf;
+    }
+
+
+    private function csv_quoted(string $value): string {
+        return '"' . str_replace('"', '""', $value) . '"';
+    }
+
+    private function csv_safe(string $value): string {
+        $trimmed = trim($value);
+        if ($trimmed !== '' && in_array($trimmed[0], ['=', '+', '-', '@'], true)) {
+            return "'" . $trimmed;
+        }
+
+        return $trimmed;
+    }
+}
+
+new RMA_Analytics();

--- a/wp-content/plugins/rma-automations/rma-automations.php
+++ b/wp-content/plugins/rma-automations/rma-automations.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Plugin Name: RMA Automations
+ * Description: Rotinas de e-mail via WP-Cron para renovação e mandato com logs de envio.
+ * Version: 0.5.0
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Automations {
+    public function __construct() {
+        add_action('init', [$this, 'schedule_cron']);
+        add_action('rma_daily_automation', [$this, 'run_daily_automation']);
+    }
+
+    public function schedule_cron(): void {
+        if (! wp_next_scheduled('rma_daily_automation')) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', 'rma_daily_automation');
+        }
+    }
+
+    public function run_daily_automation(): void {
+        $paged = 1;
+        do {
+            $query = new WP_Query([
+                'post_type' => 'rma_entidade',
+                'post_status' => ['publish', 'draft'],
+                'posts_per_page' => 500,
+                'paged' => $paged,
+                'fields' => 'ids',
+            ]);
+
+            foreach ($query->posts as $entity_id) {
+                $entity_id = (int) $entity_id;
+                $author_id = (int) get_post_field('post_author', $entity_id);
+                $email = get_the_author_meta('user_email', $author_id);
+                if (! is_email($email)) {
+                    continue;
+                }
+
+                $governance = get_post_meta($entity_id, 'governance_status', true);
+                $mandato_fim = (string) get_post_meta($entity_id, 'mandato_fim', true);
+                if ($governance === 'aprovado' && $this->is_days_before($mandato_fim, [60, 30, 7])) {
+                    $this->notify_once_daily($email, 'Mandato próximo do vencimento', 'Seu mandato está próximo do vencimento.', $entity_id, 'mandato');
+                }
+
+                $finance = (string) get_post_meta($entity_id, 'finance_status', true);
+                $anuidade_vencimento = (string) get_post_meta($entity_id, 'anuidade_vencimento', true);
+                if ($anuidade_vencimento === '') {
+                    $anuidade_vencimento = (string) get_post_meta($entity_id, 'finance_due_at', true);
+                }
+
+                if ($governance === 'aprovado' && $anuidade_vencimento !== '') {
+                    $days_to_due = $this->days_until($anuidade_vencimento);
+
+                    if ($finance === 'adimplente' && $days_to_due === 30) {
+                        $this->notify_once_daily($email, 'Renovação da anuidade em 30 dias', 'Sua anuidade vencerá em 30 dias. Gere o PIX de renovação para evitar interrupções.', $entity_id, 'anuidade_30dias');
+                    }
+
+                    if ($days_to_due < 0 && $finance !== 'adimplente') {
+                        $this->notify_once_daily($email, 'Anuidade em atraso', 'Identificamos pendência na sua anuidade. Gere seu PIX no painel para regularizar.', $entity_id, 'anuidade_atraso');
+                    }
+
+                    if ($days_to_due <= -5) {
+                        update_post_meta($entity_id, 'finance_status', 'inadimplente');
+                        update_post_meta($entity_id, 'finance_access_status', 'blocked');
+                        $this->notify_once_daily($email, 'Serviços temporariamente bloqueados', 'Sua anuidade está com mais de 5 dias de atraso. O acesso foi temporariamente bloqueado até a regularização.', $entity_id, 'anuidade_bloqueio');
+                    }
+                }
+            }
+
+            $paged++;
+        } while ($paged <= (int) $query->max_num_pages);
+
+        wp_reset_postdata();
+    }
+
+    private function is_days_before(string $date, array $days): bool {
+        if ($date === '') {
+            return false;
+        }
+
+        $target = strtotime($date);
+        if (! $target) {
+            return false;
+        }
+
+        $today = strtotime(gmdate('Y-m-d'));
+        $diff_days = (int) floor(($target - $today) / DAY_IN_SECONDS);
+
+        return in_array($diff_days, $days, true);
+    }
+
+    private function days_until(string $date): int {
+        $target = strtotime($date);
+        if (! $target) {
+            return 9999;
+        }
+
+        $today = strtotime(gmdate('Y-m-d'));
+        return (int) floor(($target - $today) / DAY_IN_SECONDS);
+    }
+
+    private function notify_once_daily(string $email, string $subject, string $message, int $entity_id, string $context): void {
+        $day_key = 'rma_mail_sent_' . md5($entity_id . '|' . $context . '|' . gmdate('Y-m-d'));
+        if (get_transient($day_key)) {
+            return;
+        }
+
+        $sent = $this->send_email($email, $subject, $message);
+        if ($sent) {
+            set_transient($day_key, 1, DAY_IN_SECONDS + HOUR_IN_SECONDS);
+        }
+
+        $logs = get_post_meta($entity_id, 'automation_logs', true);
+        $logs = is_array($logs) ? $logs : [];
+        $logs[] = [
+            'context' => $context,
+            'email' => $email,
+            'subject' => $subject,
+            'sent' => $sent,
+            'datetime' => current_time('mysql', true),
+        ];
+
+        $max_logs = 200;
+        if (count($logs) > $max_logs) {
+            $logs = array_slice($logs, -1 * $max_logs);
+        }
+
+        update_post_meta($entity_id, 'automation_logs', $logs);
+    }
+
+    private function send_email(string $email, string $subject, string $message): bool {
+        $sender_mode = (string) get_option('rma_email_sender_mode', 'wp_mail');
+
+        if ($sender_mode === 'woo_mail' && function_exists('WC') && WC() && method_exists(WC(), 'mailer')) {
+            $mailer = WC()->mailer();
+            if ($mailer) {
+                $wrapped = method_exists($mailer, 'wrap_message') ? $mailer->wrap_message($subject, nl2br(esc_html($message))) : $message;
+                $headers = ['Content-Type: text/html; charset=UTF-8'];
+
+                return (bool) $mailer->send($email, $subject, $wrapped, $headers, []);
+            }
+        }
+
+        return (bool) wp_mail($email, $subject, $message);
+    }
+
+    public static function deactivate(): void {
+        wp_clear_scheduled_hook('rma_daily_automation');
+    }
+}
+
+register_deactivation_hook(__FILE__, ['RMA_Automations', 'deactivate']);
+new RMA_Automations();

--- a/wp-content/plugins/rma-core-entities/rma-core-entities.php
+++ b/wp-content/plugins/rma-core-entities/rma-core-entities.php
@@ -1,0 +1,897 @@
+<?php
+/**
+ * Plugin Name: RMA Core Entities
+ * Description: Entidades centrais da RMA: CPT, metadados, validação/autopreenchimento de CNPJ e endpoint interno.
+ * Version: 0.4.3
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Core_Entities {
+    private const CPT = 'rma_entidade';
+    private const CNPJ_API = 'https://brasilapi.com.br/api/cnpj/v1/';
+    private const MAX_DOCUMENT_SIZE = 10485760; // 10MB
+    private const MAX_DOCUMENTS_PER_ENTITY = 30;
+
+    public function __construct() {
+        add_action('init', [$this, 'register_post_type']);
+        add_action('init', [$this, 'register_entity_meta']);
+        add_action('rest_api_init', [$this, 'register_rest_routes']);
+    }
+
+    public function register_post_type(): void {
+        register_post_type(self::CPT, [
+            'labels' => [
+                'name' => 'Entidades',
+                'singular_name' => 'Entidade',
+            ],
+            'public' => false,
+            'show_ui' => true,
+            'show_in_rest' => true,
+            'supports' => ['title', 'editor', 'author'],
+            'menu_icon' => 'dashicons-groups',
+        ]);
+    }
+
+    public function register_entity_meta(): void {
+        $meta_fields = [
+            'cnpj' => 'string',
+            'razao_social' => 'string',
+            'nome_fantasia' => 'string',
+            'cnae_principal' => 'string',
+            'email_contato' => 'string',
+            'telefone_contato' => 'string',
+            'cep' => 'string',
+            'logradouro' => 'string',
+            'numero' => 'string',
+            'complemento' => 'string',
+            'bairro' => 'string',
+            'cidade' => 'string',
+            'uf' => 'string',
+            'lat' => 'number',
+            'lng' => 'number',
+            'governance_status' => 'string',
+            'finance_status' => 'string',
+            'mandato_fim' => 'string',
+            'documentos_status' => 'string',
+            'consent_lgpd' => 'boolean',
+        ];
+
+        foreach ($meta_fields as $field => $type) {
+            register_post_meta(self::CPT, $field, [
+                'type' => $type,
+                'single' => true,
+                'show_in_rest' => true,
+                'auth_callback' => static function () {
+                    return current_user_can('edit_posts');
+                },
+                'sanitize_callback' => function ($value) use ($field) {
+                    return $this->sanitize_meta_value($field, $value);
+                },
+            ]);
+        }
+    }
+
+    public function sanitize_meta_value(string $field, $value) {
+        if ($field === 'consent_lgpd') {
+            return (bool) rest_sanitize_boolean($value);
+        }
+
+        if ($field === 'lat' || $field === 'lng') {
+            return is_numeric($value) ? (float) $value : 0.0;
+        }
+
+        if ($field === 'email_contato') {
+            return sanitize_email((string) $value);
+        }
+
+        if ($field === 'telefone_contato') {
+            return preg_replace('/[^0-9\+\-\(\)\s]/', '', (string) $value);
+        }
+
+        if ($field === 'cnpj') {
+            return preg_replace('/\D+/', '', (string) $value);
+        }
+
+        return sanitize_text_field((string) $value);
+    }
+
+    public function register_rest_routes(): void {
+        register_rest_route('rma/v1', '/cnpj/(?P<cnpj>[0-9\.\/-]+)', [
+            'methods' => 'GET',
+            'callback' => [$this, 'lookup_cnpj'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('rma/v1', '/entities', [
+            'methods' => 'POST',
+            'callback' => [$this, 'create_entity'],
+            'permission_callback' => [$this, 'can_create_entity'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/documents', [
+            'methods' => 'GET',
+            'callback' => [$this, 'list_documents'],
+            'permission_callback' => [$this, 'can_manage_documents'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/documents', [
+            'methods' => 'POST',
+            'callback' => [$this, 'upload_document'],
+            'permission_callback' => [$this, 'can_manage_documents'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/documents/(?P<doc_id>[a-f0-9\-]+)', [
+            'methods' => 'GET',
+            'callback' => [$this, 'download_document'],
+            'permission_callback' => [$this, 'can_manage_documents'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/documents/(?P<doc_id>[a-f0-9\-]+)', [
+            'methods' => 'DELETE',
+            'callback' => [$this, 'delete_document'],
+            'permission_callback' => [$this, 'can_manage_documents'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/status', [
+            'methods' => 'GET',
+            'callback' => [$this, 'entity_status'],
+            'permission_callback' => [$this, 'can_manage_documents'],
+        ]);
+
+        register_rest_route('rma/v1', '/onboarding/status', [
+            'methods' => 'GET',
+            'callback' => [$this, 'current_onboarding_status'],
+            'permission_callback' => function () {
+                return is_user_logged_in();
+            },
+        ]);
+    }
+
+    public function lookup_cnpj(WP_REST_Request $request): WP_REST_Response {
+        $rate = $this->check_rate_limit('lookup_cnpj', 30, 5 * MINUTE_IN_SECONDS);
+        if (is_wp_error($rate)) {
+            return new WP_REST_Response(['message' => $rate->get_error_message()], 429);
+        }
+
+        $raw = (string) $request->get_param('cnpj');
+        $cnpj = preg_replace('/\D+/', '', $raw);
+
+        if (! $this->is_valid_cnpj($cnpj)) {
+            return new WP_REST_Response([
+                'valid' => false,
+                'message' => 'CNPJ inválido.',
+            ], 422);
+        }
+
+        $status_data = $this->validate_cnpj_exists_and_active($cnpj);
+        if (is_wp_error($status_data)) {
+            return new WP_REST_Response([
+                'valid' => false,
+                'message' => $status_data->get_error_message(),
+            ], $this->cnpj_error_to_http_status($status_data));
+        }
+
+        return new WP_REST_Response([
+            'valid' => true,
+            'cnpj' => $cnpj,
+            'razao_social' => $status_data['razao_social'] ?? '',
+            'nome_fantasia' => $status_data['nome_fantasia'] ?? '',
+            'cnae_principal' => $status_data['cnae_principal'] ?? '',
+            'cep' => $status_data['cep'] ?? '',
+            'logradouro' => $status_data['logradouro'] ?? '',
+            'numero' => $status_data['numero'] ?? '',
+            'complemento' => $status_data['complemento'] ?? '',
+            'bairro' => $status_data['bairro'] ?? '',
+            'cidade' => $status_data['cidade'] ?? '',
+            'uf' => $status_data['uf'] ?? '',
+            'status' => 'ATIVA',
+        ]);
+    }
+
+    public function create_entity(WP_REST_Request $request): WP_REST_Response {
+        $user_id = get_current_user_id();
+        if ($user_id <= 0) {
+            return new WP_REST_Response(['message' => 'Usuário não autenticado.'], 401);
+        }
+
+        $rate = $this->check_rate_limit('create_entity', 10, 5 * MINUTE_IN_SECONDS);
+        if (is_wp_error($rate)) {
+            return new WP_REST_Response(['message' => $rate->get_error_message()], 429);
+        }
+
+        $params = $request->get_json_params();
+        $params = is_array($params) ? $params : [];
+        if (empty($params)) {
+            $fallback_params = $request->get_params();
+            $params = is_array($fallback_params) ? $fallback_params : [];
+        }
+
+        $consent_lgpd = rest_sanitize_boolean($params['consent_lgpd'] ?? false);
+        if (! $consent_lgpd) {
+            return new WP_REST_Response(['message' => 'Consentimento LGPD obrigatório.'], 422);
+        }
+
+        $cnpj = preg_replace('/\D+/', '', (string) ($params['cnpj'] ?? ''));
+        if (! $this->is_valid_cnpj($cnpj)) {
+            return new WP_REST_Response(['message' => 'CNPJ inválido.'], 422);
+        }
+
+        if ($this->entity_exists_by_cnpj($cnpj)) {
+            return new WP_REST_Response(['message' => 'Já existe entidade cadastrada para este CNPJ.'], 409);
+        }
+
+        $cnpj_status = $this->validate_cnpj_exists_and_active($cnpj);
+        if (is_wp_error($cnpj_status)) {
+            return new WP_REST_Response(['message' => $cnpj_status->get_error_message()], $this->cnpj_error_to_http_status($cnpj_status));
+        }
+
+        $official_razao = sanitize_text_field((string) ($cnpj_status['razao_social'] ?? ''));
+        $official_uf = strtoupper(sanitize_text_field((string) ($cnpj_status['uf'] ?? '')));
+
+        $razao = $official_razao !== '' ? $official_razao : sanitize_text_field((string) ($params['razao_social'] ?? ''));
+        $uf = $official_uf !== '' ? $official_uf : strtoupper(sanitize_text_field((string) ($params['uf'] ?? '')));
+        if ($razao === '' || ! preg_match('/^[A-Z]{2}$/', $uf)) {
+            return new WP_REST_Response(['message' => 'Dados obrigatórios ausentes (razão social e UF).'], 422);
+        }
+
+        if (! empty($params['email_contato']) && ! is_email((string) $params['email_contato'])) {
+            return new WP_REST_Response(['message' => 'E-mail de contato inválido.'], 422);
+        }
+
+        $params['consent_lgpd'] = $consent_lgpd;
+
+        $post_id = wp_insert_post([
+            'post_type' => self::CPT,
+            'post_status' => 'draft',
+            'post_author' => $user_id,
+            'post_title' => $razao,
+            'post_content' => sanitize_textarea_field((string) ($params['descricao'] ?? '')),
+        ], true);
+
+        if (is_wp_error($post_id)) {
+            return new WP_REST_Response(['message' => 'Não foi possível cadastrar a entidade.'], 500);
+        }
+
+        $whitelist = [
+            'cnpj', 'razao_social', 'nome_fantasia', 'cnae_principal', 'email_contato', 'telefone_contato',
+            'cep', 'logradouro', 'numero', 'complemento', 'bairro', 'cidade', 'uf', 'lat', 'lng',
+            'mandato_fim', 'consent_lgpd',
+        ];
+
+        foreach ($whitelist as $field) {
+            if (array_key_exists($field, $params)) {
+                update_post_meta($post_id, $field, $this->sanitize_meta_value($field, $params[$field]));
+            }
+        }
+
+        if ($official_razao !== '') {
+            update_post_meta($post_id, 'razao_social', $official_razao);
+            wp_update_post([
+                'ID' => $post_id,
+                'post_title' => $official_razao,
+            ]);
+        }
+
+        if (! empty($cnpj_status['nome_fantasia'])) {
+            update_post_meta($post_id, 'nome_fantasia', sanitize_text_field((string) $cnpj_status['nome_fantasia']));
+        }
+
+        if ($official_uf !== '') {
+            update_post_meta($post_id, 'uf', $official_uf);
+        }
+
+        if (! empty($cnpj_status['cidade'])) {
+            update_post_meta($post_id, 'cidade', sanitize_text_field((string) $cnpj_status['cidade']));
+        }
+
+        $official_meta_map = [
+            'cnae_principal' => 'cnae_principal',
+            'cep' => 'cep',
+            'logradouro' => 'logradouro',
+            'numero' => 'numero',
+            'complemento' => 'complemento',
+            'bairro' => 'bairro',
+        ];
+
+        foreach ($official_meta_map as $target_meta => $source_key) {
+            if (! empty($cnpj_status[$source_key])) {
+                update_post_meta($post_id, $target_meta, sanitize_text_field((string) $cnpj_status[$source_key]));
+            }
+        }
+
+        update_post_meta($post_id, 'cnpj_validated_at', current_time('mysql', true));
+        update_post_meta($post_id, 'governance_status', 'pendente');
+        update_post_meta($post_id, 'finance_status', 'pendente');
+        update_post_meta($post_id, 'documentos_status', 'pendente');
+
+        do_action('rma/entity_created', $post_id, $params);
+
+        return new WP_REST_Response([
+            'post_id' => $post_id,
+            'status' => 'pendente',
+            'message' => 'Cadastro enviado para análise.',
+        ], 201);
+    }
+
+
+    public function can_create_entity(): bool {
+        return is_user_logged_in();
+    }
+
+    public function can_manage_documents(WP_REST_Request $request): bool {
+        if (! is_user_logged_in()) {
+            return false;
+        }
+
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return false;
+        }
+
+        if (current_user_can('edit_others_posts')) {
+            return true;
+        }
+
+        return (int) get_post_field('post_author', $entity_id) === get_current_user_id();
+    }
+
+    public function list_documents(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $docs = get_post_meta($entity_id, 'entity_documents', true);
+        $docs = is_array($docs) ? $docs : [];
+
+        $response_docs = [];
+        foreach ($docs as $doc) {
+            $response_docs[] = [
+                'id' => $doc['id'] ?? '',
+                'name' => $doc['name'] ?? '',
+                'size' => (int) ($doc['size'] ?? 0),
+                'uploaded_at' => $doc['uploaded_at'] ?? '',
+                'uploaded_by' => (int) ($doc['uploaded_by'] ?? 0),
+                'document_type' => (string) ($doc['document_type'] ?? ''),
+            ];
+        }
+
+        return new WP_REST_Response($response_docs);
+    }
+
+    public function upload_document(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $rate = $this->check_rate_limit('document_upload', 40, 5 * MINUTE_IN_SECONDS);
+        if (is_wp_error($rate)) {
+            return new WP_REST_Response(['message' => $rate->get_error_message()], 429);
+        }
+
+        $file = $_FILES['file'] ?? null;
+
+        if (! is_array($file) || empty($file['tmp_name'])) {
+            return new WP_REST_Response(['message' => 'Arquivo obrigatório.'], 422);
+        }
+
+        if (! empty($file['error']) && (int) $file['error'] !== UPLOAD_ERR_OK) {
+            return new WP_REST_Response(['message' => 'Falha no upload do arquivo.'], 422);
+        }
+
+        if (! is_uploaded_file((string) $file['tmp_name'])) {
+            return new WP_REST_Response(['message' => 'Upload inválido.'], 422);
+        }
+
+        if (! is_readable((string) $file['tmp_name'])) {
+            return new WP_REST_Response(['message' => 'Não foi possível ler o arquivo enviado.'], 422);
+        }
+
+        if ((int) $file['size'] <= 0 || (int) $file['size'] > self::MAX_DOCUMENT_SIZE) {
+            return new WP_REST_Response(['message' => 'Arquivo inválido: tamanho máximo 10MB.'], 422);
+        }
+
+        $finfo = function_exists('finfo_open') ? finfo_open(FILEINFO_MIME_TYPE) : false;
+        $mime = $finfo ? (string) finfo_file($finfo, $file['tmp_name']) : '';
+        if ($finfo) {
+            finfo_close($finfo);
+        }
+
+        $filetype = wp_check_filetype((string) ($file['name'] ?? ''));
+        $checked = wp_check_filetype_and_ext((string) $file['tmp_name'], (string) ($file['name'] ?? ''));
+        $extension = strtolower((string) ($filetype['ext'] ?? ''));
+        $checked_type = strtolower((string) ($checked['type'] ?? ''));
+
+        $allowed_extensions = ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp', 'doc', 'docx'];
+        $allowed_mimes = [
+            'application/pdf',
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+            'application/msword',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/octet-stream',
+        ];
+
+        $mime_ok = in_array($mime, $allowed_mimes, true) || in_array($checked_type, $allowed_mimes, true);
+        $ext_ok = in_array($extension, $allowed_extensions, true);
+
+        if (! $mime_ok || ! $ext_ok) {
+            return new WP_REST_Response([
+                'message' => 'Formato não permitido. Envie PDF, imagem (JPG/PNG/GIF/WEBP) ou Word (DOC/DOCX).',
+            ], 422);
+        }
+
+        $document_type = sanitize_key((string) $request->get_param('document_type'));
+        if ($document_type !== '' && ! in_array($document_type, $this->allowed_document_types(), true)) {
+            return new WP_REST_Response(['message' => 'Tipo de documento inválido.'], 422);
+        }
+
+        $upload_dir = wp_upload_dir();
+        if (! empty($upload_dir['error'])) {
+            return new WP_REST_Response(['message' => 'Diretório de upload indisponível.'], 500);
+        }
+
+        $docs = get_post_meta($entity_id, 'entity_documents', true);
+        $docs = is_array($docs) ? $docs : [];
+
+        if ($document_type !== '') {
+            $docs = array_values(array_filter($docs, function ($doc) use ($document_type) {
+                return (string) ($doc['document_type'] ?? '') !== $document_type;
+            }));
+        }
+
+        if (count($docs) >= self::MAX_DOCUMENTS_PER_ENTITY) {
+            return new WP_REST_Response([
+                'message' => 'Limite de documentos por entidade atingido (30). Remova um arquivo antes de enviar outro.',
+            ], 409);
+        }
+
+        $private_base = trailingslashit($upload_dir['basedir']) . 'rma-private/' . $entity_id;
+        if (! wp_mkdir_p($private_base)) {
+            return new WP_REST_Response(['message' => 'Não foi possível preparar o diretório privado.'], 500);
+        }
+
+        $this->protect_directory($private_base);
+
+        $original_name = sanitize_file_name((string) $file['name']);
+        if ($original_name === '') {
+            $original_name = 'documento';
+        }
+
+        $doc_id = wp_generate_uuid4();
+        $safe_name = $doc_id . '-' . $original_name;
+        $target = trailingslashit($private_base) . $safe_name;
+
+        if (! move_uploaded_file($file['tmp_name'], $target)) {
+            return new WP_REST_Response(['message' => 'Falha ao salvar documento.'], 500);
+        }
+
+        $docs[] = [
+            'id' => $doc_id,
+            'name' => $original_name,
+            'path' => $target,
+            'size' => (int) $file['size'],
+            'uploaded_by' => get_current_user_id(),
+            'uploaded_at' => current_time('mysql', true),
+            'document_type' => $document_type,
+            'mime' => $mime,
+        ];
+
+        update_post_meta($entity_id, 'entity_documents', $docs);
+
+        $rejected_types = get_post_meta($entity_id, 'documentos_reprovados', true);
+        $rejected_types = is_array($rejected_types) ? array_values(array_filter(array_map('sanitize_key', $rejected_types))) : [];
+        if ($document_type !== '' && ! empty($rejected_types)) {
+            $rejected_types = array_values(array_filter($rejected_types, function ($item) use ($document_type) {
+                return $item !== $document_type;
+            }));
+            update_post_meta($entity_id, 'documentos_reprovados', $rejected_types);
+        }
+
+        update_post_meta($entity_id, 'documentos_status', empty($rejected_types) ? 'enviado' : 'pendente_reenvio');
+
+        do_action('rma/entity_document_uploaded', $entity_id, $doc_id, $original_name);
+
+        return new WP_REST_Response([
+            'message' => 'Documento enviado com sucesso.',
+            'document_id' => $doc_id,
+            'name' => $original_name,
+        ], 201);
+    }
+
+    public function download_document(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $rate = $this->check_rate_limit('document_download', 120, 5 * MINUTE_IN_SECONDS);
+        if (is_wp_error($rate)) {
+            return new WP_REST_Response(['message' => $rate->get_error_message()], 429);
+        }
+
+        $doc_id = sanitize_text_field((string) $request->get_param('doc_id'));
+
+        $docs = get_post_meta($entity_id, 'entity_documents', true);
+        $docs = is_array($docs) ? $docs : [];
+
+        $selected = null;
+        foreach ($docs as $doc) {
+            if (($doc['id'] ?? '') === $doc_id) {
+                $selected = $doc;
+                break;
+            }
+        }
+
+        if (! is_array($selected) || empty($selected['path'])) {
+            return new WP_REST_Response(['message' => 'Documento não encontrado.'], 404);
+        }
+
+        $upload_dir = wp_upload_dir();
+        $expected_base = trailingslashit($upload_dir['basedir']) . 'rma-private/' . $entity_id;
+
+        $path = (string) $selected['path'];
+        $real_file = realpath($path);
+        $real_base = realpath($expected_base);
+
+        if (! $real_file || ! $real_base || strpos($real_file, $real_base) !== 0 || ! file_exists($real_file)) {
+            return new WP_REST_Response(['message' => 'Documento não encontrado.'], 404);
+        }
+
+        $name = sanitize_file_name((string) ($selected['name'] ?? 'documento'));
+        if ($name === '') {
+            $name = 'documento';
+        }
+
+        $size = @filesize($real_file);
+        if ($size === false || $size < 0) {
+            return new WP_REST_Response(['message' => 'Não foi possível preparar o download do documento.'], 500);
+        }
+
+        nocache_headers();
+        $mime_type = (string) ($selected['mime'] ?? 'application/octet-stream');
+        if ($mime_type === '') {
+            $mime_type = 'application/octet-stream';
+        }
+
+        header('Content-Type: ' . $mime_type);
+        header('X-Content-Type-Options: nosniff');
+        header('Content-Disposition: attachment; filename="' . $name . '"');
+        header('Content-Length: ' . (string) $size);
+        readfile($real_file);
+        exit;
+    }
+
+
+    public function entity_status(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $approvals = get_post_meta($entity_id, 'governance_approvals', true);
+        $approvals = is_array($approvals) ? $approvals : [];
+
+        $governance = (string) get_post_meta($entity_id, 'governance_status', true);
+        $finance = (string) get_post_meta($entity_id, 'finance_status', true);
+        $docs_status = (string) get_post_meta($entity_id, 'documentos_status', true);
+
+        $pending_items = [];
+        if ($governance !== 'aprovado') {
+            $pending_items[] = 'governanca';
+        }
+        if ($finance !== 'adimplente') {
+            $pending_items[] = 'financeiro';
+        }
+        if ($docs_status !== 'enviado') {
+            $pending_items[] = 'documentos';
+        }
+
+        $documents = get_post_meta($entity_id, 'entity_documents', true);
+        $documents = is_array($documents) ? $documents : [];
+
+        $rejected_types = get_post_meta($entity_id, 'documentos_reprovados', true);
+        $rejected_types = is_array($rejected_types) ? array_values(array_filter(array_map('sanitize_key', $rejected_types))) : [];
+
+        $next_actions = [];
+        if (in_array('documentos', $pending_items, true)) {
+            $next_actions[] = ! empty($rejected_types)
+                ? 'Reenvie apenas os documentos reprovados pela Equipe RMA.'
+                : 'Envie os documentos obrigatórios (PDF, imagem ou Word).';
+        }
+        if (in_array('governanca', $pending_items, true)) {
+            $next_actions[] = 'Aguarde análise da governança RMA.';
+        }
+        if (in_array('financeiro', $pending_items, true) && $governance === 'aprovado') {
+            $next_actions[] = 'Regularize a anuidade via PIX para manter a adimplência.';
+        }
+
+        $approvals_count = count($approvals);
+        $approvals_remaining = max(0, 3 - $approvals_count);
+        $publish_eligible = $governance === 'aprovado' && $finance === 'adimplente';
+
+        return new WP_REST_Response([
+            'entity_id' => $entity_id,
+            'governance_status' => $governance,
+            'finance_status' => $finance,
+            'documentos_status' => $docs_status,
+            'documents_count' => count($documents),
+            'rejected_document_types' => $rejected_types,
+            'cnpj_validated_at' => (string) get_post_meta($entity_id, 'cnpj_validated_at', true),
+            'rejection_reason' => (string) get_post_meta($entity_id, 'governance_rejection_reason', true),
+            'approvals_count' => $approvals_count,
+            'approvals_remaining' => $approvals_remaining,
+            'publish_eligible' => $publish_eligible,
+            'pending_items' => $pending_items,
+            'next_actions' => $next_actions,
+        ]);
+    }
+
+
+    public function current_onboarding_status(): WP_REST_Response {
+        $user_id = get_current_user_id();
+        if ($user_id <= 0) {
+            return new WP_REST_Response(['message' => 'Usuário não autenticado.'], 401);
+        }
+
+        $query = new WP_Query([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft', 'pending', 'private'],
+            'author' => $user_id,
+            'posts_per_page' => 1,
+            'fields' => 'ids',
+            'no_found_rows' => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+        ]);
+
+        $entity_id = ! empty($query->posts) ? (int) $query->posts[0] : 0;
+        if ($entity_id <= 0) {
+            return new WP_REST_Response([
+                'entity_id' => 0,
+                'governance_status' => 'pendente',
+                'finance_status' => 'pendente',
+                'documentos_status' => 'pendente',
+                'rejected_document_types' => [],
+            ]);
+        }
+
+        $request = new WP_REST_Request('GET', '/rma/v1/entities/' . $entity_id . '/status');
+        $request->set_param('id', $entity_id);
+
+        return $this->entity_status($request);
+    }
+
+
+    private function allowed_document_types(): array {
+        return [
+            'ficha_inscricao',
+            'comprovante_cnpj',
+            'ata_fundacao',
+            'ata_diretoria',
+            'estatuto',
+            'relatorio_atividades',
+            'cartas_recomendacao',
+        ];
+    }
+
+    public function delete_document(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $rate = $this->check_rate_limit('document_delete', 60, 5 * MINUTE_IN_SECONDS);
+        if (is_wp_error($rate)) {
+            return new WP_REST_Response(['message' => $rate->get_error_message()], 429);
+        }
+
+        $doc_id = sanitize_text_field((string) $request->get_param('doc_id'));
+
+        $docs = get_post_meta($entity_id, 'entity_documents', true);
+        $docs = is_array($docs) ? $docs : [];
+
+        $kept = [];
+        $deleted = null;
+        foreach ($docs as $doc) {
+            if (($doc['id'] ?? '') === $doc_id) {
+                $deleted = $doc;
+                continue;
+            }
+            $kept[] = $doc;
+        }
+
+        if (! is_array($deleted)) {
+            return new WP_REST_Response(['message' => 'Documento não encontrado.'], 404);
+        }
+
+        $path = (string) ($deleted['path'] ?? '');
+        $upload_dir = wp_upload_dir();
+        $expected_base = trailingslashit($upload_dir['basedir']) . 'rma-private/' . $entity_id;
+        $real_file = realpath($path);
+        $real_base = realpath($expected_base);
+
+        if ($real_file && $real_base && strpos($real_file, $real_base) === 0 && file_exists($real_file)) {
+            wp_delete_file($real_file);
+        }
+
+        update_post_meta($entity_id, 'entity_documents', $kept);
+        if (empty($kept)) {
+            update_post_meta($entity_id, 'documentos_status', 'pendente');
+        }
+
+        do_action('rma/entity_document_deleted', $entity_id, $doc_id, $deleted);
+
+        return new WP_REST_Response([
+            'message' => 'Documento removido com sucesso.',
+            'document_id' => $doc_id,
+        ]);
+    }
+
+    private function protect_directory(string $directory): void {
+        $index = trailingslashit($directory) . 'index.html';
+        if (! file_exists($index)) {
+            file_put_contents($index, '');
+        }
+
+        $htaccess = trailingslashit($directory) . '.htaccess';
+        if (! file_exists($htaccess)) {
+            file_put_contents($htaccess, "Deny from all\n");
+        }
+    }
+
+    private function check_rate_limit(string $scope, int $max, int $ttl) {
+        $subject = $this->rate_limit_subject();
+        $key = 'rma_rate_' . $scope . '_' . md5($subject);
+        $count = (int) get_transient($key);
+
+        if ($count >= $max) {
+            return new WP_Error('rma_rate_limit', 'Limite de tentativas excedido. Tente novamente em alguns minutos.');
+        }
+
+        set_transient($key, $count + 1, $ttl);
+
+        return true;
+    }
+
+
+    private function rate_limit_subject(): string {
+        $user_id = get_current_user_id();
+        if ($user_id > 0) {
+            return 'user:' . $user_id;
+        }
+
+        $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+        if ($ip !== '' && filter_var($ip, FILTER_VALIDATE_IP)) {
+            return 'ip:' . $ip;
+        }
+
+        $ua = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : 'unknown';
+
+        return 'fallback:' . md5($ua);
+    }
+
+    private function entity_exists_by_cnpj(string $cnpj): bool {
+        $query = new WP_Query([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft', 'pending', 'private'],
+            'fields' => 'ids',
+            'posts_per_page' => 1,
+            'meta_query' => [
+                [
+                    'key' => 'cnpj',
+                    'value' => $cnpj,
+                ],
+            ],
+        ]);
+
+        return ! empty($query->posts);
+    }
+
+
+    private function cnpj_error_to_http_status(WP_Error $error): int {
+        $code = (string) $error->get_error_code();
+        if ($code === 'rma_cnpj_lookup_failed') {
+            return 503;
+        }
+
+        if ($code === 'rma_cnpj_not_found') {
+            return 404;
+        }
+
+        if ($code === 'rma_cnpj_inactive') {
+            return 422;
+        }
+
+        return 422;
+    }
+
+    private function validate_cnpj_exists_and_active(string $cnpj) {
+        $cache_key = 'rma_cnpj_ok_' . $cnpj;
+        $cached = get_transient($cache_key);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $response = wp_remote_get(self::CNPJ_API . $cnpj, [
+            'timeout' => 12,
+        ]);
+
+        if (is_wp_error($response)) {
+            return new WP_Error('rma_cnpj_lookup_failed', 'Não foi possível validar o CNPJ no momento.');
+        }
+
+        $status_code = (int) wp_remote_retrieve_response_code($response);
+        $body = json_decode((string) wp_remote_retrieve_body($response), true);
+
+        if ($status_code === 404) {
+            return new WP_Error('rma_cnpj_not_found', 'CNPJ não encontrado na base oficial.');
+        }
+
+        if ($status_code === 429 || $status_code >= 500) {
+            return new WP_Error('rma_cnpj_lookup_failed', 'Serviço de validação de CNPJ temporariamente indisponível.');
+        }
+
+        if ($status_code >= 400 || ! is_array($body)) {
+            return new WP_Error('rma_cnpj_lookup_failed', 'Não foi possível validar o CNPJ no momento.');
+        }
+
+        $situacao = strtoupper((string) ($body['descricao_situacao_cadastral'] ?? ''));
+        if ($situacao !== '' && $situacao !== 'ATIVA') {
+            return new WP_Error('rma_cnpj_inactive', 'CNPJ encontrado, porém não está ativo.');
+        }
+
+        $payload = [
+            'razao_social' => $body['razao_social'] ?? '',
+            'nome_fantasia' => $body['nome_fantasia'] ?? '',
+            'cnae_principal' => $body['cnae_fiscal_descricao'] ?? '',
+            'cep' => $body['cep'] ?? '',
+            'logradouro' => $body['logradouro'] ?? '',
+            'numero' => $body['numero'] ?? '',
+            'complemento' => $body['complemento'] ?? '',
+            'bairro' => $body['bairro'] ?? '',
+            'cidade' => $body['municipio'] ?? '',
+            'uf' => strtoupper((string) ($body['uf'] ?? '')),
+        ];
+
+        set_transient($cache_key, $payload, 12 * HOUR_IN_SECONDS);
+
+        return $payload;
+    }
+
+    private function is_valid_cnpj(string $cnpj): bool {
+        if (! preg_match('/^\d{14}$/', $cnpj)) {
+            return false;
+        }
+
+        if (preg_match('/^(\d)\1{13}$/', $cnpj)) {
+            return false;
+        }
+
+        $weights1 = [5,4,3,2,9,8,7,6,5,4,3,2];
+        $weights2 = [6,5,4,3,2,9,8,7,6,5,4,3,2];
+
+        $sum1 = 0;
+        for ($i = 0; $i < 12; $i++) {
+            $sum1 += intval($cnpj[$i]) * $weights1[$i];
+        }
+        $digit1 = $sum1 % 11 < 2 ? 0 : 11 - ($sum1 % 11);
+
+        $sum2 = 0;
+        for ($i = 0; $i < 13; $i++) {
+            $sum2 += intval($cnpj[$i]) * $weights2[$i];
+        }
+        $digit2 = $sum2 % 11 < 2 ? 0 : 11 - ($sum2 % 11);
+
+        return intval($cnpj[12]) === $digit1 && intval($cnpj[13]) === $digit2;
+    }
+}
+
+new RMA_Core_Entities();

--- a/wp-content/plugins/rma-demo-seeder/rma-demo-seeder.php
+++ b/wp-content/plugins/rma-demo-seeder/rma-demo-seeder.php
@@ -1,0 +1,847 @@
+<?php
+/**
+ * Plugin Name: RMA Demo Seeder
+ * Description: Gera e limpa dados demonstrativos para homologação completa do CRM RMA.
+ * Version: 0.1.0
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Demo_Seeder {
+    private const CPT = 'rma_entidade';
+    private const META_DEMO = 'rma_is_demo';
+
+    public function __construct() {
+        add_action('admin_menu', [$this, 'register_admin_page']);
+        add_action('admin_post_rma_demo_seed', [$this, 'handle_admin_seed']);
+        add_action('admin_post_rma_demo_cleanup', [$this, 'handle_admin_cleanup']);
+        add_action('admin_post_rma_demo_setup_next', [$this, 'handle_admin_setup_next']);
+        add_action('admin_post_rma_demo_setup_reset', [$this, 'handle_admin_setup_reset']);
+
+        if (defined('WP_CLI') && WP_CLI) {
+            \WP_CLI::add_command('rma seed-demo', [$this, 'cli_seed_demo']);
+            \WP_CLI::add_command('rma clear-demo', [$this, 'cli_clear_demo']);
+            \WP_CLI::add_command('rma setup-next', [$this, 'cli_setup_next']);
+        }
+    }
+
+    public function register_admin_page(): void {
+        add_menu_page(
+            'RMA Dados Demonstrativos',
+            'RMA Dados Demonstrativos',
+            'manage_options',
+            'rma-demo-seeder',
+            [$this, 'render_admin_page'],
+            'dashicons-database-add',
+            59
+        );
+    }
+
+    public function render_admin_page(): void {
+        if (! current_user_can('manage_options')) {
+            return;
+        }
+
+        $last = get_option('rma_demo_last_report', []);
+        ?>
+        <div class="wrap">
+          <h1>RMA → Dados Demonstrativos</h1>
+          <p>Gera ambiente completo de homologação sem sobrescrever dados reais.</p>
+          <?php $setup = get_option('rma_demo_setup_ctx', ['step' => 0]); $step = (int) ($setup['step'] ?? 0); ?>
+          <h2>Setup guiado (avançar)</h2>
+          <p>Step atual: <strong><?php echo esc_html((string) $step); ?></strong> (0=limpo, 1=infra, 2=entidades, 3=finalizado)</p>
+          <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin-bottom:8px;">
+            <?php wp_nonce_field('rma_demo_setup_next'); ?>
+            <input type="hidden" name="action" value="rma_demo_setup_next" />
+            <label>Entidades: <input type="number" name="entities" min="40" max="60" value="60" /></label>
+            <label style="margin-left:10px;"><input type="checkbox" name="simulate_emails" value="1" checked /> Simular e-mails</label>
+            <?php submit_button('Avançar setup demo', 'secondary', 'submit', false); ?>
+          </form>
+          <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin-bottom:12px;">
+            <?php wp_nonce_field('rma_demo_setup_reset'); ?>
+            <input type="hidden" name="action" value="rma_demo_setup_reset" />
+            <?php submit_button('Resetar setup guiado', 'secondary', 'submit', false); ?>
+          </form>
+          <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin-bottom:12px;">
+            <?php wp_nonce_field('rma_demo_seed'); ?>
+            <input type="hidden" name="action" value="rma_demo_seed" />
+            <label>Entidades: <input type="number" name="entities" min="40" max="60" value="60" /></label>
+            <label style="margin-left:10px;"><input type="checkbox" name="simulate_emails" value="1" checked /> Simular e-mails</label>
+            <?php submit_button('Gerar Dados', 'primary', 'submit', false); ?>
+          </form>
+
+          <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+            <?php wp_nonce_field('rma_demo_cleanup'); ?>
+            <input type="hidden" name="action" value="rma_demo_cleanup" />
+            <?php submit_button('Limpar Dados Demo', 'delete', 'submit', false); ?>
+          </form>
+
+          <?php if (is_array($last) && ! empty($last)) : ?>
+            <h2>Último relatório</h2>
+            <pre><?php echo esc_html(wp_json_encode($last, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)); ?></pre>
+          <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    public function handle_admin_seed(): void {
+        if (! current_user_can('manage_options') || ! check_admin_referer('rma_demo_seed')) {
+            wp_die('Sem permissão.');
+        }
+
+        $entities = max(40, min(60, absint((int) ($_POST['entities'] ?? 60))));
+        $simulate = ! empty($_POST['simulate_emails']);
+        $report = $this->seed_demo($entities, $simulate);
+        update_option('rma_demo_last_report', $report, false);
+
+        wp_safe_redirect(admin_url('admin.php?page=rma-demo-seeder'));
+        exit;
+    }
+
+    public function handle_admin_cleanup(): void {
+        if (! current_user_can('manage_options') || ! check_admin_referer('rma_demo_cleanup')) {
+            wp_die('Sem permissão.');
+        }
+
+        $report = $this->clear_demo();
+        update_option('rma_demo_last_report', $report, false);
+
+        wp_safe_redirect(admin_url('admin.php?page=rma-demo-seeder'));
+        exit;
+    }
+
+    public function handle_admin_setup_next(): void {
+        if (! current_user_can('manage_options') || ! check_admin_referer('rma_demo_setup_next')) {
+            wp_die('Sem permissão.');
+        }
+
+        $entities = max(40, min(60, absint((int) ($_POST['entities'] ?? 60))));
+        $simulate = ! empty($_POST['simulate_emails']);
+        $report = $this->run_setup_step($entities, $simulate);
+        update_option('rma_demo_last_report', $report, false);
+
+        wp_safe_redirect(admin_url('admin.php?page=rma-demo-seeder'));
+        exit;
+    }
+
+    public function handle_admin_setup_reset(): void {
+        if (! current_user_can('manage_options') || ! check_admin_referer('rma_demo_setup_reset')) {
+            wp_die('Sem permissão.');
+        }
+
+        delete_option('rma_demo_setup_ctx');
+        update_option('rma_demo_last_report', ['message' => 'Setup guiado resetado.'], false);
+        wp_safe_redirect(admin_url('admin.php?page=rma-demo-seeder'));
+        exit;
+    }
+
+    public function cli_seed_demo(array $args, array $assoc_args): void {
+        $entities = isset($assoc_args['entities']) ? max(40, min(60, absint((int) $assoc_args['entities']))) : 60;
+        $simulate = array_key_exists('simulate-emails', $assoc_args);
+        $report = $this->seed_demo($entities, $simulate);
+        \WP_CLI::success('Seeder concluído.');
+        \WP_CLI::line(wp_json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    }
+
+    public function cli_clear_demo(): void {
+        $report = $this->clear_demo();
+        \WP_CLI::success('Limpeza concluída.');
+        \WP_CLI::line(wp_json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    }
+
+    public function cli_setup_next(array $args, array $assoc_args): void {
+        $entities = isset($assoc_args['entities']) ? max(40, min(60, absint((int) $assoc_args['entities']))) : 60;
+        $simulate = array_key_exists('simulate-emails', $assoc_args);
+        $report = $this->run_setup_step($entities, $simulate);
+        \WP_CLI::success('Setup avançou uma etapa.');
+        \WP_CLI::line(wp_json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    }
+
+    private function run_setup_step(int $total_entities, bool $simulate_emails): array {
+        $ctx = get_option('rma_demo_setup_ctx', ['step' => 0]);
+        $step = (int) ($ctx['step'] ?? 0);
+
+        if ($step <= 0) {
+            $this->ensure_demo_tables();
+            $cleanup = $this->clear_demo();
+            $users = $this->ensure_demo_users();
+            $product_id = $this->ensure_demo_product();
+
+            $ctx = [
+                'step' => 1,
+                'entities_target' => $total_entities,
+                'simulate_emails' => $simulate_emails,
+                'users' => $users,
+                'product_id' => $product_id,
+                'cleanup' => $cleanup,
+            ];
+            update_option('rma_demo_setup_ctx', $ctx, false);
+
+            return ['message' => 'Setup step 1 concluído: infraestrutura preparada.', 'setup' => $ctx];
+        }
+
+        if ($step === 1) {
+            $users = is_array($ctx['users'] ?? null) ? $ctx['users'] : $this->ensure_demo_users();
+            $entities_target = max(40, min(60, absint((int) ($ctx['entities_target'] ?? $total_entities))));
+
+            $cities = $this->city_pool();
+            $statuses = $this->build_status_plan($entities_target);
+            shuffle($cities);
+
+            $created_ids = [];
+            $approved_ids = [];
+            $i = 0;
+            foreach ($statuses as $status) {
+                $city = $cities[$i % count($cities)];
+                $i++;
+                $author = ($i % 2 === 0) ? $users['entidade_a'] : $users['entidade_b'];
+                $entity_id = $this->create_demo_entity($i, $status, $city, $author);
+                $created_ids[] = $entity_id;
+                if ($status === 'aprovado') {
+                    $approved_ids[] = $entity_id;
+                    $this->seed_approvals($entity_id, $users);
+                }
+                $this->seed_documents($entity_id, rand(2, 3), $author);
+            }
+            $this->seed_mandates($created_ids);
+
+            $ctx['step'] = 2;
+            $ctx['created_ids'] = $created_ids;
+            $ctx['approved_ids'] = $approved_ids;
+            update_option('rma_demo_setup_ctx', $ctx, false);
+
+            return ['message' => 'Setup step 2 concluído: entidades/governança/documentos/mandatos.', 'created' => count($created_ids), 'approved' => count($approved_ids)];
+        }
+
+        if ($step === 2) {
+            $users = is_array($ctx['users'] ?? null) ? $ctx['users'] : $this->ensure_demo_users();
+            $approved_ids = array_map('intval', is_array($ctx['approved_ids'] ?? null) ? $ctx['approved_ids'] : []);
+            $created_ids = array_map('intval', is_array($ctx['created_ids'] ?? null) ? $ctx['created_ids'] : []);
+            $product_id = absint((int) ($ctx['product_id'] ?? 0));
+            $simulate = ! empty($ctx['simulate_emails']);
+
+            $this->seed_financial($approved_ids, $product_id, $users['entidade_a']);
+            $email_logs = $this->seed_email_logs($created_ids, $simulate);
+            $checks = $this->run_validations($users);
+
+            $ctx['step'] = 3;
+            $ctx['email_logs'] = $email_logs;
+            $ctx['validations'] = $checks;
+            update_option('rma_demo_setup_ctx', $ctx, false);
+
+            return ['message' => 'Setup step 3 concluído: financeiro/automações/validações.', 'email_logs' => $email_logs, 'validations' => $checks];
+        }
+
+        return ['message' => 'Setup já finalizado. Use reset para reiniciar.', 'setup' => $ctx];
+    }
+
+    private function seed_demo(int $total_entities, bool $simulate_emails): array {
+        $this->ensure_demo_tables();
+        $this->clear_demo();
+        $users = $this->ensure_demo_users();
+        $product_id = $this->ensure_demo_product();
+
+        $cities = $this->city_pool();
+        $statuses = $this->build_status_plan($total_entities);
+        shuffle($cities);
+
+        $created_ids = [];
+        $approved_ids = [];
+        $i = 0;
+        foreach ($statuses as $status) {
+            $city = $cities[$i % count($cities)];
+            $i++;
+            $author = ($i % 2 === 0) ? $users['entidade_a'] : $users['entidade_b'];
+            $entity_id = $this->create_demo_entity($i, $status, $city, $author);
+            $created_ids[] = $entity_id;
+            if ($status === 'aprovado') {
+                $approved_ids[] = $entity_id;
+                $this->seed_approvals($entity_id, $users);
+            }
+            $this->seed_documents($entity_id, rand(2, 3), $author);
+        }
+
+        $this->seed_financial($approved_ids, $product_id, $users['entidade_a']);
+        $this->seed_mandates($created_ids);
+        $email_logs = $this->seed_email_logs($created_ids, $simulate_emails);
+        $checks = $this->run_validations($users);
+
+        $report = [
+            'entities_created' => count($created_ids),
+            'approved' => count($approved_ids),
+            'users' => $users,
+            'product_id' => $product_id,
+            'email_logs' => $email_logs,
+            'validations' => $checks,
+            'simulate_emails' => $simulate_emails,
+        ];
+
+        error_log('[RMA DEMO] Seeder report: ' . wp_json_encode($report));
+        return $report;
+    }
+
+    private function clear_demo(): array {
+        $ids = get_posts([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft', 'pending', 'private', 'trash'],
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'meta_key' => self::META_DEMO,
+            'meta_value' => '1',
+        ]);
+
+        $order_ids = [];
+        if (function_exists('wc_get_orders')) {
+            $orders = wc_get_orders([
+                'limit' => -1,
+                'return' => 'ids',
+                'meta_key' => 'rma_is_demo',
+                'meta_value' => '1',
+            ]);
+            $order_ids = is_array($orders) ? $orders : [];
+            foreach ($order_ids as $oid) {
+                wp_delete_post((int) $oid, true);
+            }
+        }
+
+        $attachments = get_posts([
+            'post_type' => 'attachment',
+            'post_status' => 'inherit',
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'meta_key' => self::META_DEMO,
+            'meta_value' => '1',
+        ]);
+        foreach ($attachments as $aid) {
+            wp_delete_attachment((int) $aid, true);
+        }
+
+        foreach ($ids as $id) {
+            wp_delete_post((int) $id, true);
+        }
+
+        global $wpdb;
+        $wpdb->query("DELETE FROM {$wpdb->prefix}rma_approvals WHERE is_demo = 1");
+        $wpdb->query("DELETE FROM {$wpdb->prefix}rma_dues WHERE is_demo = 1");
+        $wpdb->query("DELETE FROM {$wpdb->prefix}rma_email_log WHERE is_demo = 1");
+        delete_option('rma_demo_setup_ctx');
+
+        return [
+            'entities_removed' => count($ids),
+            'orders_removed' => count($order_ids),
+            'attachments_removed' => count($attachments),
+        ];
+    }
+
+    private function ensure_demo_users(): array {
+        $map = [
+            'admin_rma_demo' => ['role' => 'administrator', 'email' => 'admin_rma_demo@example.org'],
+            'aprovador_demo' => ['role' => 'editor', 'email' => 'aprovador_demo@example.org'],
+            'entidade_demo_a' => ['role' => 'subscriber', 'email' => 'entidade_demo_a@example.org'],
+            'entidade_demo_b' => ['role' => 'subscriber', 'email' => 'entidade_demo_b@example.org'],
+        ];
+        $result = [];
+        foreach ($map as $login => $cfg) {
+            $u = get_user_by('login', $login);
+            if (! $u) {
+                $uid = wp_insert_user([
+                    'user_login' => $login,
+                    'user_pass' => wp_generate_password(20, true),
+                    'user_email' => $cfg['email'],
+                    'role' => $cfg['role'],
+                    'display_name' => ucwords(str_replace('_', ' ', $login)),
+                ]);
+                $result[$login] = (int) $uid;
+            } else {
+                $result[$login] = (int) $u->ID;
+            }
+        }
+
+        return [
+            'admin' => $result['admin_rma_demo'],
+            'aprovador' => $result['aprovador_demo'],
+            'entidade_a' => $result['entidade_demo_a'],
+            'entidade_b' => $result['entidade_demo_b'],
+        ];
+    }
+
+    private function ensure_demo_product(): int {
+        if (! class_exists('WC_Product_Simple')) {
+            return 0;
+        }
+
+        $existing = get_posts([
+            'post_type' => 'product',
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => 1,
+            'fields' => 'ids',
+            'meta_key' => self::META_DEMO,
+            'meta_value' => '1',
+            's' => 'Anuidade RMA 2026',
+        ]);
+        if (! empty($existing)) {
+            return (int) $existing[0];
+        }
+
+        $product = new WC_Product_Simple();
+        $product->set_name('Anuidade RMA 2026');
+        $product->set_regular_price('1200');
+        $product->set_status('publish');
+        $product_id = $product->save();
+        update_post_meta($product_id, self::META_DEMO, '1');
+
+        return (int) $product_id;
+    }
+
+    private function create_demo_entity(int $index, string $status, array $city, int $author_id): int {
+        $cnpj = $this->generate_valid_cnpj($index);
+        $title = sprintf('Instituto %s %02d', $city['cidade'], $index);
+        $post_id = wp_insert_post([
+            'post_type' => self::CPT,
+            'post_status' => in_array($status, ['aprovado'], true) ? 'publish' : 'draft',
+            'post_title' => $title,
+            'post_author' => $author_id,
+            'post_content' => 'Entidade demonstrativa para homologação RMA.',
+        ]);
+
+        $finance_default = in_array($status, ['aprovado'], true) ? 'inadimplente' : 'pendente';
+        $areas = $this->pick_areas();
+        $lat = $city['lat'] + (mt_rand(-40, 40) / 1000);
+        $lng = $city['lng'] + (mt_rand(-40, 40) / 1000);
+
+        $meta = [
+            self::META_DEMO => '1',
+            'cnpj' => $cnpj,
+            'razao_social' => $title . ' Associação Civil',
+            'nome_fantasia' => $title,
+            'cnae_principal' => '9493-6/00',
+            'email_contato' => 'contato+' . $post_id . '@demo-rma.org',
+            'telefone_contato' => '(11) 90000-0000',
+            'cep' => $city['cep'],
+            'logradouro' => $city['logradouro'],
+            'numero' => (string) mt_rand(10, 999),
+            'bairro' => $city['bairro'],
+            'cidade' => $city['cidade'],
+            'uf' => $city['uf'],
+            'lat' => (string) $lat,
+            'lng' => (string) $lng,
+            'governance_status' => $status,
+            'finance_status' => $finance_default,
+            'documentos_status' => 'enviado',
+            'consent_lgpd' => '1',
+            'area_interesse' => $areas[0],
+            'areas_interesse' => implode(', ', $areas),
+        ];
+
+        foreach ($meta as $k => $v) {
+            update_post_meta($post_id, $k, $v);
+        }
+
+        return (int) $post_id;
+    }
+
+    private function seed_approvals(int $entity_id, array $users): void {
+        $approvals = [];
+        $ids = [$users['admin'], $users['aprovador'], 1];
+        for ($i = 1; $i <= 3; $i++) {
+            $uid = (int) $ids[$i - 1];
+            $approvals[] = [
+                'user_id' => $uid,
+                'datetime' => gmdate('Y-m-d H:i:s', time() - (4 - $i) * DAY_IN_SECONDS),
+                'ip' => '10.0.0.' . (20 + $i),
+                'comment' => 'Aceite automático de homologação passo ' . $i,
+            ];
+            $this->insert_approval_row($entity_id, $i, $uid);
+        }
+
+        update_post_meta($entity_id, 'governance_approvals', $approvals);
+        update_post_meta($entity_id, 'governance_audit_logs', [[
+            'action' => 'approve',
+            'datetime' => current_time('mysql', true),
+            'data' => ['approvals_count' => 3, 'is_demo' => true],
+        ]]);
+    }
+
+    private function seed_financial(array $approved_ids, int $product_id, int $customer_id): void {
+        if (! function_exists('wc_create_order')) {
+            return;
+        }
+
+        $target_adimplente = (int) floor(count($approved_ids) * 0.6);
+        shuffle($approved_ids);
+        $adimplentes = array_slice($approved_ids, 0, $target_adimplente);
+
+        foreach ($approved_ids as $entity_id) {
+            $is_paid = in_array($entity_id, $adimplentes, true);
+            if ($is_paid) {
+                $order = wc_create_order(['customer_id' => $customer_id]);
+                if ($product_id > 0) {
+                    $product = wc_get_product($product_id);
+                    if ($product) {
+                        $order->add_product($product, 1);
+                    }
+                }
+                $order->update_meta_data('rma_entity_id', $entity_id);
+                $order->update_meta_data('rma_is_demo', '1');
+                $order->calculate_totals();
+                $order->update_status((rand(0, 1) ? 'completed' : 'processing'));
+                update_post_meta($entity_id, 'finance_status', 'adimplente');
+
+                $this->insert_due_row($entity_id, (int) $order->get_id(), 'adimplente', (float) $order->get_total());
+            } else {
+                update_post_meta($entity_id, 'finance_status', 'inadimplente');
+                $this->insert_due_row($entity_id, 0, 'inadimplente', 0.0);
+            }
+        }
+    }
+
+    private function seed_mandates(array $entity_ids): void {
+        shuffle($entity_ids);
+        $buckets = [
+            '30' => array_slice($entity_ids, 0, 5),
+            '7' => array_slice($entity_ids, 5, 5),
+            'expired' => array_slice($entity_ids, 10, 5),
+            'valid' => array_slice($entity_ids, 15),
+        ];
+
+        foreach ($buckets['30'] as $id) {
+            update_post_meta($id, 'mandato_fim', gmdate('Y-m-d', strtotime('+30 days')));
+        }
+        foreach ($buckets['7'] as $id) {
+            update_post_meta($id, 'mandato_fim', gmdate('Y-m-d', strtotime('+7 days')));
+        }
+        foreach ($buckets['expired'] as $id) {
+            update_post_meta($id, 'mandato_fim', gmdate('Y-m-d', strtotime('-5 days')));
+        }
+        foreach ($buckets['valid'] as $id) {
+            update_post_meta($id, 'mandato_fim', gmdate('Y-m-d', strtotime('+420 days')));
+        }
+    }
+
+    private function seed_documents(int $entity_id, int $count, int $author_id): void {
+        $upload = wp_upload_dir();
+        $base = trailingslashit($upload['basedir']) . 'rma-private/' . $entity_id;
+        wp_mkdir_p($base);
+
+        $docs = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $doc_id = wp_generate_uuid4();
+            $name = 'demo-documento-' . $i . '.pdf';
+            $path = trailingslashit($base) . $doc_id . '-' . $name;
+            file_put_contents($path, "%PDF-1.4\n%RMA DEMO\n1 0 obj <<>>\nendobj\ntrailer<<>>\n%%EOF");
+            $docs[] = [
+                'id' => $doc_id,
+                'name' => $name,
+                'path' => $path,
+                'size' => filesize($path),
+                'uploaded_by' => $author_id,
+                'uploaded_at' => current_time('mysql', true),
+            ];
+
+            $att_id = wp_insert_attachment([
+                'post_title' => 'demo-attachment-' . $doc_id,
+                'post_mime_type' => 'application/pdf',
+                'post_status' => 'inherit',
+            ], $path, $entity_id);
+            if (! is_wp_error($att_id)) {
+                update_post_meta($att_id, self::META_DEMO, '1');
+            }
+        }
+
+        update_post_meta($entity_id, 'entity_documents', $docs);
+        update_post_meta($entity_id, 'documentos_status', 'enviado');
+    }
+
+    private function seed_email_logs(array $entity_ids, bool $simulate): int {
+        $count = 0;
+        global $wpdb;
+        foreach (array_slice($entity_ids, 0, 20) as $id) {
+            $logs = get_post_meta($id, 'automation_logs', true);
+            $logs = is_array($logs) ? $logs : [];
+            $logs[] = [
+                'context' => 'demo_simulation',
+                'email' => 'entidade+' . $id . '@demo-rma.org',
+                'subject' => 'Simulação de automação RMA',
+                'sent' => $simulate ? false : true,
+                'datetime' => current_time('mysql', true),
+            ];
+            update_post_meta($id, 'automation_logs', $logs);
+
+            $wpdb->insert($wpdb->prefix . 'rma_email_log', [
+                'entity_id' => $id,
+                'context' => 'demo_simulation',
+                'recipient' => 'entidade+' . $id . '@demo-rma.org',
+                'subject' => 'Simulação de automação RMA',
+                'sent' => $simulate ? 0 : 1,
+                'created_at' => current_time('mysql', true),
+                'is_demo' => 1,
+            ]);
+            $count++;
+        }
+
+        return $count;
+    }
+
+    private function run_validations(array $users): array {
+        $approved = $this->count_entities(['governance_status' => 'aprovado']);
+        $inadimplentes = $this->count_entities(['finance_status' => 'inadimplente', 'governance_status' => 'aprovado']);
+        $mandato_vencendo = $this->count_mandato_window([7, 30]);
+
+        $map_count = 0;
+        $response = rest_do_request(new WP_REST_Request('GET', '/rma-public/v1/entities'));
+        if ($response instanceof WP_REST_Response) {
+            $data = $response->get_data();
+            $map_count = is_array($data) ? count($data) : 0;
+        }
+
+        $orders = function_exists('wc_get_orders') ? wc_get_orders(['limit' => -1, 'return' => 'ids', 'meta_key' => 'rma_is_demo', 'meta_value' => '1']) : [];
+        $orders = is_array($orders) ? $orders : [];
+        $revenue = 0.0;
+        foreach ($orders as $order_id) {
+            $order = wc_get_order($order_id);
+            if ($order) {
+                $revenue += (float) $order->get_total();
+            }
+        }
+
+        return [
+            'approved_entities' => $approved,
+            'inadimplentes_aprovadas' => $inadimplentes,
+            'mandato_vencendo_7_30' => $mandato_vencendo,
+            'map_rest_count' => $map_count,
+            'woo_orders_demo' => count($orders),
+            'woo_revenue_demo' => round($revenue, 2),
+            'by_uf' => $this->count_by_uf(),
+            'security_checks' => $this->security_check_matrix($users),
+        ];
+    }
+
+    private function count_by_uf(): array {
+        global $wpdb;
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT pm.meta_value AS uf, COUNT(*) AS total\n             FROM {$wpdb->postmeta} demo\n             INNER JOIN {$wpdb->posts} p ON p.ID = demo.post_id\n             LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = %s\n             WHERE demo.meta_key = %s AND demo.meta_value = '1' AND p.post_type = %s\n             GROUP BY pm.meta_value",
+            'uf', self::META_DEMO, self::CPT
+        ));
+
+        $out = [];
+        foreach ((array) $rows as $r) {
+            $uf = sanitize_text_field((string) ($r->uf ?? ''));
+            if ($uf === '') {
+                $uf = 'N/D';
+            }
+            $out[$uf] = (int) ($r->total ?? 0);
+        }
+
+        ksort($out);
+        return $out;
+    }
+
+    private function security_check_matrix(array $users): array {
+        $ids = get_posts([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'meta_key' => self::META_DEMO,
+            'meta_value' => '1',
+        ]);
+
+        $a = $users['entidade_a'] ?? 0;
+        $b = $users['entidade_b'] ?? 0;
+        $ownA = 0;
+        $ownB = 0;
+        $crossA = 0;
+        $crossB = 0;
+
+        foreach ($ids as $id) {
+            $author = (int) get_post_field('post_author', (int) $id);
+            if ($author === $a) {
+                $ownA++;
+                $crossB++;
+            } elseif ($author === $b) {
+                $ownB++;
+                $crossA++;
+            }
+        }
+
+        return [
+            'entidade_a_own_entities' => $ownA,
+            'entidade_b_own_entities' => $ownB,
+            'entidade_a_cross_entities_expected_denied' => $crossA,
+            'entidade_b_cross_entities_expected_denied' => $crossB,
+            'admin_expected_all_entities' => count($ids),
+        ];
+    }
+
+    private function count_entities(array $meta): int {
+        $meta_query = ['relation' => 'AND'];
+        foreach ($meta as $k => $v) {
+            $meta_query[] = ['key' => $k, 'value' => $v];
+        }
+        $meta_query[] = ['key' => self::META_DEMO, 'value' => '1'];
+
+        $q = new WP_Query([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft'],
+            'fields' => 'ids',
+            'posts_per_page' => 1,
+            'meta_query' => $meta_query,
+        ]);
+
+        return (int) $q->found_posts;
+    }
+
+    private function count_mandato_window(array $days): int {
+        $ids = get_posts([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => -1,
+            'fields' => 'ids',
+            'meta_key' => self::META_DEMO,
+            'meta_value' => '1',
+        ]);
+        $count = 0;
+        $today = strtotime(gmdate('Y-m-d'));
+        foreach ($ids as $id) {
+            $target = strtotime((string) get_post_meta($id, 'mandato_fim', true));
+            if (! $target) {
+                continue;
+            }
+            $diff = (int) floor(($target - $today) / DAY_IN_SECONDS);
+            if (in_array($diff, $days, true)) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    private function ensure_demo_tables(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $wpdb->get_charset_collate();
+
+        dbDelta("CREATE TABLE {$wpdb->prefix}rma_approvals (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            entity_id BIGINT UNSIGNED NOT NULL,
+            step TINYINT UNSIGNED NOT NULL,
+            user_id BIGINT UNSIGNED NOT NULL,
+            ip VARCHAR(45) NOT NULL,
+            comment_text TEXT NULL,
+            created_at DATETIME NOT NULL,
+            is_demo TINYINT(1) NOT NULL DEFAULT 1,
+            PRIMARY KEY (id),
+            KEY entity_id (entity_id)
+        ) {$charset};");
+
+        dbDelta("CREATE TABLE {$wpdb->prefix}rma_dues (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            entity_id BIGINT UNSIGNED NOT NULL,
+            order_id BIGINT UNSIGNED NOT NULL,
+            due_year SMALLINT UNSIGNED NOT NULL,
+            status VARCHAR(40) NOT NULL,
+            amount DECIMAL(12,2) NOT NULL DEFAULT 0,
+            created_at DATETIME NOT NULL,
+            is_demo TINYINT(1) NOT NULL DEFAULT 1,
+            PRIMARY KEY (id),
+            KEY entity_id (entity_id)
+        ) {$charset};");
+
+        dbDelta("CREATE TABLE {$wpdb->prefix}rma_email_log (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            entity_id BIGINT UNSIGNED NOT NULL,
+            context VARCHAR(60) NOT NULL,
+            recipient VARCHAR(190) NOT NULL,
+            subject VARCHAR(190) NOT NULL,
+            sent TINYINT(1) NOT NULL DEFAULT 0,
+            created_at DATETIME NOT NULL,
+            is_demo TINYINT(1) NOT NULL DEFAULT 1,
+            PRIMARY KEY (id),
+            KEY entity_id (entity_id)
+        ) {$charset};");
+    }
+
+    private function insert_approval_row(int $entity_id, int $step, int $user_id): void {
+        global $wpdb;
+        $wpdb->insert($wpdb->prefix . 'rma_approvals', [
+            'entity_id' => $entity_id,
+            'step' => $step,
+            'user_id' => $user_id,
+            'ip' => '10.0.0.' . (30 + $step),
+            'comment_text' => 'Aprovação demo passo ' . $step,
+            'created_at' => current_time('mysql', true),
+            'is_demo' => 1,
+        ]);
+    }
+
+    private function insert_due_row(int $entity_id, int $order_id, string $status, float $amount): void {
+        global $wpdb;
+        $wpdb->insert($wpdb->prefix . 'rma_dues', [
+            'entity_id' => $entity_id,
+            'order_id' => $order_id,
+            'due_year' => 2026,
+            'status' => $status,
+            'amount' => $amount,
+            'created_at' => current_time('mysql', true),
+            'is_demo' => 1,
+        ]);
+    }
+
+    private function build_status_plan(int $total): array {
+        $plan = array_merge(
+            array_fill(0, 20, 'aprovado'),
+            array_fill(0, 10, 'pendente'),
+            array_fill(0, 5, 'recusado'),
+            array_fill(0, 5, 'em_analise')
+        );
+
+        $remaining = max(0, $total - count($plan));
+        $pool = ['pendente', 'aprovado', 'recusado', 'em_analise'];
+        for ($i = 0; $i < $remaining; $i++) {
+            $plan[] = $pool[array_rand($pool)];
+        }
+
+        return $plan;
+    }
+
+    private function pick_areas(): array {
+        $areas = ['Meio Ambiente', 'Educação', 'Direitos Humanos', 'Cultura', 'Juventude', 'Saúde'];
+        shuffle($areas);
+        return array_slice($areas, 0, rand(1, 3));
+    }
+
+    private function city_pool(): array {
+        return [
+            ['uf' => 'SP', 'cidade' => 'São Paulo', 'lat' => -23.5505, 'lng' => -46.6333, 'cep' => '01001-000', 'logradouro' => 'Rua Líbero Badaró', 'bairro' => 'Centro'],
+            ['uf' => 'RJ', 'cidade' => 'Rio de Janeiro', 'lat' => -22.9068, 'lng' => -43.1729, 'cep' => '20040-020', 'logradouro' => 'Rua da Assembleia', 'bairro' => 'Centro'],
+            ['uf' => 'MG', 'cidade' => 'Belo Horizonte', 'lat' => -19.9167, 'lng' => -43.9345, 'cep' => '30130-010', 'logradouro' => 'Avenida Afonso Pena', 'bairro' => 'Centro'],
+            ['uf' => 'ES', 'cidade' => 'Vitória', 'lat' => -20.3155, 'lng' => -40.3128, 'cep' => '29010-935', 'logradouro' => 'Avenida Marechal Mascarenhas', 'bairro' => 'Centro'],
+            ['uf' => 'PR', 'cidade' => 'Curitiba', 'lat' => -25.4284, 'lng' => -49.2733, 'cep' => '80010-000', 'logradouro' => 'Rua XV de Novembro', 'bairro' => 'Centro'],
+            ['uf' => 'SC', 'cidade' => 'Florianópolis', 'lat' => -27.5949, 'lng' => -48.5482, 'cep' => '88010-400', 'logradouro' => 'Rua Felipe Schmidt', 'bairro' => 'Centro'],
+            ['uf' => 'RS', 'cidade' => 'Porto Alegre', 'lat' => -30.0346, 'lng' => -51.2177, 'cep' => '90010-150', 'logradouro' => 'Rua dos Andradas', 'bairro' => 'Centro'],
+            ['uf' => 'BA', 'cidade' => 'Salvador', 'lat' => -12.9777, 'lng' => -38.5016, 'cep' => '40020-000', 'logradouro' => 'Rua Chile', 'bairro' => 'Centro'],
+            ['uf' => 'PE', 'cidade' => 'Recife', 'lat' => -8.0476, 'lng' => -34.8770, 'cep' => '50030-230', 'logradouro' => 'Rua do Bom Jesus', 'bairro' => 'Recife'],
+            ['uf' => 'CE', 'cidade' => 'Fortaleza', 'lat' => -3.7319, 'lng' => -38.5267, 'cep' => '60060-330', 'logradouro' => 'Avenida Santos Dumont', 'bairro' => 'Aldeota'],
+        ];
+    }
+
+    private function generate_valid_cnpj(int $seed): string {
+        $n = str_pad((string) ($seed % 99999999), 8, '0', STR_PAD_LEFT) . '0001';
+        $d1 = $this->cnpj_digit($n, [5,4,3,2,9,8,7,6,5,4,3,2]);
+        $d2 = $this->cnpj_digit($n . $d1, [6,5,4,3,2,9,8,7,6,5,4,3,2]);
+        return $n . $d1 . $d2;
+    }
+
+    private function cnpj_digit(string $base, array $weights): int {
+        $sum = 0;
+        for ($i = 0; $i < count($weights); $i++) {
+            $sum += ((int) $base[$i]) * $weights[$i];
+        }
+        $mod = $sum % 11;
+        return $mod < 2 ? 0 : 11 - $mod;
+    }
+}
+
+new RMA_Demo_Seeder();

--- a/wp-content/plugins/rma-governance/rma-governance.php
+++ b/wp-content/plugins/rma-governance/rma-governance.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Plugin Name: RMA Governance
+ * Description: Workflow de 3 aceites para entidades RMA com logs de auditoria.
+ * Version: 0.4.3
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Governance {
+    private const CPT = 'rma_entidade';
+
+    public function __construct() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    public function register_routes(): void {
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/approve', [
+            'methods' => 'POST',
+            'callback' => [$this, 'approve_entity'],
+            'permission_callback' => [$this, 'can_approve'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/reject', [
+            'methods' => 'POST',
+            'callback' => [$this, 'reject_entity'],
+            'permission_callback' => [$this, 'can_approve'],
+        ]);
+
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/resubmit', [
+            'methods' => 'POST',
+            'callback' => [$this, 'resubmit_entity'],
+            'permission_callback' => [$this, 'can_resubmit'],
+        ]);
+    }
+
+    public function can_approve(): bool {
+        return current_user_can('edit_others_posts');
+    }
+
+
+    public function can_resubmit(WP_REST_Request $request): bool {
+        if (! is_user_logged_in()) {
+            return false;
+        }
+
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return false;
+        }
+
+        if (current_user_can('edit_others_posts')) {
+            return true;
+        }
+
+        return (int) get_post_field('post_author', $entity_id) === get_current_user_id();
+    }
+
+    public function approve_entity(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $status = $this->normalized_governance_status($entity_id);
+        if ($status === 'aprovado') {
+            return new WP_REST_Response(['message' => 'Entidade já aprovada.'], 409);
+        }
+
+        if ($status === 'recusado') {
+            return new WP_REST_Response([
+                'message' => 'Entidade recusada deve ser reenviada antes de novos aceites.',
+                'current_status' => $status,
+            ], 409);
+        }
+
+        if (! in_array($status, ['pendente', 'em_analise'], true)) {
+            return new WP_REST_Response([
+                'message' => 'Status de governança inválido para aceite.',
+                'current_status' => $status,
+            ], 409);
+        }
+
+        $user_id = get_current_user_id();
+        if ($user_id <= 0) {
+            return new WP_REST_Response(['message' => 'Usuário não autenticado.'], 401);
+        }
+
+        $author_id = (int) get_post_field('post_author', $entity_id);
+        if ($author_id > 0 && $author_id === $user_id) {
+            return new WP_REST_Response([
+                'message' => 'Auto-aceite não é permitido para a própria entidade.',
+                'current_status' => $status,
+            ], 409);
+        }
+
+        $approvals = get_post_meta($entity_id, 'governance_approvals', true);
+        $approvals = is_array($approvals) ? $approvals : [];
+
+        foreach ($approvals as $entry) {
+            if ((int) ($entry['user_id'] ?? 0) === $user_id) {
+                return new WP_REST_Response(['message' => 'Usuário já registrou aceite nesta entidade.'], 409);
+            }
+        }
+
+        if (count($approvals) >= 3) {
+            return new WP_REST_Response(['message' => 'Limite de 3 aceites já atingido.'], 409);
+        }
+
+        $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+        $comment = $this->limit_text(sanitize_textarea_field((string) $request->get_param('comment')), 1000);
+
+        $approvals[] = [
+            'user_id' => $user_id,
+            'datetime' => current_time('mysql', true),
+            'ip' => $ip,
+            'comment' => $comment,
+        ];
+
+        $new_status = count($approvals) >= 3 ? 'aprovado' : 'em_analise';
+        update_post_meta($entity_id, 'governance_approvals', $approvals);
+        update_post_meta($entity_id, 'governance_status', $new_status);
+        delete_post_meta($entity_id, 'governance_rejection_reason');
+
+        $this->append_audit_log($entity_id, 'approve', [
+            'user_id' => $user_id,
+            'ip' => $ip,
+            'comment' => $comment,
+            'approvals_count' => count($approvals),
+        ]);
+
+        if ($new_status === 'aprovado') {
+            wp_update_post([
+                'ID' => $entity_id,
+                'post_status' => 'publish',
+            ]);
+            do_action('rma/entity_approved', $entity_id, $approvals);
+        } else {
+            wp_update_post([
+                'ID' => $entity_id,
+                'post_status' => 'draft',
+            ]);
+        }
+
+        return new WP_REST_Response([
+            'entity_id' => $entity_id,
+            'approvals_count' => count($approvals),
+            'governance_status' => $new_status,
+        ]);
+    }
+
+    public function reject_entity(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $status = $this->normalized_governance_status($entity_id);
+        if ($status === 'aprovado') {
+            return new WP_REST_Response(['message' => 'Entidade aprovada não pode ser recusada diretamente.'], 409);
+        }
+
+        if ($status === 'recusado') {
+            return new WP_REST_Response([
+                'message' => 'Entidade já está recusada. Use o reenvio para reiniciar o ciclo.',
+                'current_status' => $status,
+            ], 409);
+        }
+
+        if (! in_array($status, ['pendente', 'em_analise'], true)) {
+            return new WP_REST_Response([
+                'message' => 'Status de governança inválido para recusa.',
+                'current_status' => $status,
+            ], 409);
+        }
+
+        $reason = $this->limit_text(sanitize_textarea_field((string) $request->get_param('reason')), 1000);
+        if ($reason === '') {
+            return new WP_REST_Response(['message' => 'Motivo da recusa é obrigatório.'], 422);
+        }
+
+        $user_id = get_current_user_id();
+        if ($user_id <= 0) {
+            return new WP_REST_Response(['message' => 'Usuário não autenticado.'], 401);
+        }
+
+        update_post_meta($entity_id, 'governance_status', 'recusado');
+        update_post_meta($entity_id, 'governance_rejection_reason', $reason);
+        update_post_meta($entity_id, 'governance_approvals', []);
+
+        wp_update_post([
+            'ID' => $entity_id,
+            'post_status' => 'draft',
+        ]);
+
+        $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+
+        $this->append_audit_log($entity_id, 'reject', [
+            'user_id' => $user_id,
+            'ip' => $ip,
+            'reason' => $reason,
+        ]);
+
+        do_action('rma/entity_rejected', $entity_id, $reason);
+
+        return new WP_REST_Response([
+            'entity_id' => $entity_id,
+            'governance_status' => 'recusado',
+            'reason' => $reason,
+        ]);
+    }
+
+
+    public function resubmit_entity(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $current_status = $this->normalized_governance_status($entity_id);
+        if ($current_status !== 'recusado') {
+            return new WP_REST_Response([
+                'message' => 'Somente entidades recusadas podem ser reenviadas.',
+                'current_status' => $current_status,
+            ], 409);
+        }
+
+        $user_id = get_current_user_id();
+        if ($user_id <= 0) {
+            return new WP_REST_Response(['message' => 'Usuário não autenticado.'], 401);
+        }
+
+        update_post_meta($entity_id, 'governance_status', 'pendente');
+        update_post_meta($entity_id, 'governance_approvals', []);
+        delete_post_meta($entity_id, 'governance_rejection_reason');
+
+        wp_update_post([
+            'ID' => $entity_id,
+            'post_status' => 'draft',
+        ]);
+
+        $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+
+        $this->append_audit_log($entity_id, 'resubmit', [
+            'user_id' => $user_id,
+            'ip' => $ip,
+        ]);
+
+        do_action('rma/entity_resubmitted', $entity_id);
+
+        return new WP_REST_Response([
+            'entity_id' => $entity_id,
+            'governance_status' => 'pendente',
+            'message' => 'Entidade reenviada para análise.',
+        ]);
+    }
+
+
+    private function normalized_governance_status(int $entity_id): string {
+        $status = (string) get_post_meta($entity_id, 'governance_status', true);
+        $status = trim($status);
+
+        if ($status === '') {
+            return 'pendente';
+        }
+
+        return $status;
+    }
+
+
+    private function limit_text(string $value, int $max): string {
+        if ($max <= 0) {
+            return '';
+        }
+
+        if (function_exists('mb_substr')) {
+            return mb_substr($value, 0, $max);
+        }
+
+        return substr($value, 0, $max);
+    }
+
+    private function append_audit_log(int $entity_id, string $action, array $data): void {
+        $logs = get_post_meta($entity_id, 'governance_audit_logs', true);
+        $logs = is_array($logs) ? $logs : [];
+
+        $logs[] = [
+            'action' => $action,
+            'datetime' => current_time('mysql', true),
+            'data' => $data,
+        ];
+
+        $max_logs = 200;
+        if (count($logs) > $max_logs) {
+            $logs = array_slice($logs, -1 * $max_logs);
+        }
+
+        update_post_meta($entity_id, 'governance_audit_logs', $logs);
+    }
+}
+
+new RMA_Governance();

--- a/wp-content/plugins/rma-governance/rma-governance.php
+++ b/wp-content/plugins/rma-governance/rma-governance.php
@@ -15,6 +15,125 @@ final class RMA_Governance {
 
     public function __construct() {
         add_action('rest_api_init', [$this, 'register_routes']);
+        add_action('admin_menu', [$this, 'register_admin_page']);
+    }
+
+    public function register_admin_page(): void {
+        add_submenu_page(
+            'edit.php?post_type=' . self::CPT,
+            'Governança RMA',
+            'Governança',
+            'edit_others_posts',
+            'rma-governance-audit',
+            [$this, 'render_admin_page']
+        );
+    }
+
+    public function render_admin_page(): void {
+        if (! current_user_can('edit_others_posts')) {
+            wp_die('Você não tem permissão para acessar esta página.');
+        }
+
+        $rows = $this->load_governance_rows();
+        ?>
+        <div class="wrap">
+            <h1>Governança RMA</h1>
+            <p>Painel para acompanhamento de status e trilha de auditoria das entidades.</p>
+
+            <?php if (empty($rows)) : ?>
+                <p>Nenhuma entidade encontrada para governança.</p>
+            <?php else : ?>
+                <table class="widefat striped">
+                    <thead>
+                    <tr>
+                        <th>Entidade</th>
+                        <th>Status</th>
+                        <th>Aceites</th>
+                        <th>Documentos</th>
+                        <th>Último evento de auditoria</th>
+                        <th>Ações</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($rows as $row) : ?>
+                        <tr>
+                            <td>
+                                <strong><?php echo esc_html($row['title']); ?></strong><br/>
+                                <small>ID #<?php echo esc_html((string) $row['id']); ?></small>
+                            </td>
+                            <td>
+                                <code><?php echo esc_html($row['status']); ?></code>
+                                <?php if ($row['rejection_reason'] !== '') : ?>
+                                    <br/><small><strong>Motivo:</strong> <?php echo esc_html($row['rejection_reason']); ?></small>
+                                <?php endif; ?>
+                            </td>
+                            <td><?php echo esc_html((string) $row['approvals_count']); ?>/3</td>
+                            <td><?php echo esc_html((string) $row['documents_count']); ?></td>
+                            <td>
+                                <?php if ($row['last_audit'] === '') : ?>
+                                    <span>—</span>
+                                <?php else : ?>
+                                    <small><?php echo esc_html($row['last_audit']); ?></small>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <a href="<?php echo esc_url(get_edit_post_link($row['id'])); ?>">Abrir entidade</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    private function load_governance_rows(): array {
+        $posts = get_posts([
+            'post_type' => self::CPT,
+            'post_status' => ['draft', 'publish', 'pending', 'private'],
+            'posts_per_page' => 200,
+            'orderby' => 'modified',
+            'order' => 'DESC',
+        ]);
+
+        if (empty($posts)) {
+            return [];
+        }
+
+        $rows = [];
+
+        foreach ($posts as $post) {
+            $entity_id = (int) $post->ID;
+            $approvals = get_post_meta($entity_id, 'governance_approvals', true);
+            $approvals = is_array($approvals) ? $approvals : [];
+
+            $documents = get_post_meta($entity_id, 'entity_documents', true);
+            $documents = is_array($documents) ? $documents : [];
+
+            $audit_logs = get_post_meta($entity_id, 'governance_audit_logs', true);
+            $audit_logs = is_array($audit_logs) ? $audit_logs : [];
+            $last_audit = '';
+
+            if (! empty($audit_logs)) {
+                $last_log = end($audit_logs);
+                $action = (string) ($last_log['action'] ?? 'evento');
+                $datetime = (string) ($last_log['datetime'] ?? '');
+                $last_audit = trim($action . ' · ' . $datetime, " ·");
+            }
+
+            $rows[] = [
+                'id' => $entity_id,
+                'title' => (string) get_the_title($entity_id),
+                'status' => $this->normalized_governance_status($entity_id),
+                'approvals_count' => count($approvals),
+                'documents_count' => count($documents),
+                'rejection_reason' => (string) get_post_meta($entity_id, 'governance_rejection_reason', true),
+                'last_audit' => $last_audit,
+            ];
+        }
+
+        return $rows;
     }
 
     public function register_routes(): void {

--- a/wp-content/plugins/rma-maps-directory/rma-maps-directory.php
+++ b/wp-content/plugins/rma-maps-directory/rma-maps-directory.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Plugin Name: RMA Maps & Directory
+ * Description: Endpoint público para diretório/mapa com filtros de UF e regras de visibilidade.
+ * Version: 0.6.0
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Maps_Directory {
+    private const CPT = 'rma_entidade';
+    private const CACHE_INDEX_OPTION = 'rma_public_entities_cache_keys';
+
+    public function __construct() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+        add_action('save_post_' . self::CPT, [$this, 'clear_cache']);
+        add_action('trashed_post', [$this, 'clear_cache_on_post_event'], 10, 2);
+        add_action('untrashed_post', [$this, 'clear_cache_on_post_event'], 10, 2);
+        add_action('deleted_post', [$this, 'clear_cache_on_post_event'], 10, 2);
+        add_action('updated_post_meta', [$this, 'clear_cache_on_meta'], 10, 4);
+        add_action('added_post_meta', [$this, 'clear_cache_on_meta'], 10, 4);
+        add_action('deleted_post_meta', [$this, 'clear_cache_on_meta'], 10, 4);
+        add_action('update_option_rma_maps_only_adimplente', [$this, 'clear_cache_on_option_change'], 10, 2);
+    }
+
+    public function register_routes(): void {
+        register_rest_route('rma-public/v1', '/entities', [
+            'methods' => 'GET',
+            'callback' => [$this, 'list_entities'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('rma-public/v1', '/entities/(?P<id>\d+)', [
+            'methods' => 'GET',
+            'callback' => [$this, 'get_entity_profile'],
+            'permission_callback' => '__return_true',
+        ]);
+    }
+
+    public function list_entities(WP_REST_Request $request): WP_REST_Response {
+        $uf = strtoupper(sanitize_text_field((string) $request->get_param('uf')));
+        if ($uf !== '' && ! preg_match('/^[A-Z]{2}$/', $uf)) {
+            return new WP_REST_Response(['message' => 'UF inválida. Use sigla com 2 letras.'], 422);
+        }
+
+        $search = sanitize_text_field((string) $request->get_param('q'));
+        $search = $this->normalize_search_term($search);
+
+        $area = sanitize_text_field((string) $request->get_param('area'));
+        $area = $this->normalize_search_term($area);
+
+        $situacao = $this->normalize_situacao((string) $request->get_param('situacao'));
+        if ($situacao === '') {
+            return new WP_REST_Response(['message' => 'Situação inválida. Use: ativa, inadimplente ou todas.'], 422);
+        }
+
+        $only_adimplente = (bool) get_option('rma_maps_only_adimplente', true);
+        $page = max(1, absint((int) $request->get_param('page')));
+        $per_page = absint((int) $request->get_param('per_page'));
+        if ($per_page <= 0) {
+            $per_page = 100;
+        }
+        $per_page = min(200, $per_page);
+
+        $cache_key = 'rma_public_entities_' . md5($uf . '|' . $search . '|' . $area . '|' . $situacao . '|' . $page . '|' . $per_page . '|' . ($only_adimplente ? '1' : '0'));
+        $cached = get_transient($cache_key);
+
+        if (is_array($cached) && isset($cached['items'], $cached['total'], $cached['total_pages'])) {
+            $response = new WP_REST_Response($cached['items']);
+            $response->header('X-WP-Total', (string) $cached['total']);
+            $response->header('X-WP-TotalPages', (string) $cached['total_pages']);
+
+            return $response;
+        }
+
+        $meta_query = [
+            'relation' => 'AND',
+            [
+                'key' => 'governance_status',
+                'value' => 'aprovado',
+            ],
+        ];
+
+        $effective_situacao = $situacao;
+        if ($effective_situacao === 'default') {
+            $effective_situacao = $only_adimplente ? 'ativa' : 'todas';
+        }
+
+        if ($effective_situacao === 'ativa') {
+            $meta_query[] = [
+                'key' => 'finance_status',
+                'value' => 'adimplente',
+            ];
+        } elseif ($effective_situacao === 'inadimplente') {
+            $meta_query[] = [
+                'key' => 'finance_status',
+                'value' => 'inadimplente',
+            ];
+        }
+
+        if ($uf !== '') {
+            $meta_query[] = [
+                'key' => 'uf',
+                'value' => $uf,
+            ];
+        }
+
+        if ($area !== '') {
+            $meta_query[] = [
+                'relation' => 'OR',
+                [
+                    'key' => 'area_interesse',
+                    'value' => $area,
+                    'compare' => 'LIKE',
+                ],
+                [
+                    'key' => 'areas_interesse',
+                    'value' => $area,
+                    'compare' => 'LIKE',
+                ],
+            ];
+        }
+
+        $query = new WP_Query([
+            'post_type' => self::CPT,
+            'post_status' => 'publish',
+            'posts_per_page' => $per_page,
+            'paged' => $page,
+            's' => $search,
+            'meta_query' => $meta_query,
+        ]);
+
+        $entities = [];
+        foreach ($query->posts as $post) {
+            $id = $post->ID;
+            $entities[] = [
+                'id' => $id,
+                'nome' => sanitize_text_field((string) get_the_title($id)),
+                'slug' => sanitize_title((string) $post->post_name),
+                'cidade' => sanitize_text_field((string) get_post_meta($id, 'cidade', true)),
+                'uf' => $this->normalize_uf((string) get_post_meta($id, 'uf', true)),
+                'lat' => (float) get_post_meta($id, 'lat', true),
+                'lng' => (float) get_post_meta($id, 'lng', true),
+                'nome_fantasia' => sanitize_text_field((string) get_post_meta($id, 'nome_fantasia', true)),
+                'finance_status' => sanitize_text_field((string) get_post_meta($id, 'finance_status', true)),
+                'area_interesse' => sanitize_text_field((string) get_post_meta($id, 'area_interesse', true)),
+                'areas_interesse' => sanitize_text_field((string) get_post_meta($id, 'areas_interesse', true)),
+            ];
+        }
+
+        wp_reset_postdata();
+
+        $payload = [
+            'items' => $entities,
+            'total' => (int) $query->found_posts,
+            'total_pages' => (int) $query->max_num_pages,
+        ];
+
+        set_transient($cache_key, $payload, 5 * MINUTE_IN_SECONDS);
+        $this->remember_cache_key($cache_key);
+
+        $response = new WP_REST_Response($entities);
+        $response->header('X-WP-Total', (string) $payload['total']);
+        $response->header('X-WP-TotalPages', (string) $payload['total_pages']);
+
+        return $response;
+    }
+
+
+
+    public function get_entity_profile(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = absint((int) $request->get_param('id'));
+        if ($entity_id <= 0 || get_post_type($entity_id) !== self::CPT || get_post_status($entity_id) !== 'publish') {
+            return new WP_REST_Response(['message' => 'Entidade não encontrada.'], 404);
+        }
+
+        $governance = (string) get_post_meta($entity_id, 'governance_status', true);
+        if ($governance !== 'aprovado') {
+            return new WP_REST_Response(['message' => 'Entidade indisponível no diretório público.'], 404);
+        }
+
+        $data = [
+            'id' => $entity_id,
+            'nome' => sanitize_text_field((string) get_the_title($entity_id)),
+            'slug' => sanitize_title((string) get_post_field('post_name', $entity_id)),
+            'razao_social' => sanitize_text_field((string) get_post_meta($entity_id, 'razao_social', true)),
+            'nome_fantasia' => sanitize_text_field((string) get_post_meta($entity_id, 'nome_fantasia', true)),
+            'descricao' => sanitize_textarea_field((string) get_post_field('post_content', $entity_id)),
+            'cidade' => sanitize_text_field((string) get_post_meta($entity_id, 'cidade', true)),
+            'uf' => $this->normalize_uf((string) get_post_meta($entity_id, 'uf', true)),
+            'logradouro' => sanitize_text_field((string) get_post_meta($entity_id, 'logradouro', true)),
+            'bairro' => sanitize_text_field((string) get_post_meta($entity_id, 'bairro', true)),
+            'lat' => (float) get_post_meta($entity_id, 'lat', true),
+            'lng' => (float) get_post_meta($entity_id, 'lng', true),
+            'area_interesse' => sanitize_text_field((string) get_post_meta($entity_id, 'area_interesse', true)),
+            'areas_interesse' => sanitize_text_field((string) get_post_meta($entity_id, 'areas_interesse', true)),
+            'finance_status' => sanitize_text_field((string) get_post_meta($entity_id, 'finance_status', true)),
+            'profile_url' => get_permalink($entity_id) ?: '',
+        ];
+
+        return new WP_REST_Response($data);
+    }
+
+    private function normalize_uf(string $uf): string {
+        $normalized = strtoupper(trim($uf));
+
+        if (! preg_match('/^[A-Z]{2}$/', $normalized)) {
+            return '';
+        }
+
+        return $normalized;
+    }
+
+    private function normalize_search_term(string $search): string {
+        $search = trim($search);
+        $search = function_exists('mb_substr') ? mb_substr($search, 0, 100) : substr($search, 0, 100);
+
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($search);
+        }
+
+        return strtolower($search);
+    }
+
+    private function normalize_situacao(string $situacao): string {
+        $situacao = trim(strtolower($situacao));
+
+        if ($situacao === '') {
+            return 'default';
+        }
+
+        $allowed = ['ativa', 'inadimplente', 'todas'];
+        if (! in_array($situacao, $allowed, true)) {
+            return '';
+        }
+
+        return $situacao;
+    }
+
+    public function clear_cache(int $post_id): void {
+        if (get_post_type($post_id) !== self::CPT) {
+            return;
+        }
+
+        $this->clear_cache_for_all();
+    }
+
+    public function clear_cache_on_post_event(int $post_id, $post = null): void {
+        $post_type = '';
+        if ($post instanceof WP_Post) {
+            $post_type = (string) $post->post_type;
+        } else {
+            $post_type = (string) get_post_type($post_id);
+        }
+
+        if ($post_type !== self::CPT) {
+            return;
+        }
+
+        $this->clear_cache_for_all();
+    }
+
+
+    public function clear_cache_on_option_change($old_value, $value): void {
+        if ((bool) $old_value === (bool) $value) {
+            return;
+        }
+
+        $this->clear_cache_for_all();
+    }
+
+    public function clear_cache_on_meta($meta_id, $post_id, $meta_key, $meta_value): void {
+        if (get_post_type((int) $post_id) !== self::CPT) {
+            return;
+        }
+
+        $keys = ['governance_status', 'finance_status', 'lat', 'lng', 'cidade', 'uf', 'area_interesse', 'areas_interesse'];
+        if (in_array($meta_key, $keys, true)) {
+            $this->clear_cache((int) $post_id);
+        }
+    }
+
+
+    private function clear_cache_for_all(): void {
+        $keys = get_option(self::CACHE_INDEX_OPTION, []);
+        if (! is_array($keys)) {
+            $keys = [];
+        }
+
+        foreach ($keys as $key) {
+            delete_transient((string) $key);
+        }
+
+        update_option(self::CACHE_INDEX_OPTION, [], false);
+    }
+
+    private function remember_cache_key(string $cache_key): void {
+        $keys = get_option(self::CACHE_INDEX_OPTION, []);
+        $keys = is_array($keys) ? $keys : [];
+
+        $changed = false;
+        if (! in_array($cache_key, $keys, true)) {
+            $keys[] = $cache_key;
+            $changed = true;
+        }
+
+        $max_keys = 500;
+        if (count($keys) > $max_keys) {
+            $keys = array_slice($keys, -1 * $max_keys);
+            $changed = true;
+        }
+
+        if ($changed) {
+            update_option(self::CACHE_INDEX_OPTION, $keys, false);
+        }
+    }
+}
+
+new RMA_Maps_Directory();

--- a/wp-content/plugins/rma-woo-sync/rma-woo-sync.php
+++ b/wp-content/plugins/rma-woo-sync/rma-woo-sync.php
@@ -1,0 +1,690 @@
+<?php
+/**
+ * Plugin Name: RMA Woo Sync
+ * Description: Sincroniza status financeiro da entidade com pedidos WooCommerce (anuidade via PIX).
+ * Version: 0.7.0
+ * Author: RMA
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+final class RMA_Woo_Sync {
+    private const CPT = 'rma_entidade';
+
+    public function __construct() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+
+        add_action('woocommerce_order_status_completed', [$this, 'mark_adimplente']);
+        add_action('woocommerce_order_status_processing', [$this, 'mark_adimplente']);
+        add_action('woocommerce_order_status_failed', [$this, 'mark_inadimplente']);
+        add_action('woocommerce_order_status_cancelled', [$this, 'mark_inadimplente']);
+        add_action('woocommerce_order_status_refunded', [$this, 'mark_inadimplente']);
+
+        add_action('init', [$this, 'schedule_annual_dues_cron']);
+        add_action('rma_generate_annual_dues', [$this, 'generate_annual_dues']);
+    }
+
+    public function register_routes(): void {
+        register_rest_route('rma/v1', '/entities/(?P<id>\d+)/finance/payment-status', [
+            'methods' => 'GET',
+            'callback' => [$this, 'payment_status'],
+            'permission_callback' => [$this, 'can_view_entity_finance'],
+        ]);
+    }
+
+    public function can_view_entity_finance(WP_REST_Request $request): bool {
+        if (! is_user_logged_in()) {
+            return false;
+        }
+
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return false;
+        }
+
+        if (current_user_can('edit_others_posts')) {
+            return true;
+        }
+
+        return (int) get_post_field('post_author', $entity_id) === get_current_user_id();
+    }
+
+    public function payment_status(WP_REST_Request $request): WP_REST_Response {
+        $entity_id = (int) $request->get_param('id');
+        if (get_post_type($entity_id) !== self::CPT) {
+            return new WP_REST_Response(['message' => 'Entidade inválida.'], 404);
+        }
+
+        $finance_status = (string) get_post_meta($entity_id, 'finance_status', true);
+        $is_paid = $finance_status === 'adimplente';
+        $latest_order = $this->get_latest_entity_order($entity_id);
+
+        $payload = [
+            'entity_id' => $entity_id,
+            'finance_status' => $finance_status,
+            'is_paid' => $is_paid,
+            'should_redirect' => $is_paid,
+            'redirect_url' => home_url('/dashboard/'),
+            'latest_order' => $latest_order,
+        ];
+
+        return new WP_REST_Response($payload);
+    }
+
+    public function mark_adimplente(int $order_id): void {
+        $this->sync_financial_status($order_id, 'adimplente');
+    }
+
+    public function mark_inadimplente(int $order_id): void {
+        $this->sync_financial_status($order_id, 'inadimplente');
+    }
+
+    private function sync_financial_status(int $order_id, string $target_status): void {
+        if (! function_exists('wc_get_order')) {
+            return;
+        }
+
+        $order = wc_get_order($order_id);
+        if (! $order) {
+            return;
+        }
+
+        $entity_id = (int) $order->get_meta('rma_entity_id');
+        if ($entity_id <= 0 || get_post_type($entity_id) !== self::CPT) {
+            return;
+        }
+
+        update_post_meta($entity_id, 'finance_status', $target_status);
+
+        if ($target_status === 'adimplente') {
+            $paid_ts = time();
+            $due_ts = $paid_ts + (365 * DAY_IN_SECONDS);
+            update_post_meta($entity_id, 'finance_paid_at', gmdate('Y-m-d H:i:s', $paid_ts));
+            update_post_meta($entity_id, 'finance_due_at', gmdate('Y-m-d H:i:s', $due_ts));
+            update_post_meta($entity_id, 'anuidade_vencimento', gmdate('Y-m-d', $due_ts));
+            update_post_meta($entity_id, 'finance_access_status', 'active');
+        }
+
+        $history = get_post_meta($entity_id, 'finance_history', true);
+        $history = is_array($history) ? $history : [];
+
+        $event_key = $order_id . '|' . $order->get_status() . '|' . $target_status;
+        $is_duplicate = false;
+        foreach ($history as $event) {
+            $existing_key = (int) ($event['order_id'] ?? 0) . '|' . (string) ($event['status'] ?? '') . '|' . (string) ($event['finance_status'] ?? '');
+            if ($existing_key === $event_key) {
+                $is_duplicate = true;
+                break;
+            }
+        }
+
+        if (! $is_duplicate) {
+            $paid_date = $order->get_date_paid();
+            $year = $paid_date ? $paid_date->date('Y') : gmdate('Y');
+
+            $history[] = [
+                'order_id' => $order_id,
+                'year' => $year,
+                'status' => $order->get_status(),
+                'finance_status' => $target_status,
+                'total' => (float) $order->get_total(),
+                'paid_at' => current_time('mysql', true),
+            ];
+
+            $max_history = 500;
+            if (count($history) > $max_history) {
+                $history = array_slice($history, -1 * $max_history);
+            }
+
+            update_post_meta($entity_id, 'finance_history', $history);
+        }
+
+        do_action('rma/entity_finance_updated', $entity_id, $order_id, $history);
+    }
+
+    public function schedule_annual_dues_cron(): void {
+        if (! wp_next_scheduled('rma_generate_annual_dues')) {
+            wp_schedule_event(time() + 10 * MINUTE_IN_SECONDS, 'daily', 'rma_generate_annual_dues');
+        }
+    }
+
+    public function generate_annual_dues(): void {
+        if (! function_exists('wc_create_order')) {
+            return;
+        }
+
+        $year = gmdate('Y');
+        if (! $this->is_due_cycle_open()) {
+            return;
+        }
+
+        $product_id = absint((int) get_option('rma_annual_dues_product_id', 0));
+        $annual_value = (float) get_option('rma_annual_due_value', '0');
+
+        $query = new WP_Query([
+            'post_type' => self::CPT,
+            'post_status' => ['publish', 'draft'],
+            'posts_per_page' => 500,
+            'fields' => 'ids',
+            'meta_query' => [
+                [
+                    'key' => 'governance_status',
+                    'value' => 'aprovado',
+                ],
+            ],
+        ]);
+
+        $created = 0;
+        foreach ($query->posts as $entity_id) {
+            $entity_id = (int) $entity_id;
+            if ($this->has_due_order_for_year($entity_id, $year)) {
+                continue;
+            }
+
+            $author_id = (int) get_post_field('post_author', $entity_id);
+            $customer_id = $author_id > 0 ? $author_id : 0;
+
+            $order = wc_create_order(['customer_id' => $customer_id]);
+            if (is_wp_error($order) || ! $order) {
+                continue;
+            }
+
+            $has_item = false;
+            if ($product_id > 0) {
+                $product = wc_get_product($product_id);
+                if ($product) {
+                    $order->add_product($product, 1);
+                    $has_item = true;
+                }
+            }
+
+            if (! $has_item && $annual_value > 0) {
+                $fee = new WC_Order_Item_Fee();
+                $fee->set_name('Anuidade RMA ' . $year);
+                $fee->set_amount($annual_value);
+                $fee->set_total($annual_value);
+                $order->add_item($fee);
+            }
+
+            $order->update_meta_data('rma_entity_id', $entity_id);
+            $order->update_meta_data('rma_due_year', $year);
+            $order->update_meta_data('rma_is_annual_due', '1');
+            $order->calculate_totals();
+            $order->save();
+
+            update_post_meta($entity_id, 'finance_status', 'inadimplente');
+            $created++;
+        }
+
+        wp_reset_postdata();
+        update_option('rma_annual_dues_last_run', [
+            'year' => $year,
+            'created_orders' => $created,
+            'ran_at' => current_time('mysql', true),
+        ], false);
+    }
+
+    private function is_due_cycle_open(): bool {
+        $day_month = (string) get_option('rma_due_day_month', '01-01');
+        if (! preg_match('/^(\d{2})-(\d{2})$/', $day_month, $matches)) {
+            $day_month = '01-01';
+            $matches = ['01-01', '01', '01'];
+        }
+
+        $day = (int) $matches[1];
+        $month = (int) $matches[2];
+        if (! checkdate($month, $day, 2024)) {
+            $day_month = '01-01';
+        }
+
+        $current_md = gmdate('m-d');
+        $target_md = substr($day_month, 3, 2) . '-' . substr($day_month, 0, 2);
+
+        return $current_md >= $target_md;
+    }
+
+    private function has_due_order_for_year(int $entity_id, string $year): bool {
+        if (! function_exists('wc_get_orders')) {
+            return false;
+        }
+
+        $orders = wc_get_orders([
+            'limit' => 1,
+            'return' => 'ids',
+            'meta_query' => [
+                [
+                    'key' => 'rma_entity_id',
+                    'value' => $entity_id,
+                ],
+                [
+                    'key' => 'rma_due_year',
+                    'value' => $year,
+                ],
+            ],
+            'status' => ['pending', 'on-hold', 'processing', 'completed', 'cancelled', 'failed', 'refunded'],
+        ]);
+
+        return ! empty($orders);
+    }
+
+    private function get_latest_entity_order(int $entity_id): array {
+        if (! function_exists('wc_get_orders')) {
+            return [];
+        }
+
+        $orders = wc_get_orders([
+            'limit' => 1,
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'meta_key' => 'rma_entity_id',
+            'meta_value' => $entity_id,
+            'status' => ['pending', 'on-hold', 'processing', 'completed', 'cancelled', 'failed', 'refunded'],
+        ]);
+
+        if (empty($orders) || ! is_array($orders)) {
+            return [];
+        }
+
+        $order = $orders[0];
+        if (! $order instanceof WC_Order) {
+            return [];
+        }
+
+        return [
+            'order_id' => (int) $order->get_id(),
+            'status' => (string) $order->get_status(),
+            'total' => (float) $order->get_total(),
+            'pay_url' => $order->get_checkout_payment_url(),
+            'due_year' => (string) $order->get_meta('rma_due_year'),
+        ];
+    }
+
+    public static function deactivate(): void {
+        wp_clear_scheduled_hook('rma_generate_annual_dues');
+    }
+}
+
+function rma_contains_annual_dues_product(): bool {
+    if (! function_exists('WC') || ! WC()->cart) {
+        return false;
+    }
+
+    $dues_product_id = (int) get_option('rma_annual_dues_product_id', 0);
+    if ($dues_product_id <= 0) {
+        $dues_product_id = (int) get_option('rma_woo_product_id', 0);
+    }
+    if ($dues_product_id <= 0) {
+        $dues_product_id = 3407;
+    }
+
+    foreach (WC()->cart->get_cart() as $item) {
+        $product_id = (int) ($item['product_id'] ?? 0);
+        if ($product_id === $dues_product_id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function rma_is_checkout_mode(): bool {
+    if (! function_exists('is_checkout') || ! is_checkout()) {
+        return false;
+    }
+
+    return rma_contains_annual_dues_product();
+}
+
+add_filter('body_class', function (array $classes): array {
+    if (rma_is_checkout_mode()) {
+        $classes[] = 'rma-checkout-mode';
+    }
+
+    return $classes;
+});
+
+add_filter('woocommerce_available_payment_gateways', function (array $gateways): array {
+    if (! rma_is_checkout_mode()) {
+        return $gateways;
+    }
+
+    if (isset($gateways['rma_pix'])) {
+        return ['rma_pix' => $gateways['rma_pix']];
+    }
+
+    return $gateways;
+});
+
+add_filter('wc_add_to_cart_message_html', function (string $message): string {
+    if (rma_is_checkout_mode()) {
+        return '';
+    }
+
+    return $message;
+}, 10, 1);
+
+add_action('woocommerce_before_checkout_form', function (): void {
+    if (! rma_is_checkout_mode() || ! function_exists('wc_get_notices')) {
+        return;
+    }
+
+    $success = wc_get_notices('success');
+    if (! empty($success)) {
+        wc_clear_notices();
+    }
+}, 1);
+
+function rma_pix_build_payload(string $pix_key, string $amount, string $txid): string {
+    $pix_key = preg_replace('/\s+/', '', sanitize_text_field($pix_key));
+    $amount = number_format(max(0, (float) $amount), 2, '.', '');
+    $txid = strtoupper(preg_replace('/[^A-Z0-9]/', '', sanitize_text_field($txid)));
+    if ($txid === '') {
+        $txid = 'RMA';
+    }
+    $txid = substr($txid, 0, 25);
+
+    $merchant = 'RMA';
+    $city = 'SAO PAULO';
+
+    $gui = '0014BR.GOV.BCB.PIX';
+    $keyField = sprintf('%02d%s', strlen($pix_key), $pix_key);
+    $merchantAccount = '26' . sprintf('%02d%s', strlen($gui . '01' . $keyField), $gui . '01' . $keyField);
+
+    $payload = '000201'; // payload format indicator
+    $payload .= $merchantAccount;
+    $payload .= '52040000';
+    $payload .= '5303986'; // BRL
+    $payload .= '54' . sprintf('%02d%s', strlen($amount), $amount);
+    $payload .= '5802BR';
+    $payload .= '59' . sprintf('%02d%s', strlen($merchant), $merchant);
+    $payload .= '60' . sprintf('%02d%s', strlen($city), $city);
+    $tx = '05' . sprintf('%02d%s', strlen($txid), $txid);
+    $payload .= '62' . sprintf('%02d%s', strlen($tx), $tx);
+    $payload .= '6304';
+
+    $crc = strtoupper(dechex(rma_pix_crc16($payload)));
+    $crc = str_pad($crc, 4, '0', STR_PAD_LEFT);
+
+    return $payload . $crc;
+}
+
+function rma_pix_crc16(string $payload): int {
+    $polynomial = 0x1021;
+    $result = 0xFFFF;
+    $len = strlen($payload);
+
+    for ($i = 0; $i < $len; $i++) {
+        $result ^= (ord($payload[$i]) << 8);
+        for ($bit = 0; $bit < 8; $bit++) {
+            $result = ($result & 0x8000) ? (($result << 1) ^ $polynomial) : ($result << 1);
+            $result &= 0xFFFF;
+        }
+    }
+
+    return $result;
+}
+
+add_filter('woocommerce_checkout_fields', function (array $fields): array {
+    if (! rma_contains_annual_dues_product()) {
+        return $fields;
+    }
+
+    $fields['billing'] = [];
+    $fields['shipping'] = [];
+
+    if (isset($fields['order']['order_comments'])) {
+        unset($fields['order']['order_comments']);
+    }
+
+    return $fields;
+}, 999);
+
+add_filter('woocommerce_enable_order_notes_field', function ($enabled) {
+    if (rma_contains_annual_dues_product()) {
+        return false;
+    }
+    return $enabled;
+});
+
+add_filter('woocommerce_cart_needs_shipping', function ($needs_shipping) {
+    if (rma_contains_annual_dues_product()) {
+        return false;
+    }
+    return $needs_shipping;
+});
+
+function rma_get_current_user_entity_id(): int {
+    $user_id = get_current_user_id();
+    if ($user_id <= 0) {
+        return 0;
+    }
+
+    if (function_exists('rma_get_entity_id_by_author')) {
+        return (int) rma_get_entity_id_by_author($user_id);
+    }
+
+    $entity_id = (int) get_posts([
+        'post_type' => 'rma_entidade',
+        'post_status' => ['publish', 'draft'],
+        'author' => $user_id,
+        'fields' => 'ids',
+        'posts_per_page' => 1,
+        'orderby' => 'date',
+        'order' => 'DESC',
+    ])[0] ?? 0;
+
+    return max(0, $entity_id);
+}
+
+add_action('woocommerce_checkout_process', function (): void {
+    if (! rma_contains_annual_dues_product()) {
+        return;
+    }
+
+    if (rma_get_current_user_entity_id() <= 0) {
+        wc_add_notice('Não foi possível vincular o pagamento a uma entidade RMA. Faça login com a conta da entidade e tente novamente.', 'error');
+    }
+});
+
+add_action('woocommerce_checkout_create_order', function (WC_Order $order): void {
+    if (! rma_contains_annual_dues_product()) {
+        return;
+    }
+
+    $entity_id = rma_get_current_user_entity_id();
+    if ($entity_id > 0) {
+        $order->update_meta_data('rma_entity_id', $entity_id);
+    }
+
+    $order->update_meta_data('rma_is_annual_due', '1');
+    $order->update_meta_data('rma_due_year', gmdate('Y'));
+}, 20);
+
+add_action('wp_enqueue_scripts', function (): void {
+    if (! function_exists('is_checkout') || ! is_checkout()) {
+        return;
+    }
+    if (! rma_contains_annual_dues_product()) {
+        return;
+    }
+
+    wp_register_style('rma-woo-checkout-premium', false, [], '1.1.0');
+    wp_enqueue_style('rma-woo-checkout-premium');
+    wp_add_inline_style('rma-woo-checkout-premium', '
+        .woocommerce-checkout{font-family:"Maven Pro",system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif;background:#fff!important;padding:0;border-radius:0}.rma-checkout-mode,.rma-checkout-mode .site,.rma-checkout-mode .site-main,.rma-checkout-mode .content-area{background:#fff!important}.rma-checkout-mode .woocommerce-notices-wrapper{display:none!important}.rma-checkout-mode .woocommerce-message .button,.rma-checkout-mode a.wc-forward{display:none!important}.rma-checkout-mode .woocommerce form.checkout{max-width:900px!important;margin:0 auto!important;display:block!important}.rma-checkout-mode .woocommerce form.checkout>.row{display:block!important;margin-left:0!important;margin-right:0!important}.rma-checkout-mode .woocommerce form.checkout>.row>[class*="col-xl-8"],.rma-checkout-mode .woocommerce form.checkout>.row>[class*="col-lg-8"]{display:none!important}.rma-checkout-mode .woocommerce form.checkout>.row>[class*="col-xl-4"],.rma-checkout-mode .woocommerce form.checkout>.row>[class*="col-lg-4"]{flex:0 0 100%!important;max-width:100%!important;width:100%!important;padding-left:0!important;padding-right:0!important}.rma-checkout-mode .woocommerce-checkout .col2-set,.rma-checkout-mode .woocommerce-checkout #customer_details{display:none!important;height:0!important;margin:0!important;padding:0!important;overflow:hidden!important}.rma-checkout-mode .woocommerce-checkout #order_review_heading{display:none!important}.rma-checkout-mode .woocommerce-checkout #order_review,.rma-checkout-mode .woocommerce-checkout .woocommerce-checkout-review-order,.rma-checkout-mode .woocommerce-checkout .woocommerce-checkout-review-order-table{float:none!important;width:100%!important;max-width:900px!important;margin:0 auto!important;display:block!important}
+        .woocommerce-checkout .col2-set,.woocommerce-checkout #customer_details{display:none!important}
+        .woocommerce-checkout #order_review_heading{display:none!important}.woocommerce-checkout #order_review{float:none!important;width:100%!important;max-width:100%!important;margin:0 auto!important}
+        .woocommerce-checkout #order_review{display:grid;gap:8px}
+        .woocommerce-checkout #payment{background:#ffffff;border:1px solid #e5e7eb;border-radius:20px;padding:18px;box-shadow:0 16px 40px rgba(15,23,42,.09);width:100%!important;max-width:100%!important;margin:0 auto!important}.woocommerce-checkout #order_review{background:#fff;border:1px solid #edf1f4;border-radius:18px;padding:14px;box-shadow:0 12px 28px rgba(0,0,0,.05)}
+        .woocommerce-checkout h3,.woocommerce-checkout h2{color:#1f2937;letter-spacing:-.02em}
+        .woocommerce-checkout-review-order-table{background:#fff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;box-shadow:0 10px 26px rgba(15,23,42,.05)}
+        .woocommerce-checkout-payment ul.payment_methods{padding:0!important;border:none!important;background:transparent!important}
+        .woocommerce-checkout-payment .payment_method_rma_pix>label{font-weight:800;color:#1f2937;font-size:1.05rem}
+        .rma-pix-card{background:#fff;border:1px solid #d9e3dc;border-radius:20px;padding:20px;box-shadow:0 14px 34px rgba(15,23,42,.08);margin:0 auto;max-width:1040px}
+        .rma-pix-hero{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px}
+        .rma-pix-title{font-size:1.7rem;line-height:1.2;margin:0;color:#1f2937}
+        .rma-pix-subtitle{margin:0;color:#4b5563}
+        .rma-pix-badge{background:rgba(93,218,187,.16);color:#0f766e;border:1px solid rgba(15,118,110,.18);border-radius:999px;padding:6px 12px;font-size:.78rem;font-weight:700;white-space:nowrap}
+        .rma-pix-grid{display:grid;grid-template-columns:minmax(380px,1.25fr) minmax(260px,.75fr);gap:18px;margin-top:16px;align-items:start}
+        .rma-pix-panel{background:#f9fbfd;border:1px solid #e5e7eb;border-radius:16px;padding:16px}
+        .rma-pix-panel h4{margin:0 0 8px;color:#1f2937;font-size:1.02rem}
+        .rma-pix-qr-wrap{text-align:center}
+        .rma-pix-qr{max-width:230px;width:100%;background:#fff;border:10px solid #fff;box-shadow:0 14px 30px rgba(15,23,42,.16);border-radius:14px}
+        .rma-pix-copy{width:100%;padding:12px;border:1px solid #cbd5e1;border-radius:10px;color:#111827;background:#fff;font-size:.92rem;margin:8px 0 10px;min-height:92px;resize:vertical;line-height:1.35}
+        .rma-pix-copy-btn{background:linear-gradient(135deg,#7bad39,#5ddabb);color:#fff;border:none;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;display:inline-flex;align-items:center;gap:8px}
+        .rma-pix-copy-btn:hover{filter:brightness(1.03);transform:translateY(-1px)}
+        .rma-pix-copy-status{font-size:.9rem;color:#047857;margin-top:8px;display:none}
+        .rma-pix-copy-status.is-visible{display:block}
+        .rma-pix-steps{margin:12px 0 0;padding-left:18px;color:#4b5563}
+        .rma-pix-steps li{margin:6px 0}
+        .rma-pix-warning{font-size:.9rem;color:#6b7280;margin-top:10px}
+        .rma-pix-qr-fallback{display:none;color:#4b5563;font-size:.9rem;margin-top:8px}
+        .rma-pix-qr-fallback.is-visible{display:block}
+        @media (max-width:900px){.rma-pix-grid{grid-template-columns:1fr}.rma-pix-hero{flex-direction:column;align-items:flex-start}.rma-pix-title{font-size:1.45rem}.rma-pix-card{padding:16px}.woocommerce-checkout{padding:0}}
+    ');
+}, 30);
+
+add_filter('woocommerce_payment_gateways', function (array $gateways): array {
+    if (class_exists('WC_Payment_Gateway')) {
+        $gateways[] = 'RMA_WC_Gateway_PIX';
+    }
+
+    return $gateways;
+});
+
+add_action('plugins_loaded', function (): void {
+    if (! class_exists('WC_Payment_Gateway')) {
+        return;
+    }
+
+    class RMA_WC_Gateway_PIX extends WC_Payment_Gateway {
+        public function __construct() {
+            $this->id = 'rma_pix';
+            $this->method_title = 'PIX RMA';
+            $this->method_description = 'Pagamento institucional via PIX para Anuidade RMA.';
+            $this->has_fields = true;
+            $this->title = 'PIX institucional RMA';
+            $this->description = 'Finalize sua filiação com segurança via PIX.';
+            $this->supports = ['products'];
+            $this->enabled = 'yes';
+        }
+
+        public function is_available() {
+            if (! parent::is_available()) {
+                return false;
+            }
+
+            if (! rma_contains_annual_dues_product()) {
+                return false;
+            }
+
+            $pix_key = (string) get_option('rma_pix_key', '');
+            return $pix_key !== '';
+        }
+
+        public function payment_fields() {
+            $pix_key = (string) get_option('rma_pix_key', '');
+            if ($pix_key === '') {
+                echo '<p><strong>Pagamento PIX indisponível no momento.</strong> Entre em contato com a equipe RMA.</p>';
+                return;
+            }
+
+            $cart_total = function_exists('WC') && WC()->cart ? (float) WC()->cart->total : 0;
+            $payload = rma_pix_build_payload($pix_key, (string) $cart_total, 'RMA-CHECKOUT');
+            $qr_url = 'https://api.qrserver.com/v1/create-qr-code/?size=420x420&data=' . rawurlencode($payload);
+
+            echo '<div class="rma-pix-card">';
+            echo '<div class="rma-pix-hero">';
+            echo '<div>';
+            echo '<h3 class="rma-pix-title">Pagamento da Anuidade RMA</h3>';
+            echo '<p class="rma-pix-subtitle">Finalize sua filiação com segurança.</p>';
+            echo '</div>';
+            echo '<span class="rma-pix-badge">Pagamento via PIX • Compensação conforme seu banco</span>';
+            echo '</div>';
+            echo '<p style="color:#4b5563;margin:0">Para concluir sua filiação, realize o pagamento via PIX. O acesso será ativado automaticamente após a compensação.</p>';
+            echo '<div style="margin-top:12px;padding:10px 12px;border-radius:10px;background:#edf9ec;color:#166534;font-weight:600;">Anuidade adicionada. Finalize o pagamento via PIX para concluir sua filiação.</div>';
+            echo '<div class="rma-pix-grid">';
+            echo '<div class="rma-pix-panel">';
+            echo '<h4>Escaneie o QR Code</h4>';
+            echo '<div class="rma-pix-qr-wrap">';
+            echo '<img class="rma-pix-qr" src="' . esc_url($qr_url) . '" alt="QR Code PIX" onerror="var n=this.nextElementSibling;this.style.display=\'none\';if(n){n.classList.add(\'is-visible\');}" />';
+            echo '<div class="rma-pix-qr-fallback">Não foi possível carregar o QR Code agora. Use o código copia e cola abaixo.</div>';
+            echo '</div>';
+            echo '<ol class="rma-pix-steps"><li>Abra o app do seu banco</li><li>Escolha PIX > QR Code ou Copiar e Colar</li><li>Confirme o pagamento e finalize o pedido</li></ol>';
+            echo '</div>';
+            echo '<div class="rma-pix-panel">';
+            echo '<h4>Resumo do pedido</h4>';
+            echo '<p style="color:#4b5563;margin:0 0 6px">Total da anuidade: <strong style="color:#1f2937">' . wp_kses_post(wc_price($cart_total)) . '</strong></p>';
+            echo '<textarea readonly class="rma-pix-copy" id="rma-pix-copy-code">' . esc_textarea($payload) . '</textarea>';
+            echo '<button type="button" class="rma-pix-copy-btn" id="rma-pix-copy-btn">Copiar código PIX</button>';
+            echo '<div class="rma-pix-copy-status" id="rma-pix-copy-status">Código PIX copiado com sucesso.</div>';
+            echo '<p class="rma-pix-warning">O prazo de compensação pode variar conforme o banco.</p>';
+            echo '</div>';
+            echo '</div>';
+            echo '</div>';
+
+            echo '<script>(function(){var b=document.getElementById("rma-pix-copy-btn");var i=document.getElementById("rma-pix-copy-code");var s=document.getElementById("rma-pix-copy-status");if(!b||!i){return;}b.addEventListener("click",function(){var v=i.value||"";if(!v){return;}if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(v).then(function(){s&&s.classList.add("is-visible");});return;}i.focus();i.select();i.setSelectionRange(0,99999);try{document.execCommand("copy");s&&s.classList.add("is-visible");}catch(e){}});})();</script>';
+        }
+
+        public function process_payment($order_id) {
+            $order = wc_get_order($order_id);
+            if (! $order) {
+                return ['result' => 'fail'];
+            }
+
+            $entity_id = (int) $order->get_meta('rma_entity_id');
+            if ($entity_id <= 0) {
+                $entity_id = rma_get_current_user_entity_id();
+                if ($entity_id > 0) {
+                    $order->update_meta_data('rma_entity_id', $entity_id);
+                    $order->save();
+                }
+            }
+
+            $order->update_status('on-hold', 'Aguardando pagamento PIX da Anuidade RMA.');
+            $order->add_order_note('Pedido criado via PIX institucional RMA.');
+            wc_reduce_stock_levels($order_id);
+            if (function_exists('WC') && WC()->cart) {
+                WC()->cart->empty_cart();
+            }
+
+            return [
+                'result' => 'success',
+                'redirect' => $this->get_return_url($order),
+            ];
+        }
+    }
+});
+
+add_action('woocommerce_thankyou_rma_pix', function (int $order_id): void {
+    $order = wc_get_order($order_id);
+    if (! $order) {
+        return;
+    }
+
+    $pix_key = (string) get_option('rma_pix_key', '');
+    if ($pix_key === '') {
+        wc_print_notice('Pagamento PIX indisponível no momento. Entre em contato com a equipe RMA.', 'notice');
+        return;
+    }
+
+    $total = (string) $order->get_total();
+    $payload = rma_pix_build_payload($pix_key, $total, 'RMAORDER' . $order->get_id());
+    $qr_url = 'https://api.qrserver.com/v1/create-qr-code/?size=420x420&data=' . rawurlencode($payload);
+
+    echo '<section class="rma-pix-card" style="margin-top:20px">';
+    echo '<h2 style="margin-top:0;color:#1f2937">Pagamento da Anuidade RMA</h2>';
+    echo '<p style="color:#4b5563">Seu pedido está em <strong>aguardando pagamento</strong>. Escaneie o QR Code ou copie o código PIX abaixo.</p>';
+    echo '<img class="rma-pix-qr" src="' . esc_url($qr_url) . '" alt="QR Code PIX do pedido" onerror="this.style.display=\'none\'" />';
+    echo '<textarea readonly class="rma-pix-copy" id="rma-pix-order-copy-code">' . esc_textarea($payload) . '</textarea>';
+    echo '<button type="button" class="rma-pix-copy-btn" id="rma-pix-order-copy-btn">Copiar código PIX</button>';
+    echo '<div class="rma-pix-copy-status" id="rma-pix-order-copy-status">Copiado com sucesso.</div>';
+    echo '<p style="color:#6b7280;font-size:.9rem">Assim que houver compensação, seu acesso RMA será liberado automaticamente.</p>';
+    echo '</section>';
+    echo '<script>(function(){var b=document.getElementById("rma-pix-order-copy-btn");var i=document.getElementById("rma-pix-order-copy-code");var s=document.getElementById("rma-pix-order-copy-status");if(!b||!i){return;}b.addEventListener("click",function(){var v=i.value||"";if(!v){return;}if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(v).then(function(){s&&s.classList.add("is-visible");});return;}i.select();i.setSelectionRange(0,99999);document.execCommand("copy");s&&s.classList.add("is-visible");});})();</script>';
+});
+
+register_deactivation_hook(__FILE__, ['RMA_Woo_Sync', 'deactivate']);
+new RMA_Woo_Sync();


### PR DESCRIPTION
### Motivation
- Stepper GIFs were loaded via hardcoded root-relative paths (e.g. `/exertio/images/...`) which broke asset loading in subdirectory installs and when images live in the active theme rather than the plugin.

### Description
- Added helper `rma_theme_image_uri($filename)` to resolve stepper image URIs from the active theme (`get_template_directory_uri() . '/images/{file}'`).
- Replaced hardcoded `/exertio/images/*.gif` occurrences in the onboarding snippet with `esc_url(rma_theme_image_uri('*.gif'))` so the step icons load from the theme path.
- Kept all behavior intact (no changes to stepper logic or states), only fixed how the images are referenced so they work correctly across environments.

### Testing
- ✅ Ran PHP syntax check: `php -l ui/rma-glass-theme-wordpress-snippet.php` (no syntax errors).
- ✅ Verified updated occurrences with quick search to ensure all step image references were replaced and now call `rma_theme_image_uri`.
- ✅ Smoke-committed the file after validation to ensure the change is present in the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a480bf9a68832ba4a55a47ddef20c8)